### PR TITLE
5157

### DIFF
--- a/ch.elexis.core.releng/prepare_for_jubula.sh
+++ b/ch.elexis.core.releng/prepare_for_jubula.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -v
+# Copyright 2016 by Niklaus Giger <niklaus.giger@member.fsf.org>
+#
+# A simple helper script to create a Jubula enabled Elexis
+# * Must be run after after "mvn clean install"
+# * Asssumes a installed installation of Jubula under /opt/jubula_8.3.0.122
+#
+rm -rf work
+mkdir work
+cd work
+unzip ../ch.elexis.core.p2site/target/products/ch.elexis.core.application.ElexisApp-linux.gtk.x86_64.zip
+cd plugins
+unzip /opt/jubula_8.3.0.122/development/rcp-support.zip
+cd ../..
+cp work/configuration/config.ini work/configuration/config.org
+awk -i inplace '{sub(/osgi.bundles=/,"osgi.bundles=reference\\\:file\\\:org.eclipse.jubula.rc.rcp_4.0.0.201607281404.jar@3\\\:start,")}; 1' work/configuration/config.ini

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/DisplayPanel.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/DisplayPanel.java
@@ -76,6 +76,15 @@ public class DisplayPanel extends Composite implements ActiveControlListener {
 			}
 		}
 		tb = tActions.createControl(this);
+		// For the Jubula GUI tests we create unique identifiers for all tool items
+		if (parent.getData("TEST_COMP_NAME") != null) {
+			for (int idx = 0; idx < tb.getItemCount(); idx++)
+			{
+				tb.getItem(idx).setData("TEST_COMP_NAME",
+					parent.getData("TEST_COMP_NAME") + "_" + idx + "_tbi");
+			}
+		}
+		
 		FormData fdActions = new FormData();
 		fdActions.top = new FormAttachment(0, 0);
 		fdActions.right = new FormAttachment(100, 0);

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/SelectorPanel.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/SelectorPanel.java
@@ -133,6 +133,13 @@ public class SelectorPanel extends Composite implements ActiveControlListener {
 		fd.right = new FormAttachment(100, 0);
 		cFields.setLayoutData(fd);
 		cFields.setLayout(new FillLayout());
+		if (parent.getData("TEST_COMP_NAME") != null) {
+			for (int idx = 0; idx < tb.getItemCount(); idx++)
+			{
+				tb.getItem(idx).setData("TEST_COMP_NAME",
+					parent.getData("TEST_COMP_NAME") + "_" + idx + "_tbi");
+			}
+		}
 		pack();
 	}
 	

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/CommonViewer.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/CommonViewer.java
@@ -74,13 +74,35 @@ public class CommonViewer implements ISelectionChangedListener, IDoubleClickList
 	private HashSet<DoubleClickListener> dlListeners;
 	private MenuManager mgr;
 	private Composite composite;
+	private String viewName = null;
 	
 	public Composite getParent(){
 		return parent;
 	}
 	
 	public CommonViewer(){
-		
+		String callerClassName = new Exception().getStackTrace()[1].getClassName();
+		String[] x = callerClassName.split("\\.");
+		viewName = x[x.length-1];
+	}
+	
+	/**
+	 * Sets the view name. Mainly used for GUI-Jubula tests.
+	 * The view name is used to uniquely identify the toolbar items by
+	 * setting the TEST_COMP_NAME accordingly
+	 *
+	 * @param s
+	 */
+	public void setViewName(String s) {
+		viewName = s;
+	}
+	
+	/**
+	 * Gets the view name. Mainly used for GUI-Jubula tests.
+	 *
+	 */
+	public String getViewName() {
+		return viewName;
 	}
 	
 	public void setObjectCreateAction(IViewSite site, IAction action){
@@ -118,7 +140,9 @@ public class CommonViewer implements ISelectionChangedListener, IDoubleClickList
 		}
 		ControlFieldProvider cfp = vc.getControlFieldProvider();
 		if (cfp != null) {
+			ret.setData("TEST_COMP_NAME", "cv_ret_" + viewName); // for Jubula
 			Composite ctlf = vc.getControlFieldProvider().createControl(ret);
+			ctlf.setData("TEST_COMP_NAME", "cv_ctlf_" + viewName); // for Jubula
 			ctlf.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		}
 		viewer = vc.getWidgetProvider().createViewer(ret);
@@ -136,6 +160,9 @@ public class CommonViewer implements ISelectionChangedListener, IDoubleClickList
 		}
 		bNew = vc.getButtonProvider().createButton(ret);
 		if (bNew != null) {
+			if (viewName != null) {
+				bNew.setData("TEST_COMP_NAME",  "cv_bNew_"+ viewName + "_btn"); // for Jubula
+			}
 			GridData gdNew = new GridData(GridData.GRAB_HORIZONTAL | GridData.FILL_HORIZONTAL);
 			bNew.setLayoutData(gdNew);
 			if (vc.getButtonProvider().isAlwaysEnabled() == false) {

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/CommonViewer.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/CommonViewer.java
@@ -81,9 +81,7 @@ public class CommonViewer implements ISelectionChangedListener, IDoubleClickList
 	}
 	
 	public CommonViewer(){
-		String callerClassName = new Exception().getStackTrace()[1].getClassName();
-		String[] x = callerClassName.split("\\.");
-		viewName = x[x.length-1];
+		viewName = "unknown";
 	}
 	
 	/**

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/BlockDetailDisplay.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/BlockDetailDisplay.java
@@ -211,6 +211,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 		});
 		bNew = tk.createButton(body, Messages.BlockDetailDisplay_addPredefinedServices, SWT.PUSH); //$NON-NLS-1$
 		bNew.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+		bNew.setData("TEST_COMP_NAME", "blkd_addPredefinedServices_btn");
 		bNew.addSelectionListener(new SelectionAdapter() {
 			
 			@Override
@@ -230,6 +231,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 		bEigen =
 			tk.createButton(body, Messages.BlockDetailDisplay_addSelfDefinedServices, SWT.PUSH); //$NON-NLS-1$
 		bEigen.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+		bEigen.setData("TEST_COMP_NAME", "blkd_createPredefinedServices_btn");
 		bEigen.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(final SelectionEvent e){
@@ -249,6 +251,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 		
 		bDiag = tk.createButton(body, "Diagnose hinzufügen", SWT.PUSH); //$NON-NLS-1$
 		bDiag.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+		bDiag.setData("TEST_COMP_NAME", "btn_addDiagnosis_btn");
 		bDiag.addSelectionListener(new SelectionAdapter() {
 			
 			@Override

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/CodeDetailView.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/CodeDetailView.java
@@ -291,6 +291,7 @@ public class CodeDetailView extends ViewPart implements IActivationListener, ISa
 			setLayout(new FillLayout());
 			sash = new SashForm(this, SWT.NONE);
 			cv = new CommonViewer();
+			cv.setViewName(master.getCodeSystemName());
 			cv.create(master.createViewerConfigurer(cv), sash, SWT.NONE, getViewSite());
 			// cv.getViewerWidget().addSelectionChangedListener(
 			// GlobalEventDispatcher.getInstance().getDefaultListener());


### PR DESCRIPTION
Beim Testen von neuen Blöcken und Eigenleistungen fiel mir erneut auf, dass Jubula die Toolbar-Items nicht eindeutig identifizieren kann und man mit dem Aufruf von setData("TEST_COMP_NAME", ..) nachhelfen muss. Bei Elementen, welche auf dem CommonViewer beruhen ist, dies nicht mal ganz so einfach.