### PR TITLE
Use Eclipse Platform Command Framework for global print actions

### DIFF
--- a/bundles/ch.elexis.core.application/src/ch/elexis/core/application/advisors/ApplicationActionBarAdvisor.java
+++ b/bundles/ch.elexis.core.application/src/ch/elexis/core/application/advisors/ApplicationActionBarAdvisor.java
@@ -242,7 +242,7 @@ public class ApplicationActionBarAdvisor extends ActionBarAdvisor {
 			}
 			
 			setToolTipText((StringTool.isNothing(name) ? perspectiveDescriptor.getLabel() : name)
-				+ Messages.ApplicationActionBarAdvisor_10);
+				+ " " + Messages.ApplicationActionBarAdvisor_10);
 			
 			this.perspectiveDescriptor = perspectiveDescriptor;
 		}

--- a/bundles/ch.elexis.core.ui/plugin.xml
+++ b/bundles/ch.elexis.core.ui/plugin.xml
@@ -758,6 +758,21 @@
             id="ch.elexis.core.ui.command.openCompendium"
             name="%open.compendium">
       </command>
+      <command
+            id="ch.elexis.core.ui.commands.printPatientLabel"
+            categoryId="ch.elexis.core.ui.commands.kategorie"
+            defaultHandler="ch.elexis.core.ui.commands.PrintPatientLabelHandler">
+      </command>
+      <command
+            id="ch.elexis.core.ui.commands.printVersionedLabel"
+            categoryId="ch.elexis.core.ui.commands.kategorie"
+            defaultHandler="ch.elexis.core.ui.commands.PrintVersionedLabelHandler">
+      </command>
+      <command
+            id="ch.elexis.core.ui.commands.printAddressLabel"
+            categoryId="ch.elexis.core.ui.commands.kategorie"
+            defaultHandler="ch.elexis.core.ui.commands.PrintAddressLabelHandler">
+      </command>
    </extension>
       <extension
             point="ch.elexis.core.ui.KonsExtension">

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
@@ -32,6 +32,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.Category;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.Action;
@@ -61,6 +65,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.actions.ActionFactory.IWorkbenchAction;
+import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.help.IWorkbenchHelpSystem;
 import org.eclipse.ui.part.ViewPart;
