### PR TITLE
Lower case

### DIFF
--- a/ch.elexis.core.data/rsc/createDB.script
+++ b/ch.elexis.core.data/rsc/createDB.script
@@ -117,6 +117,7 @@ CREATE TABLE BEHANDLUNGEN(
 	MandantID		VARCHAR(25),					# foreign key from KONTAKT -> mandator
 	RechnungsID		VARCHAR(25),					# foreign key from RECHNUGNEN -> bill
 	Datum			CHAR(8),						# date of treatment
+	Zeit			CHAR(8),						# time the consultation was created
 	Diagnosen		VARCHAR(25),					# diagnoses
 	Leistungen		VARCHAR(25),					# deprecated, do not use.
 	Eintrag			BLOB							# treatment text (as VersionedResource)

--- a/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
+++ b/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
@@ -76,7 +76,7 @@ public class CoreHub implements BundleActivator {
 	public static String Version = "3.4.0.qualifier"; //$NON-NLS-1$
 	public static final String APPLICATION_NAME = "Elexis Core"; //$NON-NLS-1$
 	static final String neededJRE = "1.8.0"; //$NON-NLS-1$
-	public static final String DBVersion = "3.4.2"; //$NON-NLS-1$
+	public static final String DBVersion = "3.4.3"; //$NON-NLS-1$
 	
 	protected static Logger log = LoggerFactory.getLogger(CoreHub.class.getName());
 	

--- a/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
+++ b/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
@@ -31,6 +31,7 @@ import ch.elexis.core.data.extension.CoreOperationExtensionPoint;
 import ch.elexis.core.data.status.ElexisStatus;
 import ch.elexis.data.BezugsKontakt;
 import ch.elexis.data.Brief;
+import ch.elexis.data.Konsultation;
 import ch.elexis.data.Leistungsblock;
 import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Prescription;
@@ -63,7 +64,7 @@ public class DBUpdate {
 		"1.4.5", "1.4.6", "1.5.0", "1.6.0", "1.6.1", "1.6.2", "1.6.3", "1.6.4", "1.7.0", "1.7.1",
 		"1.7.2", "1.8.0", "1.8.1", "1.8.2", "1.8.3", "1.8.4", "1.8.5", "1.8.6", "1.8.7", "1.8.8",
 		"1.8.9", "1.8.10", "1.8.11", "1.8.12", "1.8.13", "1.8.14", "1.8.15", "1.8.16", "1.9.0", "3.0.0",
-		"3.1.0", "3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.4.0", "3.4.1", "3.4.2"
+		"3.1.0", "3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.4.0", "3.4.1", "3.4.2", "3.4.3"
 	};
 	static final String[] cmds =
 		{
@@ -431,7 +432,11 @@ public class DBUpdate {
 			// 3.4.1
 			FILE_LOCATED,
 			// 3.4.2
-			FILE_LOCATED
+			FILE_LOCATED,
+			// 3.4.3
+			"UPDATE user_ SET `id` = LOWER(`id`);"+
+			ALTER_TABLE+Konsultation.TABLENAME+ADD+Konsultation.FLD_TIME+" CHAR(6);"
+		
 			};
 	//@formatter:on
 	

--- a/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
+++ b/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
@@ -435,7 +435,7 @@ public class DBUpdate {
 			FILE_LOCATED,
 			// 3.4.3
 			"UPDATE user_ SET `id` = LOWER(`id`);"+
-			ALTER_TABLE+Konsultation.TABLENAME+ADD+Konsultation.FLD_TIME+" CHAR(6);"
+			ALTER_TABLE+Konsultation.TABLENAME+ADD+Konsultation.FLD_TIME+" CHAR(8);"
 		
 			};
 	//@formatter:on

--- a/ch.elexis.core.data/src/ch/elexis/data/Anwender.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/Anwender.java
@@ -54,13 +54,12 @@ public class Anwender extends Person {
 	public static final String FLD_EXTINFO_MANDATORS = "Mandant";
 	
 	static {
-		addMapping(Kontakt.TABLENAME, FLD_EXTINFO, Kontakt.FLD_IS_USER,
-			FLD_LABEL + "=Bezeichnung3", FLD_JOINT_REMINDERS
-				+ "=JOINT:ReminderID:ResponsibleID:REMINDERS_RESPONSIBLE_LINK");
+		addMapping(Kontakt.TABLENAME, FLD_EXTINFO, Kontakt.FLD_IS_USER, FLD_LABEL + "=Bezeichnung3",
+			FLD_JOINT_REMINDERS + "=JOINT:ReminderID:ResponsibleID:REMINDERS_RESPONSIBLE_LINK");
 	}
 	
 	public Anwender(String Username, String Password){
-		this(Username, Password, false);	
+		this(Username, Password, false);
 	}
 	
 	/**
@@ -77,7 +76,8 @@ public class Anwender extends Person {
 		
 		User user = new User(this, username, password);
 		if (isExecutiveDoctor)
-			user.setAssignedRole(Role.load(RoleConstants.SYSTEMROLE_LITERAL_EXECUTIVE_DOCTOR), true);
+			user.setAssignedRole(Role.load(RoleConstants.SYSTEMROLE_LITERAL_EXECUTIVE_DOCTOR),
+				true);
 	}
 	
 	public Anwender(final String Name, final String Vorname, final String Geburtsdatum,
@@ -92,6 +92,7 @@ public class Anwender extends Person {
 		}
 		return null;
 	}
+	
 	/**
 	 * Return a short or long label for this Anwender
 	 * 
@@ -171,7 +172,7 @@ public class Anwender extends Person {
 		List<String> edList = hashSet.stream().map(p -> p.getLabel()).collect(Collectors.toList());
 		setExtInfoStoredObjectByKey(FLD_EXTINFO_MANDATORS, edList.isEmpty() ? "" : ts(edList));
 	}
-
+	
 	@Override
 	protected String getConstraint(){
 		return Kontakt.FLD_IS_USER + StringTool.equals + JdbcLink.wrap(StringConstants.ONE);
@@ -207,49 +208,49 @@ public class Anwender extends Person {
 		User.load(ADMINISTRATOR).setAssignedContact(admin);
 		
 		CoreHub.actUser = admin;
-		ElexisEventDispatcher.getInstance().fire(
-			new ElexisEvent(admin, Anwender.class, ElexisEvent.EVENT_USER_CHANGED));
+		ElexisEventDispatcher.getInstance()
+			.fire(new ElexisEvent(admin, Anwender.class, ElexisEvent.EVENT_USER_CHANGED));
 	}
 	
 	/**
-	 * Login: Anwender anmelden, passenden Mandanten anmelden. (Jeder Anwender
-	 * ist entweder selber ein Mandant oder ist einem Mandanten zugeordnet)
+	 * Login: Anwender anmelden, passenden Mandanten anmelden. (Jeder Anwender ist entweder selber
+	 * ein Mandant oder ist einem Mandanten zugeordnet)
 	 * 
 	 * @param username
 	 *            Kurzname
 	 * @param password
 	 *            Passwort
-	 * @return <code>true</code> erfolgreich angemeldet, CoreHub.actUser
-	 *         gesetzt, else <code>false</code>
+	 * @return <code>true</code> erfolgreich angemeldet, CoreHub.actUser gesetzt, else
+	 *         <code>false</code>
 	 * @since 3.1 queries {@link User}
 	 */
-	public static boolean login(final String username, final String password) {
+	public static boolean login(final String username, final String password){
 		((LocalLockService) CoreHub.getLocalLockService()).reconfigure();
 		((ElexisServerEventService) CoreHub.getElexisServerEventService()).reconfigure();
-
+		
 		CoreHub.logoffAnwender();
-
+		
 		// check if user exists
 		User user = User.load(username);
 		if (!user.exists()) {
 			return false;
 		}
 		
-		if(!username.equals(user.get(FLD_ID))) {
+		if (!username.toLowerCase().equals(user.get(FLD_ID))) {
 			return false;
 		}
-
+		
 		// is the user currently active, or locked?
 		if (!user.isActive()) {
 			return false;
 		}
-
+		
 		// check if password is valid
 		boolean result = user.verifyPassword(password);
 		if (!result) {
 			return false;
 		}
-
+		
 		// check anwender is valid
 		Anwender anwender = Anwender.load(user.getAssignedContactId());
 		if (anwender == null) {
@@ -270,34 +271,35 @@ public class Anwender extends Person {
 		}
 		
 		// set user in system
-		ElexisEventDispatcher.getInstance().fire(new ElexisEvent(user, User.class, ElexisEvent.EVENT_SELECTED));
+		ElexisEventDispatcher.getInstance()
+			.fire(new ElexisEvent(user, User.class, ElexisEvent.EVENT_SELECTED));
 		CoreHub.actUser = anwender;
 		ElexisEventDispatcher.getInstance()
-				.fire(new ElexisEvent(CoreHub.actUser, Anwender.class, ElexisEvent.EVENT_USER_CHANGED));
-
+			.fire(new ElexisEvent(CoreHub.actUser, Anwender.class, ElexisEvent.EVENT_USER_CHANGED));
+		
 		cod.adaptForUser();
-
+		
 		CoreHub.actUser.setInitialMandator();
-
+		
 		CoreHub.userCfg = new SqlSettings(getConnection(), "USERCONFIG", "Param", "Value",
-				"UserID=" + CoreHub.actUser.getWrappedId());
-
+			"UserID=" + CoreHub.actUser.getWrappedId());
+		
 		CoreHub.heart.resume(true);
-
+		
 		return true;
 	}
 	
 	/**
 	 * @since 3.1
 	 */
-	public static void logoff() {
+	public static void logoff(){
 		CoreHub.logoffAnwender();
 	}
 	
 	private void setInitialMandator(){
 		String mandantLabel = (String) getExtInfoStoredObjectByKey(FLD_EXTINFO_MANDATORS);
 		String MandantID = null;
-		if (mandantLabel!=null && mandantLabel.length()>0) {
+		if (mandantLabel != null && mandantLabel.length() > 0) {
 			mandantLabel = mandantLabel.split(",")[0];
 			for (Mandant m : CoreHub.getMandantenList()) {
 				if (m.getLabel().equals(mandantLabel)) {
@@ -319,14 +321,13 @@ public class Anwender extends Person {
 					CoreHub.setMandant(m);
 					
 				} else {
-					MessageEvent
-						.fireError("Kein Mandant definiert",
-							"Sie können Elexis erst normal benutzen, wenn Sie mindestens einen Mandanten definiert haben");
+					MessageEvent.fireError("Kein Mandant definiert",
+						"Sie können Elexis erst normal benutzen, wenn Sie mindestens einen Mandanten definiert haben");
 				}
 			}
 		}
 	}
-
+	
 	/**
 	 * 
 	 * @return <code>true</code> if {@link Anwender} is also {@link Mandant}
@@ -339,10 +340,11 @@ public class Anwender extends Person {
 	
 	/**
 	 * 
-	 * @param value <code>true</code> to define as {@link Mandant}, else <code>false</code>
+	 * @param value
+	 *            <code>true</code> to define as {@link Mandant}, else <code>false</code>
 	 * @since 3.1
 	 */
-	public void setExecutiveDoctor(boolean value) {
+	public void setExecutiveDoctor(boolean value){
 		set(FLD_IS_MANDATOR, ts(value));
 	}
 }

--- a/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
@@ -33,7 +33,6 @@ import ch.elexis.core.exceptions.PersistenceException;
 import ch.elexis.core.model.IDiagnose;
 import ch.elexis.core.model.prescription.EntryType;
 import ch.elexis.core.text.model.Samdas;
-import ch.rgw.crypt.BadParameterException;
 import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLink.Stm;
@@ -738,9 +737,8 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	
 	/** Die zu dieser Konsultation gehörenden Leistungen holen */
 	public List<Verrechnet> getLeistungen(String[] prefetch){
-		Query<Verrechnet> qbe =
-			new Query<Verrechnet>(Verrechnet.class, Verrechnet.KONSULTATION, getId(),
-				Verrechnet.TABLENAME, prefetch);
+		Query<Verrechnet> qbe = new Query<Verrechnet>(Verrechnet.class, Verrechnet.KONSULTATION,
+			getId(), Verrechnet.TABLENAME, prefetch);
 		qbe.orderBy(false, Verrechnet.CLASS, Verrechnet.LEISTG_CODE);
 		return qbe.execute();
 	}
@@ -850,8 +848,9 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	public int getKosten(){
 		int sum = 0;
 		/*
-		 * TimeTool mine=new TimeTool(getDatum()); List<Verrechenbar> l=getLeistungen();
-		 * for(Verrechenbar v:l){ sum+=(v.getZahl()v.getKosten(mine)); }
+		 * TimeTool mine=new TimeTool(getDatum()); List<Verrechenbar>
+		 * l=getLeistungen(); for(Verrechenbar v:l){
+		 * sum+=(v.getZahl()v.getKosten(mine)); }
 		 */
 		Stm stm = getDBConnection().getStatement();
 		try {
@@ -926,8 +925,9 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 			StringBuilder sb = new StringBuilder();
 			sb.append("UPDATE LEISTUNGEN SET SCALE='").append(scale).append("' WHERE BEHANDLUNG=")
 				.append(getWrappedId()) /*
-										 * .append ( " AND " ) .append ( "KLASSE=" ) .append (
-										 * JdbcLink . wrap (v .getClass ( ).getName ()))
+										 * .append ( " AND " ) .append ( "KLASSE=" )
+										 * .append ( JdbcLink . wrap (v .getClass (
+										 * ).getName ()))
 										 */
 				.append(" AND LEISTG_CODE=").append(JdbcLink.wrap(v.getId()));
 			
@@ -941,7 +941,8 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 			StringBuilder sql = new StringBuilder();
 			sql.append("UPDATE LEISTUNGEN SET ZAHL=").append(nz)
 				/*
-				 * .append(" WHERE KLASSE=").append(JdbcLink.wrap(v.getClass().getName ()))
+				 * .append(" WHERE KLASSE=").append(JdbcLink.wrap(v.getClass
+				 * ().getName ()))
 				 */
 				.append(" WHERE LEISTG_CODE=").append(JdbcLink.wrap(v.getId()))
 				.append(" AND BEHANDLUNG=").append(getWrappedId());
@@ -976,7 +977,9 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 		return true;
 	}
 	
-	/** Interface Comparable, um die Behandlungen nach Datum sortieren zu können */
+	/**
+	 * Interface Comparable, um die Behandlungen nach Datum sortieren zu können
+	 */
 	public int compareTo(Konsultation b){
 		TimeTool me = new TimeTool(getDatum());
 		TimeTool other = new TimeTool(b.getDatum());
@@ -1034,7 +1037,8 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	}
 	
 	/*
-	 * public interface Listener { public boolean creatingKons(Konsultation k); }
+	 * public interface Listener { public boolean creatingKons(Konsultation k);
+	 * }
 	 */
 	
 	/**

--- a/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
@@ -159,7 +159,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 			set(new String[] {
 				DATE, FLD_TIME, FLD_CASE_ID, FLD_MANDATOR_ID
 			}, now.toString(TimeTool.DATE_GER),
-				now.toString(TimeTool.TIME_FULL).replaceAll(":", ""), fall.getId(),
+				now.toString(TimeTool.TIME_FULL), fall.getId(),
 				ElexisEventDispatcher.getSelectedMandator().getId());
 			fall.getPatient().setExtInfoStoredObjectByKey("LetzteBehandlung", getId());
 		}
@@ -379,10 +379,10 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	 */
 	public void setTime(String time, boolean force){
 		if (time != null) {
-			if (time.length() == 4) {
-				time += "00";
-			} else if (time.length() != 6) {
-				throw new InvalidParameterException("Time must be in HHMM or HHMMSS format");
+			if (time.length() == 5) {
+				time += ":00";
+			} else if (time.length() != 8) {
+				throw new InvalidParameterException("Time must be in HH:MM or HH:MM:SS format");
 			}
 			if (force || isEditable(true)) {
 				set(FLD_TIME, time);
@@ -398,7 +398,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	public String getTime(){
 		String time = get(FLD_TIME);
 		if (StringTool.isNothing(time)) {
-			return "000000";
+			return "00:00:00";
 		} else {
 			return time;
 		}
@@ -413,7 +413,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	 */
 	public void setTime(TimeTool time, boolean force){
 		if (force || isEditable(true)) {
-			set(FLD_TIME, time.toString(TimeTool.TIME_FULL).replaceAll(":", ""));
+			set(FLD_TIME, time.toString(TimeTool.TIME_FULL));
 		}
 	}
 	

--- a/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
@@ -155,11 +155,13 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 				"Zu einem abgeschlossenen Fall kann keine neue Konsultation erstellt werden");
 		} else {
 			create(null);
+			TimeTool now = new TimeTool();
 			set(new String[] {
-				DATE, FLD_CASE_ID, FLD_MANDATOR_ID
-			}, new TimeTool().toString(TimeTool.DATE_GER), fall.getId(),
-				CoreHub.actMandant.getId());
-			fall.getPatient().setInfoElement("LetzteBehandlung", getId());
+				DATE, FLD_TIME, FLD_CASE_ID, FLD_MANDATOR_ID
+			}, now.toString(TimeTool.DATE_GER),
+				now.toString(TimeTool.TIME_FULL).replaceAll(":", ""), fall.getId(),
+				ElexisEventDispatcher.getSelectedMandator().getId());
+			fall.getPatient().setExtInfoStoredObjectByKey("LetzteBehandlung", getId());
 		}
 		if (getDefaultDiagnose() != null)
 			addDiagnose(getDefaultDiagnose());
@@ -983,7 +985,14 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	public int compareTo(Konsultation b){
 		TimeTool me = new TimeTool(getDatum());
 		TimeTool other = new TimeTool(b.getDatum());
-		return me.compareTo(other);
+		int dateComp = me.compareTo(other);
+		if (dateComp == 0) {
+			String mine = getTime();
+			String others = b.getTime();
+			return mine.compareTo(others);
+		} else {
+			return dateComp;
+		}
 	}
 	
 	/**

--- a/ch.elexis.core.data/src/ch/elexis/data/User.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/User.java
@@ -64,7 +64,7 @@ public class User extends PersistentObject {
 	 * @param password
 	 */
 	public User(Anwender anw, String username, String password){
-		create(username);
+		create(username.toLowerCase());
 		setAssignedContact(anw);
 		if (password == null || password.length() == 0) {
 			password = StringTool.unique("pswd");
@@ -75,7 +75,7 @@ public class User extends PersistentObject {
 	}
 	
 	protected User(final String id){
-		super(id);
+		super(id.toLowerCase());
 	}
 	
 	/**
@@ -86,7 +86,7 @@ public class User extends PersistentObject {
 	 * @return
 	 */
 	public static @NonNull User load(final String id) {
-		return new User(id.toLowerCase());
+		return new User(id);
 	}
 	
 	/**

--- a/ch.elexis.core.data/src/ch/elexis/data/User.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/User.java
@@ -86,7 +86,7 @@ public class User extends PersistentObject {
 	 * @return
 	 */
 	public static @NonNull User load(final String id) {
-		return new User(id);
+		return new User(id.toLowerCase());
 	}
 	
 	/**

--- a/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
+++ b/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
@@ -556,6 +556,8 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			if (!bClosed && !bOpen) {
 				qbe.insertFalse();
 			}
+			qbe.orderBy(false, Konsultation.DATE,Konsultation.FLD_TIME);
+
 			qbe.addPostQueryFilter(new IFilter() {
 				public boolean select(final Object toTest){
 					if (filterAction.isChecked()) {


### PR DESCRIPTION
This makes two changes:
(1) user names are case independent. It is not only unnecessary but also error prone to have "Username" and "username" refer to different users. So, this patch converts all usernames to lowercase in the first place and then also converts usernames to lowercase on create and on login.

(2) Insert a Column "Zeit" into elexis.behandlungen. The new tarmed revision rises the need to create several consultations on the same day and ordering and managing consultations is easier if creation time is visible in the database. (This is not the same as modification time of the consultation entry as given in the 'eintrag' VersionedResource.)

The patch sets the creation time for all newly created consultations to the current time. Existing consultations are not touched. The Comparator will respect date and time, and the "PatHeuteView" orders consultations by date and time now. 
