### PR TITLE
Allow Jubula to enter a date via the text field

### DIFF
--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
@@ -297,6 +297,23 @@ public class FallDetailBlatt2 extends Composite {
 		cReason.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tk.createLabel(top, Messages.FallDetailBlatt2_StartDate); //$NON-NLS-1$
 		dpVon = new DatePickerCombo(top, SWT.NONE);
+		// This listener is fired when you enter directly text instead
+		// of selecting the date from the combo. This is necessary for
+		// Jubula-GUI tests, as it unable to handle the DatePickerCombo
+		dpVon.addFocusListener(new FocusListener() {
+			
+			@Override
+			public void focusGained(FocusEvent e){
+			}
+			
+			@Override
+			public void focusLost(FocusEvent e){
+				Fall fall = getFall();
+				fall.setBeginnDatum(new TimeTool(dpVon.getDate().getTime())
+					.toString(TimeTool.DATE_GER));
+				ElexisEventDispatcher.fireSelectionEvent(fall.getPatient());
+			}
+		});
 		dpVon.addSelectionListener(new SelectionAdapter() {
 			
 			@Override


### PR DESCRIPTION
Hi Marco

I would like to make all DatePickerCombo's of Elexis (there are 30) in elexis-3-core and elexis-3-base suiteable for testing with Jubula GUI. 

The Jubula does not allow me to control the DatePickerCombo. But when one enters the date (at least here) directly, this work. This would also a shortcut as one does not need to use the mouse to enter a different date. 

Changing the date of cases, consultations, etc are important use case which I want to cover with Jubula.

Before changing all the ret of the 32 DatePickerCombos I wanted to get your okay. And if you have an idea how we could implement in one place, I would be even happier.