### PR TITLE
[5612]New kons always add default diagnosis

### DIFF
--- a/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
@@ -132,6 +132,8 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 				CoreHub.actMandant.getId());
 			fall.getPatient().setInfoElement("LetzteBehandlung", getId());
 		}
+		if (getDefaultDiagnose() != null)
+			addDiagnose(getDefaultDiagnose());
 	}
 	
 	/** Eine Konsultation anhand ihrer ID von der Datenbank einlesen */
@@ -969,8 +971,6 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 		if (initialText != null) {
 			n.updateEintrag(initialText, false);
 		}
-		if (getDefaultDiagnose() != null)
-			n.addDiagnose(getDefaultDiagnose());
 		
 		ElexisEventDispatcher.fireSelectionEvent(actFall);
 		ElexisEventDispatcher.fireSelectionEvent(n);


### PR DESCRIPTION
A default diagnosis should be added whether you create a new kons via Fall.neueKonsultation or Konsultation.newKons(initialText)