### PR TITLE
[8769] Make Maven Build (almost) reproducible

### DIFF
--- a/bundles/ch.elexis.core.documents/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.documents/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Elexis Document Store
 Bundle-SymbolicName: ch.elexis.core.documents
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: ch.elexis.core;bundle-version="3.2.0",
- ch.elexis.core.l10n;bundle-version="3.5.0"
+Require-Bundle: ch.elexis.core;bundle-version="3.7.0",
+ ch.elexis.core.l10n;bundle-version="3.7.0"
 Import-Package: ch.elexis.core.data.interfaces.events,
  ch.rgw.tools,
  org.apache.commons.io;version="2.4.0",

--- a/bundles/ch.elexis.core.eigenartikel/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.eigenartikel/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eigenartikel
 Bundle-SymbolicName: ch.elexis.core.eigenartikel;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.info
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",

--- a/bundles/ch.elexis.core.eigendiagnosen/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.eigendiagnosen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eigendiagnosen
 Bundle-SymbolicName: ch.elexis.core.eigendiagnosen;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.info
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",

--- a/bundles/ch.elexis.core.findings.fhir.po/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.fhir.po/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Findings Persistent Object
 Bundle-SymbolicName: ch.elexis.core.findings.fhir.po;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: ch.elexis.core.findings;bundle-version="1.0.0",
- ch.elexis.core.findings.util;bundle-version="1.0.0",
+Require-Bundle: ch.elexis.core.findings;bundle-version="3.7.0",
+ ch.elexis.core.findings.util;bundle-version="3.7.0",
  ch.elexis.core;bundle-version="3.2.0",
  ch.elexis.core.data;bundle-version="3.2.0",
  org.eclipse.core.runtime;bundle-version="3.8.0",

--- a/bundles/ch.elexis.core.findings.templates.edit/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.templates.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ch.elexis.core.findings.templates.edit;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: ch.elexis.core.findings.templates.model.provider.ModelEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/ch.elexis.core.findings.templates.po/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.templates.po/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Findings Templates PersistentObject
 Bundle-SymbolicName: ch.elexis.core.findings.templates.po
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: ch.elexis.core.findings;bundle-version="1.0.0",
- ch.elexis.core.findings.templates;bundle-version="3.0.0",
+Require-Bundle: ch.elexis.core.findings;bundle-version="3.7.0",
+ ch.elexis.core.findings.templates;bundle-version="3.7.0",
  org.eclipse.osgi.services;bundle-version="3.5.100",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.apache.commons.io;bundle-version="2.4.0",

--- a/bundles/ch.elexis.core.findings.templates.ui/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.templates.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Templates UI
 Bundle-SymbolicName: ch.elexis.core.findings.templates.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/bundles/ch.elexis.core.findings.templates/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.templates/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ch.elexis.core.findings.templates;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/ch.elexis.core.findings.ui/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.ui/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Findings Ui
 Bundle-SymbolicName: ch.elexis.core.findings.ui;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: ch.elexis.core.data,
- ch.elexis.core.findings,
- ch.elexis.core.findings.util;bundle-version="1.0.0",
+ ch.elexis.core.findings;bundle-version="3.7.0",
+ ch.elexis.core.findings.util;bundle-version="3.7.0",
  ch.elexis.core.ui,
  ch.elexis.core.ui.icons,
  org.eclipse.jface;bundle-version="3.8.0",

--- a/bundles/ch.elexis.core.findings.util/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings.util/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core Findings Util
 Bundle-SymbolicName: ch.elexis.core.findings.util
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: ch.elexis.core.findings;bundle-version="1.0.0",
+Require-Bundle: ch.elexis.core.findings;bundle-version="3.7.0",
  hapi-fhir-osgi-core;bundle-version="2.4.0",
  org.springframework.spring-web
 Export-Package: ch.elexis.core.findings.scripting,

--- a/bundles/ch.elexis.core.findings/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.findings/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Findings
 Bundle-SymbolicName: ch.elexis.core.findings
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: medevit.at
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: ch.elexis.core.findings,

--- a/bundles/ch.elexis.core.logging.default_configuration/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.logging.default_configuration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Default_configuration
 Bundle-SymbolicName: ch.elexis.core.logging.default_configuration
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Fragment-Host: ch.qos.logback.classic
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: rsc/

--- a/bundles/ch.elexis.core.logging.osgi/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.logging.osgi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OSGI Slf4J Logging Adapter
 Bundle-SymbolicName: ch.elexis.core.logging.osgi
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.info
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/bundles/ch.elexis.core.scripting.beanshell/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.scripting.beanshell/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Beanshell scripting for Elexis
 Bundle-SymbolicName: ch.elexis.core.scripting.beanshell;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.info
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,

