### PR TITLE
[14835] Show dialog when dbupdate fails. User may continue

### DIFF
--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
@@ -485,7 +485,17 @@ public abstract class PersistentObject implements IPersistentObject {
 		log.info("Gefundene Datenbankversion: " + vi.version());
 		if (vi.isOlder(CoreHub.DBVersion)) {
 			log.warn("Ältere Version der Datenbank gefunden ");
-			DBUpdate.doUpdate();
+			if (!DBUpdate.doUpdate()) {
+				String msg = String.format(
+						"Datenbank '%1s':\nUpdate auf '%2s' von '%3s' schlug fehlt.\nWollen Sie trotzdem fortsetzen?",
+						connection.getDBConnectString(), vi.version().toString(), CoreHub.DBVersion);
+				log.error(msg);
+				if (!cod.openQuestion("Datenbank update failed ", msg)) {
+					System.exit(8);
+				} else {
+					log.error("User continues with failed Elexis database update");
+				}
+			}
 		}
 		vi = new VersionInfo(CoreHub.globalCfg.get("ElexisVersion", "0.0.0"));
 		log.info("Verlangte Elexis-Version: " + vi.version());

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SqlWithUiRunner.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SqlWithUiRunner.java
@@ -62,16 +62,19 @@ public class SqlWithUiRunner {
 				@Override
 				public void run(){
 					Shell parent = null;
+					boolean isDummyShell = false;
 					try {
 						parent = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 					} catch (IllegalStateException e) {
 						// the workbench has not been created yet ... create a dummy Shell on the
 						// display
 						parent = new Shell(Display.getDefault());
+						isDummyShell = true;
 					} catch (NullPointerException e) {
 						// the workbench has not been created yet ... create a dummy Shell on the
 						// display
 						parent = new Shell(Display.getDefault());
+						isDummyShell = true;
 					}
 					ProgressMonitorDialog dialog = new ProgressMonitorDialog(parent);
 					try {
@@ -93,6 +96,9 @@ public class SqlWithUiRunner {
 						e.printStackTrace();
 					} catch (InterruptedException e) {
 						e.printStackTrace();
+					}
+					if (isDummyShell) {
+						parent.close();
 					}
 				}
 			});


### PR DESCRIPTION
Das sollte das von Gerry gesehene Problem lösen, welche es am 7.1.19 auf der Entwicklerliste gepostet hat:

> Das störende Fenster ist nicht das Splash-Popup, sondern die
Hintergrund Shell der Fortschrittsanzeige des Datenbank-Updates. Da zu
diesem Zeitpunkt noch kein Elexis-Fenster existiert, scheint das RCP
Framework dafür eine eigene Shell zu erzeugen. Oder irgendwo in Elexis
ist code, der das tut.

Da das Update so schnell durchlauft, kriegt man es meistens nicht mit
(und kriegt auch nicht die Fehlermeldungen angezeigt), aber die Shell
bleibt stehen.

Beweis: Wenn man die Methode doUpate in DBUpdate.java auskommentiert,
erscheint dieses Fenster nicht mehr.

Vorschlag:

- Wenn der Update-Prozess auf die Nase fällt, sollte der User das als
Meldung angezeigt bekommen. Vielleicht ist es ja wichtig...

- Die Fortschrittsanzeige sollte danach mitsamt ihrer Shell
geschlossen werden.