### PR TITLE
Added support for CheckBoxes/Tristate CheckBoxes to LabeledInputField, needed for Eigendiagnosen

### DIFF
--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/util/LabeledInputField.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/util/LabeledInputField.java
@@ -635,6 +635,7 @@ public class LabeledInputField extends Composite {
 					// def[i].setText(Double.toString(betr/100.0));
 					break;
 				case CHECKBOX:
+					val = StringTool.unNull(val);
 					((Button) (def[i].mine.getControl())).setSelection(val.equalsIgnoreCase("1"));
 					break;
 				case CHECKBOXTRISTATE:


### PR DESCRIPTION
Added support for CheckBoxes/Tristate CheckBoxes to LabeledInputField.
This one will be used for the new version or Eigendiagnosen.
Added some documentation for the methods how it should actually be - makes it much simpler for newbies...

Many other types are not implemented which would be more than just useful. This way we can let look our AutoForms much more professional.
I already have implemented some others but that's not yet clean. Still thinking about the best/consistent way...

Gruss, Harry
