### PR TITLE
remove NFE

### DIFF
--- a/ch.elexis.core.data/src/ch/elexis/data/dto/BriefDocumentDTO.java
+++ b/ch.elexis.core.data/src/ch/elexis/data/dto/BriefDocumentDTO.java
@@ -34,9 +34,12 @@ public class BriefDocumentDTO extends AbstractDocumentDTO {
 		setDescription(data[2]);
 		setTitle(data[3]);
 		setMimeType(data[4]);
-		setLastchanged(new Date(Long.valueOf(brief.get(Brief.FLD_LASTUPDATE))));
+    try {
+			setLastchanged(new Date(Long.valueOf(brief.get(Brief.FLD_LASTUPDATE))));
+		} catch (NumberFormatException nex) {
+			setLastchanged(new Date());
+		}
 		setCreated(new TimeTool(brief.get(Brief.FLD_DATE)).getTime());
-		
 		setExtension(evaluateExtension(data[4]));
 		
 		if (StringUtils.isNotEmpty(data[5])) {


### PR DESCRIPTION
At  leeast in my database, the BriefDocumentDTO Constructor fails with NumberFormatExceptions, when I try to:

```
IDocument[] arr=documents.getDocuments(pat.getId(), null, null, null).toArray(new IDocument[0]);
```
Where documents is the IDocumentStore Service.

This PR catches these NFEs