@@ -139,12 +144,16 @@ public class GlobalActions {
 	public static Action printKontaktEtikette;
 	private static IWorkbenchHelpSystem help;
 	private static Logger logger;
+	private static ICommandService cmdService;
+	private static Category cmdCategory;
 	
 	public GlobalActions(final IWorkbenchWindow window){
 		if (Hub.mainActions != null) {
 			return;
 		}
 		logger = LoggerFactory.getLogger(this.getClass());
+		cmdService = (ICommandService) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getService(ICommandService.class);
+		cmdCategory = cmdService.getCategory("ch.elexis.core.ui.commands.kategorie");
 		mainWindow = window;
 		help = Hub.plugin.getWorkbench().getHelpSystem();
 		exitAction = ActionFactory.QUIT.create(window);
@@ -377,29 +386,15 @@ public class GlobalActions {
 			
 			@Override
 			public void run(){
-				Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
-				if (actPatient == null) {
-					SWTHelper.showInfo("Kein Patient ausgewählt",
-						"Bitte wählen Sie vor dem Drucken einen Patient!");
-					return;
+				Command cmd = cmdService.getCommand("ch.elexis.core.ui.commands.printAddressLabel");
+				if (!cmd.isDefined()) {
+					  cmd.define(Messages.GlobalActions_PrintAddressLabel, Messages.GlobalActions_PrintAddressLabelToolTip, cmdCategory);
 				}
 				
-				EtiketteDruckenDialog dlg =
-					new EtiketteDruckenDialog(mainWindow.getShell(), actPatient, TT_ADDRESS_LABEL);
-				dlg.setTitle(Messages.GlobalActions_PrintAddressLabel);
-				dlg.setMessage(Messages.GlobalActions_PrintAddressLabelToolTip);
-				if (isDirectPrint()) {
-					dlg.setBlockOnOpen(false);
-					dlg.open();
-					if (dlg.doPrint()) {
-						dlg.close();
-					} else {
-						SWTHelper.alert("Fehler beim Drucken",
-							"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
-					}
-				} else {
-					dlg.setBlockOnOpen(true);
-					dlg.open();
+				try {
+					cmd.executeWithChecks(new ExecutionEvent());
+				} catch (Exception e) {
+					logger.error("Failed to execute command ch.elexis.core.ui.commands.printAddressLabel", e);
 				}
 			}
 		};
@@ -412,28 +407,15 @@ public class GlobalActions {
 			
 			@Override
 			public void run(){
-				Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
-				if (actPatient == null) {
-					SWTHelper.showInfo("Kein Patient ausgewählt",
-						"Bitte wählen Sie vor dem Drucken einen Patient!");
-					return;
+				Command cmd = cmdService.getCommand("ch.elexis.core.ui.commands.printVersionedLabel");
+				if (!cmd.isDefined()) {
+					  cmd.define(Messages.GlobalActions_PrintVersionedLabel, Messages.GlobalActions_PrintVersionedLabelToolTip, cmdCategory);
 				}
-				EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(mainWindow.getShell(),
-					actPatient, TT_PATIENT_LABEL_ORDER);
-				dlg.setTitle(Messages.GlobalActions_PrintVersionedLabel);
-				dlg.setMessage(Messages.GlobalActions_PrintVersionedLabelToolTip);
-				if (isDirectPrint()) {
-					dlg.setBlockOnOpen(false);
-					dlg.open();
-					if (dlg.doPrint()) {
-						dlg.close();
-					} else {
-						SWTHelper.alert("Fehler beim Drucken",
-							"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
-					}
-				} else {
-					dlg.setBlockOnOpen(true);
-					dlg.open();
+				
+				try {
+					cmd.executeWithChecks(new ExecutionEvent());
+				} catch (Exception e) {
+					logger.error("Failed to execute command ch.elexis.core.ui.commands.printVersionedLabel", e);
 				}
 			}
 		};
@@ -446,28 +428,15 @@ public class GlobalActions {
 			
 			@Override
 			public void run(){
-				Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
-				if (actPatient == null) {
-					SWTHelper.showInfo("Kein Patient ausgewählt",
-						"Bitte wählen Sie vor dem Drucken einen Patient!");
-					return;
+				Command cmd = cmdService.getCommand("ch.elexis.core.ui.commands.printPatientLabel");
+				if (!cmd.isDefined()) {
+					  cmd.define(Messages.GlobalActions_PrintLabel, Messages.GlobalActions_PrintLabelToolTip, cmdCategory);
 				}
-				EtiketteDruckenDialog dlg =
-					new EtiketteDruckenDialog(mainWindow.getShell(), actPatient, TT_PATIENT_LABEL);
-				dlg.setTitle(Messages.GlobalActions_PrintLabel);
-				dlg.setMessage(Messages.GlobalActions_PrintLabelToolTip);
-				if (isDirectPrint()) {
-					dlg.setBlockOnOpen(false);
-					dlg.open();
-					if (dlg.doPrint()) {
-						dlg.close();
-					} else {
-						SWTHelper.alert("Fehler beim Drucken",
-							"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
-					}
-				} else {
-					dlg.setBlockOnOpen(true);
-					dlg.open();
+				
+				try {
+					cmd.executeWithChecks(new ExecutionEvent());
+				} catch (Exception e) {
+					logger.error("Failed to execute command ch.elexis.core.ui.commands.printPatientLabel", e);
 				}
 			}
 		};

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
@@ -394,6 +394,7 @@ public class GlobalActions {
 				try {
 					cmd.executeWithChecks(new ExecutionEvent());
 				} catch (Exception e) {
+					ExHandler.handle(e);
 					logger.error("Failed to execute command ch.elexis.core.ui.commands.printAddressLabel", e);
 				}
 			}
@@ -415,6 +416,7 @@ public class GlobalActions {
 				try {
 					cmd.executeWithChecks(new ExecutionEvent());
 				} catch (Exception e) {
+					ExHandler.handle(e);
 					logger.error("Failed to execute command ch.elexis.core.ui.commands.printVersionedLabel", e);
 				}
 			}
@@ -436,6 +438,7 @@ public class GlobalActions {
 				try {
 					cmd.executeWithChecks(new ExecutionEvent());
 				} catch (Exception e) {
+					ExHandler.handle(e);
 					logger.error("Failed to execute command ch.elexis.core.ui.commands.printPatientLabel", e);
 				}
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintAddressLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintAddressLabelHandler.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IT-Med AG <info@it-med-ag.ch>.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IT-Med AG <info@it-med-ag.ch> - initial implementation
+ ******************************************************************************/
+
 package ch.elexis.core.ui.commands;
 
 import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_ADDRESS_LABEL;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintAddressLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintAddressLabelHandler.java
@@ -1,0 +1,46 @@
+package ch.elexis.core.ui.commands;
+
+import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_ADDRESS_LABEL;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PlatformUI;
+
+import ch.elexis.core.data.activator.CoreHub;
+import ch.elexis.core.data.events.ElexisEventDispatcher;
+import ch.elexis.core.ui.actions.Messages;
+import ch.elexis.core.ui.dialogs.EtiketteDruckenDialog;
+import ch.elexis.core.ui.util.SWTHelper;
+import ch.elexis.data.Patient;
+
+public final class PrintAddressLabelHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
+		if (actPatient == null) {
+			SWTHelper.showInfo("Kein Patient ausgewählt", "Bitte wählen Sie vor dem Drucken einen Patient!");
+			return null;
+		}
+
+		EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), actPatient, TT_ADDRESS_LABEL);
+		dlg.setTitle(Messages.GlobalActions_PrintAddressLabel);
+		dlg.setMessage(Messages.GlobalActions_PrintAddressLabelToolTip);
+		if (!CoreHub.localCfg.get("Drucker/Etiketten/Choose", true)) {
+			dlg.setBlockOnOpen(false);
+			dlg.open();
+			if (dlg.doPrint()) {
+				dlg.close();
+			} else {
+				SWTHelper.alert("Fehler beim Drucken",
+						"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
+			}
+		} else {
+			dlg.setBlockOnOpen(true);
+			dlg.open();
+		}
+		return null;
+	}
+}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
@@ -1,0 +1,45 @@
+package ch.elexis.core.ui.commands;
+
+import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_PATIENT_LABEL;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PlatformUI;
+
+import ch.elexis.core.data.activator.CoreHub;
+import ch.elexis.core.data.events.ElexisEventDispatcher;
+import ch.elexis.core.ui.actions.Messages;
+import ch.elexis.core.ui.dialogs.EtiketteDruckenDialog;
+import ch.elexis.core.ui.util.SWTHelper;
+import ch.elexis.data.Patient;
+
+public final class PrintPatientLabelHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
+		if (actPatient == null) {
+			SWTHelper.showInfo("Kein Patient ausgewählt", "Bitte wählen Sie vor dem Drucken einen Patient!");
+			return null;
+		}
+		EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), actPatient, TT_PATIENT_LABEL);
+		dlg.setTitle(Messages.GlobalActions_PrintLabel);
+		dlg.setMessage(Messages.GlobalActions_PrintLabelToolTip);
+		if (!CoreHub.localCfg.get("Drucker/Etiketten/Choose", true)) {
+			dlg.setBlockOnOpen(false);
+			dlg.open();
+			if (dlg.doPrint()) {
+				dlg.close();
+			} else {
+				SWTHelper.alert("Fehler beim Drucken",
+						"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
+			}
+		} else {
+			dlg.setBlockOnOpen(true);
+			dlg.open();
+		}
+		return null;
+	}
+}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IT-Med AG <info@it-med-ag.ch>.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IT-Med AG <info@it-med-ag.ch> - initial implementation
+ ******************************************************************************/
+
 package ch.elexis.core.ui.commands;
 
 import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_PATIENT_LABEL;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintPatientLabelHandler.java
@@ -23,6 +23,7 @@ public final class PrintPatientLabelHandler extends AbstractHandler {
 			SWTHelper.showInfo("Kein Patient ausgewählt", "Bitte wählen Sie vor dem Drucken einen Patient!");
 			return null;
 		}
+		
 		EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), actPatient, TT_PATIENT_LABEL);
 		dlg.setTitle(Messages.GlobalActions_PrintLabel);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
@@ -17,12 +17,13 @@ import ch.elexis.data.Patient;
 public final class PrintVersionedLabelHandler extends AbstractHandler {
 
 	@Override
-	public Object execute(ExecutionEvent arg0) throws ExecutionException {
+	public Object execute(ExecutionEvent event) throws ExecutionException {
 		Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
 		if (actPatient == null) {
 			SWTHelper.showInfo("Kein Patient ausgewählt", "Bitte wählen Sie vor dem Drucken einen Patient!");
 			return null;
 		}
+		
 		EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), actPatient, TT_PATIENT_LABEL_ORDER);
 		dlg.setTitle(Messages.GlobalActions_PrintVersionedLabel);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IT-Med AG <info@it-med-ag.ch>.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IT-Med AG <info@it-med-ag.ch> - initial implementation
+ ******************************************************************************/
+
 package ch.elexis.core.ui.commands;
 
 import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_PATIENT_LABEL_ORDER;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/PrintVersionedLabelHandler.java
@@ -1,0 +1,45 @@
+package ch.elexis.core.ui.commands;
+
+import static ch.elexis.core.ui.text.TextTemplateRequirement.TT_PATIENT_LABEL_ORDER;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PlatformUI;
+
+import ch.elexis.core.data.activator.CoreHub;
+import ch.elexis.core.data.events.ElexisEventDispatcher;
+import ch.elexis.core.ui.actions.Messages;
+import ch.elexis.core.ui.dialogs.EtiketteDruckenDialog;
+import ch.elexis.core.ui.util.SWTHelper;
+import ch.elexis.data.Patient;
+
+public final class PrintVersionedLabelHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent arg0) throws ExecutionException {
+		Patient actPatient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
+		if (actPatient == null) {
+			SWTHelper.showInfo("Kein Patient ausgewählt", "Bitte wählen Sie vor dem Drucken einen Patient!");
+			return null;
+		}
+		EtiketteDruckenDialog dlg = new EtiketteDruckenDialog(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), actPatient, TT_PATIENT_LABEL_ORDER);
+		dlg.setTitle(Messages.GlobalActions_PrintVersionedLabel);
+		dlg.setMessage(Messages.GlobalActions_PrintVersionedLabelToolTip);
+		if (!CoreHub.localCfg.get("Drucker/Etiketten/Choose", true)) {
+			dlg.setBlockOnOpen(false);
+			dlg.open();
+			if (dlg.doPrint()) {
+				dlg.close();
+			} else {
+				SWTHelper.alert("Fehler beim Drucken",
+						"Beim Drucken ist ein Fehler aufgetreten. Bitte überprüfen Sie die Einstellungen.");
+			}
+		} else {
+			dlg.setBlockOnOpen(true);
+			dlg.open();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
These patches move the logic of the global print actions in GlobalActions to handlers. This provides more flexibility and allows developers to override the default handler.

There is also a bugfix for the tooltip text of ApplicationBarAdvisor:
![elexis](https://user-images.githubusercontent.com/22741746/50291548-31821380-046f-11e9-9517-6b66834ae8b0.png)
