### PR TITLE
Populate toolbar contribution manager for VerrechnungsDisplay

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
@@ -64,6 +64,8 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -227,6 +229,11 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 				return false;
 			}
 		});
+		
+		// Populate toolbar contribution manager
+		IMenuService menuService = (IMenuService) PlatformUI.getWorkbench().getService(IMenuService.class);
+		menuService.populateContributionManager(toolBarManager, "toolbar:ch.elexis.VerrechnungsDisplay");
+		
 		ToolBar toolBar = toolBarManager.createControl(this);
 		toolBar.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		


### PR DESCRIPTION
This allows you to add commands to the toolbar of VerrechnungsDisplay:

```
<menuContribution locationURI="toolbar:ch.elexis.VerrechnungsDisplay">
	<command commandId="someCommandId" />
</menuContribution>
```
This change is needed for one of our plugins that we intend to contribute to the open source stack.