### PR TITLE
[14812] Allow bypassing FirstMandantDialog

### DIFF
--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/constants/ElexisSystemPropertyConstants.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/constants/ElexisSystemPropertyConstants.java
@@ -29,6 +29,25 @@ public class ElexisSystemPropertyConstants {
 	public static final String RUN_MODE_FROM_SCRATCH = "RunFromScratch";
 	
 	/**
+	 * Allows bypassing the ErsterMandantDialog on startup. Intended for GUI tests,
+	 * and automated setup of an initial DB for a new practice
+	 * @since 3.8
+	 */
+	public static final String FIRST_MANDANT_NAME = "ch.elexis.firstMandantName"; //$NON-NLS-1$
+	/**
+	 * Allows bypassing the ErsterMandantDialog on startup. Intended for GUI tests,
+	 * and automated setup of an initial DB for a new practice
+	 * @since 3.8
+	 */
+	public static final String FIRST_MANDANT_EMAIL = "ch.elexis.firstMandantEmail"; //$NON-NLS-1$
+	/**
+	 * Allows bypassing the ErsterMandantDialog on startup. Intended for GUI tests,
+	 * and automated setup of an initial DB for a new practice
+	 * @since 3.8
+	 */
+	public static final String FIRST_MANDANT_PASSWORD = "ch.elexis.firstMandantPassword"; //$NON-NLS-1$
+
+	/**
 	 * REST URL of the elexis server, e.g. http://localhost:8380/services"
 	 */
 	public static final String ELEXIS_SERVER_REST_INTERFACE_URL = "elexisServerUrl";

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Mandant.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Mandant.java
@@ -94,6 +94,17 @@ public class Mandant extends Anwender {
 	public Mandant(String name, String pwd){
 		super(name, pwd, true);
 	}
+
+	/**
+	 * @since 3.8
+	 * @param name
+	 * @param pwd
+	 * @param email
+	 */
+	public Mandant(String name, String pwd, String email){
+		super(name, pwd, true);
+		set(new String[] {Person.FLD_E_MAIL}, email);
+	}
 	
 	protected String getConstraint(){
 		return new StringBuilder(FLD_IS_MANDATOR).append(Query.EQUALS)

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
@@ -425,34 +425,26 @@ public abstract class PersistentObject implements IPersistentObject {
 					executeDBInitScriptForClass(User.class, null);
 					executeDBInitScriptForClass(Role.class, null);
 					
-					CoreHub.globalCfg = new SqlSettings(connection.getJdbcLink(), "CONFIG");
-					CoreHub.globalCfg.undo();
-					CoreHub.globalCfg.set("created", new TimeTool().toString(TimeTool.FULL_GER));
+					PersistentObjectUtil.initializeGlobalCfg(connection);
 					Mandant.initializeAdministratorUser();
 					CoreHub.pin.initializeGrants();
 					CoreHub.pin.initializeGlobalPreferences();
-					if (connection.isRunningFromScratch()) {
-						Mandant m = new Mandant("007", "topsecret");
-						String clientEmail =
-							System.getProperty(ElexisSystemPropertyConstants.CLIENT_EMAIL);
-						if (clientEmail == null)
-							clientEmail = "james@bond.invalid";
-						m.set(new String[] {
-							Person.NAME, Person.FIRSTNAME, Person.TITLE, Person.SEX,
-							Person.FLD_E_MAIL, Person.FLD_PHONE1, Person.FLD_FAX,
-							Kontakt.FLD_STREET, Kontakt.FLD_ZIP, Kontakt.FLD_PLACE
-						}, "Bond", "James", "Dr. med.", Person.MALE, clientEmail, "0061 555 55 55",
-							"0061 555 55 56", "10, Baker Street", "9999", "Elexikon");
-					} else {
-						cod.requestInitialMandatorConfiguration();
-					}
+					Mandant bypassMandator = PersistentObjectUtil.autoCreateFirstMandant(connection.isRunningFromScratch());
 					
+					if (bypassMandator == null) {
+						cod.requestInitialMandatorConfiguration();
+						MessageEvent.fireInformation("Neue Datenbank", //$NON-NLS-1$
+							"Es wurde eine neue Datenbank angelegt."); //$NON-NLS-1$
+					} else {
+						// When running from Scratch or bypassing the first mandant we
+						// do not want to pop up any message dialog before
+						// Elexis finished the startup. A log entry is okay
+						log.info(
+								"Bypassed mandator initialization dialog, auto-created Mandator [{}] {}", //$NON-NLS-1$
+								bypassMandator.getId(), bypassMandator.getPersonalia());
+					}
 					CoreHub.globalCfg.flush();
 					CoreHub.localCfg.flush();
-					if (!connection.isRunningFromScratch()) {
-						MessageEvent.fireInformation("Neue Datenbank",
-							"Es wurde eine neue Datenbank angelegt.");
-					}
 				} else {
 					log.error("Kein create script für Datenbanktyp " + connection.getDBFlavor()
 						+ " gefunden.");

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectUtil.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectUtil.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019, G. Weirich and Elexis
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Niklaus Giger <niklaus.giger@member.fsf.org>
+ *    Marco Descher <descher@medevit.at>
+ *******************************************************************************/
+package ch.elexis.data;
+
+import ch.elexis.core.data.activator.CoreHub;
+import ch.elexis.core.data.constants.ElexisSystemPropertyConstants;
+import ch.rgw.io.SqlSettings;
+import ch.rgw.tools.TimeTool;
+/**
+ * Contains some utility procedure to make PersitentObject more readable$
+ * @since 3.8
+ * @author Niklaus Giger <niklaus.giger@member.fsf.org>
+ */
+class PersistentObjectUtil {
+
+	/**
+	 * New DB initialization: init Global Config table
+	 * 
+	 * @param connection
+	 */
+	static void initializeGlobalCfg(DBConnection connection) {
+		CoreHub.globalCfg = new SqlSettings(connection.getJdbcLink(), "CONFIG"); //$NON-NLS-1$
+		CoreHub.globalCfg.undo();
+		CoreHub.globalCfg.set("created", new TimeTool().toString(TimeTool.FULL_GER)); //$NON-NLS-1$
+	}
+
+	/**
+	 * When running from scratch or given 3 system properties for name, email and password
+	 * we create a first mandator. This is needed for unit tests (runFromScratch) or
+	 * GUI-tests. In both cases we want to startup Elexis with a clean, almost empty
+	 * database which contains only default settings, eg. user rights$
+	 * @since 3.8
+	 * @param fromScratch Whether the database is running from Scratch
+	 * @return mandant or null (meaning, please pop up FirstMandandDialog)
+	 */
+	static Mandant autoCreateFirstMandant(boolean fromScratch) {
+		Mandant m = null;
+		if (fromScratch) {
+			String clientEmail = System.getProperty(ElexisSystemPropertyConstants.CLIENT_EMAIL);
+			if (clientEmail == null) {
+				clientEmail = "james@bond.invalid"; //$NON-NLS-1$
+			}
+			m = new Mandant("007", "topsecret", clientEmail); //$NON-NLS-1$ //$NON-NLS-2$
+			m.set(new String[] { Person.NAME, Person.FIRSTNAME, Person.TITLE, Person.SEX, Person.FLD_PHONE1,
+					Person.FLD_FAX, Kontakt.FLD_STREET, Kontakt.FLD_ZIP, Kontakt.FLD_PLACE }, "Bond", "James", //$NON-NLS-1$ //$NON-NLS-2$
+					"Dr. med.", Person.MALE, //$NON-NLS-1$
+					"0061 555 55 55", //$NON-NLS-1$
+					"0061 555 55 56", "10, Baker Street", "9999", "Elexikon"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		} else {
+			String firstMandantName = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_NAME, ""); //$NON-NLS-1$
+			String firstMandantEmail = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_EMAIL, ""); //$NON-NLS-1$
+			String firstMandantPassword = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_PASSWORD, ""); //$NON-NLS-1$
+			// The FirstMandantDialog requires
+			// * a name
+			// * a password
+			// * a email address containing a '@'
+			// Therefore we apply the same tests here
+			if (firstMandantEmail.contains("@") && !firstMandantName.isEmpty() //$NON-NLS-1$
+					&& !firstMandantPassword.isEmpty()) {
+				return new Mandant(firstMandantName, firstMandantPassword, firstMandantEmail);
+			}
+		}
+		return m;
+	}
+}


### PR DESCRIPTION
I tested it (after installing it into the work subdirectory) by using the following bash commands

```
rm -rfv ~/elexis/first.h2.db ~/elexis/demoDB
work/Elexis3 -vmargs -Dch.elexis.dbFlavor=h2 -Dch.elexis.dbSpec='jdbc:h2:~/elexis/first;AUTO_SERVER=TRUE' -Dch.elexis.dbUser=sa -Dch.elexis.dbPw='' \
-Dch.elexis.firstMandantName=test \
-Dch.elexis.firstMandantPassword=test \
-Dch.elexis.firstMandantEmail=test@invalid.org \
-Dch.elexis.username=test \
-Dch.elexis.password=test 
```