### PR TITLE
Fix to allow logging with user/password on commandline

### DIFF
--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/UiDesk.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/UiDesk.java
@@ -124,6 +124,9 @@ public class UiDesk {
 	}
 	
 	public static void updateFont(String cfgName){
+		Display display = Display.getCurrent();
+		if (display == null)
+			return;
 		FontRegistry fr = JFaceResources.getFontRegistry();
 		FontData[] fd =
 			PreferenceConverter.getFontDataArray(new SettingsPreferenceStore(CoreHub.userCfg),


### PR DESCRIPTION
Needed to able log in giving username/password on the commandline.

Tested uning a  demoDB and passing -Dch.elexis.username=test -Dch.elexis.password=test 
