### PR TITLE
8571

### DIFF
--- a/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
+++ b/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
@@ -102,6 +102,7 @@ public class Desk implements IApplication {
 		}
 		
 		// care for log-in
+		context.applicationRunning();
 		cod.performLogin(UiDesk.getDisplay().getActiveShell());
 		if ((CoreHub.actUser == null) || !CoreHub.actUser.isValid()) {
 			// no valid user, exit (don't consider this as an error)

--- a/ch.elexis.core.product/Elexis.product
+++ b/ch.elexis.core.product/Elexis.product
@@ -16,8 +16,6 @@
    <launcherArgs>
       <vmArgs>-Dosgi.console.enable.builtin=true -Xms256m -Xmx1024m -Duser.language=de -Duser.region=CH  -Dfile.encoding=utf-8
       </vmArgs>
-      <vmArgsLin>-DSWT_GTK3=0
-      </vmArgsLin>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts=false -Dfile.encoding=utf-8
       </vmArgsMac>
    </launcherArgs>


### PR DESCRIPTION
Platform.endSplash(); ist  deprecated. Aber wenn man hier wirklich anfängt aufzuräumen müsste man das besser ganz auf E4 umbauen und dazu habe ich im Moment keine Zeit und KnowHow.