### PR TITLE
[8768] Load correctly p2 configuration

### DIFF
--- a/ch.elexis.core.product/Elexis.product
+++ b/ch.elexis.core.product/Elexis.product
@@ -27,13 +27,11 @@
    <launcher name="Elexis3">
       <linux icon="rsc/elexis48.xpm"/>
       <macosx icon="rsc/elexis-mac.icns"/>
-      <solaris/>
       <win useIco="true">
          <ico path="rsc/elexis.ico"/>
          <bmp/>
       </win>
    </launcher>
-
 
    <vm>
       <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</linux>
@@ -49,7 +47,7 @@
    </plugins>
 
    <features>
-   	  <feature id="ch.elexis.core.application.feature" installMode="root"/>
+      <feature id="ch.elexis.core.application.feature" installMode="root"/>
       <feature id="ch.elexis.core.common.feature" installMode="root"/>
       <feature id="ch.elexis.core.logging.feature" installMode="root"/>
       <feature id="ch.elexis.core.ui.feature" installMode="root"/>
@@ -59,6 +57,7 @@
 
    <configurations>
       <plugin id="ch.elexis.core.logging" autoStart="true" startLevel="2" />
+      <plugin id="ch.elexis.core.ui.p2" autoStart="true" startLevel="4" />
       <plugin id="ch.qos.logback.classic" autoStart="true" startLevel="2" />
       <plugin id="ch.qos.logback.core" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />

--- a/ch.elexis.core.ui.p2/plugin_customization.ini
+++ b/ch.elexis.core.ui.p2/plugin_customization.ini
@@ -1,34 +1,34 @@
 # we can configure the update UI by using application preferences to initialize the default UI policy
 
 # should user be able to see and manipulate repositories in the install wizard
-org.eclipse.equinox.p2.examples.rcp.cloud/repositoriesVisible=false
+ch.elexis.core.ui.p2/repositoriesVisible=true
 
 # force restart after a provisioning operation (see possible values in org.eclipse.equinox.p2.ui.Policy.restartPolicy())
-org.eclipse.equinox.p2.examples.rcp.cloud/restartPolicy=1
+ch.elexis.core.ui.p2/restartPolicy=0
 
 # show only latest versions when browsing for updates
-org.eclipse.equinox.p2.examples.rcp.cloud/showLatestVersionOnly=true
+ch.elexis.core.ui.p2/showLatestVersionOnly=true
 
 # software should be grouped by category by default
-org.eclipse.equinox.p2.examples.rcp.cloud/groupByCategory=true
+ch.elexis.core.ui.p2/groupByCategory=false
 
 # show only groups (features) in the available list, not every bundle
-org.eclipse.equinox.p2.examples.rcp.cloud/showAllBundlesAvailable=false
+ch.elexis.core.ui.p2/showAllBundlesAvailable=false
 
 # show only the install roots in the installed software list
-org.eclipse.equinox.p2.examples.rcp.cloud/showAllBundlesInstalled=true
+ch.elexis.core.ui.p2/showAllBundlesInstalled=true
 
 # do not drilldown into requirements in the wizards, just show the high level things
-org.eclipse.equinox.p2.examples.rcp.cloud/showDrilldownRequirements=false
+ch.elexis.core.ui.p2/showDrilldownRequirements=false
 
 # automatic update options are defined in org.eclipse.equinox.p2.sdk.scheduler.PreferenceConstants
 
 # check for updates on startup
-org.eclipse.equinox.p2.ui.sdk.scheduler/enabled=true
-org.eclipse.equinox.p2.ui.sdk.scheduler/schedule=on-startup
+# org.eclipse.equinox.p2.ui.sdk.scheduler/enabled=true
+# org.eclipse.equinox.p2.ui.sdk.scheduler/schedule=on-startup
 
 # remind the user every 4 hours
-org.eclipse.equinox.p2.ui.sdk.scheduler/remindOnSchedule=true
+org.eclipse.equinox.p2.ui.sdk.scheduler/remindOnSchedule=false
 # see AutomaticUpdatesPopup, values can be "30 minutes", "Hour", "4 Hours"
 org.eclipse.equinox.p2.ui.sdk.scheduler/remindElapsedTime=4 Hours
 

--- a/ch.elexis.core.ui.p2/src/ch/elexis/core/ui/p2/internal/PreferenceInitializer.java
+++ b/ch.elexis.core.ui.p2/src/ch/elexis/core/ui/p2/internal/PreferenceInitializer.java
@@ -30,10 +30,11 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	 * org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences
 	 * ()
 	 */
+	@Override
 	public void initializeDefaultPreferences(){
 		Preferences node = DefaultScope.INSTANCE.getNode(Activator.PLUGIN_ID); //$NON-NLS-1$
 		// default values
-		node.putBoolean(PreferenceConstants.REPOSITORIES_VISIBLE, false);
+		node.putBoolean(PreferenceConstants.REPOSITORIES_VISIBLE, true);
 		node.putBoolean(PreferenceConstants.SHOW_LATEST_VERSION_ONLY, true);
 		node.putBoolean(PreferenceConstants.AVAILABLE_SHOW_ALL_BUNDLES, false);
 		node.putBoolean(PreferenceConstants.INSTALLED_SHOW_ALL_BUNDLES, false);
@@ -42,7 +43,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		node.putInt(PreferenceConstants.RESTART_POLICY,
 			Policy.RESTART_POLICY_PROMPT_RESTART_OR_APPLY);
 		node.putInt(PreferenceConstants.UPDATE_WIZARD_STYLE, Policy.UPDATE_STYLE_MULTIPLE_IUS);
-		node.putBoolean(PreferenceConstants.FILTER_ON_ENV, false);
+		node.putBoolean(PreferenceConstants.FILTER_ON_ENV, true);
 		node.putInt(PreferenceConstants.UPDATE_DETAILS_HEIGHT, SWT.DEFAULT);
 		node.putInt(PreferenceConstants.UPDATE_DETAILS_WIDTH, SWT.DEFAULT);
 	}

--- a/ch.elexis.core.ui.p2/src/ch/elexis/core/ui/p2/policy/ElexisCloudPolicy.java
+++ b/ch.elexis.core.ui.p2/src/ch/elexis/core/ui/p2/policy/ElexisCloudPolicy.java
@@ -38,5 +38,6 @@ public class ElexisCloudPolicy extends Policy {
 			setVisibleAvailableIUQuery(QueryUtil.ALL_UNITS);
 		else
 			setVisibleAvailableIUQuery(new UserVisibleRootQuery());
+		setContactAllSites(false);
 	}
 }


### PR DESCRIPTION
Habe folgendes festgestellt:

 *  ch.elexis.core.ui.p2 wird als Plugin nicht gestartet. Deshalb werden die Prozeduren für die Initialisirung nie aufgerufen
 *  plugin_customization.ini definiert Variablen für falsches Plugin org.eclipse.equinox.p2.examples.rcp.cloud/
 *   Installation von features läuft nur, wenn
  **      "Contact all update sites" deaktviert ist
  **      NUR elexis-3-base als P2-Site enabled ist