--- a/bundles/ch.elexis.core.ui.contacts/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.ui.contacts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Elexis Core Contacts
 Bundle-SymbolicName: ch.elexis.core.ui.contacts;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Activator: ch.elexis.core.ui.contacts.Activator
 Bundle-Vendor: elexis.info
 Bundle-Localization: plugin

--- a/bundles/ch.elexis.core.ui.eigenartikel/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.ui.eigenartikel/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eigenartikel
 Bundle-SymbolicName: ch.elexis.core.ui.eigenartikel;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.ch
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
@@ -21,5 +21,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.core.databinding.property,
  org.eclipse.jface.databinding,
  com.ibm.icu,
- ch.elexis.core.l10n;bundle-version="3.5.0"
+ ch.elexis.core.l10n;bundle-version="3.7.0"
 Bundle-ActivationPolicy: lazy

--- a/bundles/ch.elexis.core.ui.eigendiagnosen/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.ui.eigendiagnosen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Selbstdefinierte Diagnosen
 Bundle-SymbolicName: ch.elexis.core.ui.eigendiagnosen;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.ch
 Require-Bundle: ch.elexis.core;bundle-version="3.0.0",
  ch.elexis.core.data;bundle-version="3.0.0",

--- a/bundles/ch.elexis.core.ui.medication/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.ui.medication/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Elexis Core Medication
 Bundle-SymbolicName: ch.elexis.core.ui.medication;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Vendor: elexis.info
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/bundles/ch.elexis.core.ui.stock/META-INF/MANIFEST.MF
+++ b/bundles/ch.elexis.core.ui.stock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Stock
 Bundle-SymbolicName: ch.elexis.core.ui.stock;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jface,
  org.eclipse.osgi.services,

--- a/bundles/org.iatrix.help.wiki/META-INF/MANIFEST.MF
+++ b/bundles/org.iatrix.help.wiki/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Iatrix Help Wiki
 Bundle-SymbolicName: org.iatrix.help.wiki; singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.7.0.qualifier
 Bundle-Activator: org.iatrix.help.wiki.Activator
 Bundle-Vendor: org.iatrix
 Require-Bundle: org.eclipse.ui,

--- a/ch.elexis.core.releng/pom.xml
+++ b/ch.elexis.core.releng/pom.xml
@@ -6,6 +6,6 @@
   <parent>
     <groupId>ch.elexis</groupId>
     <artifactId>elexis-3-core</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       </repository>
     </repositories>
     <properties>
-		<tycho.version>1.0.0</tycho.version>
+		<tycho.version>1.2.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tycho-groupid>org.eclipse.tycho</tycho-groupid>
         <git.target.branch>master</git.target.branch>
@@ -57,7 +57,7 @@
 		<module>bundles</module>
 		<module>features</module>
 		<module>tests</module>
-		<module>ch.elexis.core.p2site</module>
+		<module>ch.elexis.core.p2site</module>    
 	</modules>
 	<profiles>
 		<profile>
@@ -261,7 +261,6 @@
 							<scripts>
 								<script><![CDATA[
   import java.text.SimpleDateFormat;
-  HINT_GENERATED    = "#  ${project.name}: Generated from pom.xml groovy shell using gmavenplus-plugin at ${new Date()}\n"
   HINT_LAST_CHANGED = "# Last changed from pom.xml groovy shell by gmavenplus-plugin in pom.xml at ${new Date()}\n"
 
   // Returns the current branchName
@@ -274,7 +273,13 @@
         println "NO CI_COMMIT_REF_NAME environment branch is now ${branch}"
       }
       commit_id="git rev-parse HEAD".execute().text.replaceAll("\n", '')
-      elexis_version = "${project.version}".replace("-SNAPSHOT", ".") + new SimpleDateFormat("yyyyMMdd-HHmm").format(Calendar.getInstance().getTime())
+      time_from_commit="git log -1 --format=%cD".execute().text.replaceAll("\n", '')
+      odt = java.time.LocalDateTime.parse (time_from_commit, java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME);
+      sdf = java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmm")
+      commit_time = odt.format(sdf)
+      println("${project.name}: commit_id ${commit_id} commit_time: ${commit_time}} time_from_commit ${time_from_commit}")
+      elexis_version = "${project.version}".replace("-SNAPSHOT", "${commit_time}")
+      println("${project.name}: commit_time ${commit_time} elexis_version ${elexis_version} from commit_id ${commit_id}")
       tags =  "git tag --contains ${commit_id}".execute().text.split("\n")
       for ( i in tags ) {
           if (i ==~/release\/(.*)/ ) {
@@ -287,6 +292,8 @@
       System.setProperty("git_branch",  branch)
       System.setProperty("elexis_version",  elexis_version)
       repo_version_file = new File(filename)
+      HINT_GENERATED    = "#  ${project.name}: Generated from pom.xml groovy shell using gmavenplus-plugin\n"
+      
       repo_version_file.write(HINT_GENERATED)
       repo_version_file.append("elexis.version=${elexis_version}\n")
       println("${project.name}: Created ${repo_version_file} with elexis_version ${elexis_version} from commit_id ${commit_id}")
@@ -297,6 +304,7 @@
     // Now we are have the info to crate teh repo.properties
     repo_version_file = new File(repo_properties_name)
     repo_version_file.write(HINT_GENERATED)
+    repo_version_file.append("// run at  ${new Date()}\n")
     repo_version_file.append("repoVariant=${branch}\n")
     repo_version_file.append("project.id=${project.id}\n")
     repo_version_file.append("project.name=${project.name}\n")
@@ -371,7 +379,52 @@ if ( System.getProperty("git_branch") == null && project.name == 'ch.elexis.core
         </execution>
       </executions>
     </plugin>
-  </plugins>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.4</version>
+        <executions>
+          <execution>
+            <id>retrieve-git-info</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <injectAllReactorProjects>true</injectAllReactorProjects>
+          <runOnlyOnce>true</runOnlyOnce>
+          <skipPoms>false</skipPoms>
+          <dateFormat>yyyyMMddHHmmss</dateFormat>
+          <dateFormatTimeZone>UTC</dateFormatTimeZone>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.github.zlika</groupId>
+        <artifactId>reproducible-build-maven-plugin</artifactId>
+        <version>0.7</version>
+        <executions>
+          <execution>
+            <id>strip-jaxb</id>
+            <goals>
+              <goal>strip-jaxb</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>strip-jar</id>
+            <goals>
+              <goal>strip-jar</goal>
+            </goals>
+            <configuration>
+              <zipDateTime>${git.commit.time}</zipDateTime>
+              <!-- Set custom date/time format pattern, "yyyyMMddHHmmss" by default -->
+              <!-- <zipDateTimeFormatPattern>yyyyMMddHHmmss</zipDateTimeFormatPattern> -->
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   <pluginManagement>
     <plugins>
     		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
@@ -405,6 +458,16 @@ if ( System.getProperty("git_branch") == null && project.name == 'ch.elexis.core
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <!-- Use compiler plugin with tycho as the adapter to the JDT compiler. -->
         <artifactId>maven-compiler-plugin </artifactId>
@@ -446,14 +509,6 @@ Without it Maven would put two versions of each class file into the jars
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <version>${tycho.version}</version>
-        <configuration>
-          <executionEnvironment>JavaSE-1.8</executionEnvironment>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-compiler-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
@@ -483,6 +538,7 @@ Without it Maven would put two versions of each class file into the jars
            <jgit.ignore>
              pom.xml
              .polyglot.build.properties
+             maven
            </jgit.ignore>
           <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
         </configuration>
@@ -520,6 +576,11 @@ Without it Maven would put two versions of each class file into the jars
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
+           <baselineRepositories>
+             <repository>
+              <url>http://download.eclipse.org/eclipse/updates/3.8</url>
+             </repository>
+           </baselineRepositories>
           <corelineMode>warn</corelineMode>
           <corelineReplace>none</corelineReplace>
           <corelineRepositories>
@@ -538,7 +599,7 @@ Without it Maven would put two versions of each class file into the jars
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
+				<version>3.1.</version>
 				<configuration>
 					<includeTestResources>false</includeTestResources>
 					<linkXRef>true</linkXRef>


### PR DESCRIPTION
Folgende Anpassungen im pom.xml gemacht:
* Tycho von Version 1.0.0 auf 1.2.0 hochgezogen
* baselineRepositories für hinzugefügt
* elexis_version wird neu aufgrund des commit-timestamps generiert
* version in repo.properties hat commit-timestamp und aktuelles Datum/Uhrzeit
* Neue Maven plugins git-commit-id-plugin und reproducible-build-maven-plugin


Wenn ich in einem anderen Verzeichnis jeweils, nochmals mvn clean verify  -Dtycho.localArtifacts=ignore -Dmaven.test.skip=true -Pall-arch aufrief, wurden von ch.elexis.core.findings.fhir immer eine alte und nicht die neue Version genommen. Nachdem ich bei ca 15 MANIFEST.MF die Version auf 3.7.0 hochgesetzt hatte, verschwanden diese Probleme.

Es bleiben Differenzen im p2/org.eclipse.equinox.p2.engine/.settings/org.eclipse.equinox.p2.metadata.repository.prefs, artifacts.xml und im p2/org.eclipse.equinox.p2.core/cache/artifacts.xml, wo die Einträge nie gleich sortiert werden und ein TimeStamp hinzugefügt wurde.

Gemöss https://dev.eclipse.org/mhonarc/lists/tycho-user/msg03927.html scheint dies ein bekanntes Problem zu sein.
