### PR TITLE
[14803] Fix timetool properties for getDurationAsString if language is not german

### DIFF
--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
@@ -2789,11 +2789,11 @@ LabItem_shortOwnLab = own
 
 LabMapping_reasonDefinitionNotValid = Laboratory value not defined
 
-LabMapping_reasonLineNotValid = The importing line [% s] is invalid. Found only% d of 10 expected values.
+LabMapping_reasonLineNotValid = The importing line [%s] is invalid. Found only %d of 10 expected values.
 
-LabMapping_reasonMoreContacts = Found more than one contact to the lab with abbreviation [% s]
+LabMapping_reasonMoreContacts = Found more than one contact to the lab with abbreviation [%s]
 
-LabMapping_reasonMoreLabItems = Found more than 1 laboratory value with LOINC [% s] and abbreviation [% s]
+LabMapping_reasonMoreLabItems = Found more than 1 laboratory value with LOINC [%s] and abbreviation [%s]
 
 LabNotSeenView_date = date
 
@@ -3021,7 +3021,7 @@ LaborSelectionComposite_title = Select laboratory
 
 LaborVerordnungDialog_alreadyOrdered = (already prescribed today)
 
-LaborVerordnungDialog_errorOrderNumber = Order number [% s] has already been assigned! New order number is [% s].
+LaborVerordnungDialog_errorOrderNumber = Order number [%s] has already been assigned! New order number is [%s].
 
 LaborVerordnungDialog_labelOrderNumber = Order number:
 
@@ -3349,9 +3349,9 @@ LogbackConfigDefault = Default value: Since no value for logback.configurationFi
 
 LogbackConfigDetails = Detailed information on logging can be found at https://github.com/elexis/elexis/wiki/logging-configuration.
 
-LogbackConfigXmlExists = At startup the program was referenced via logback.configurationFile to the file% s. Please open this file to see where the logfiles are created.
+LogbackConfigXmlExists = At startup the program was referenced via logback.configurationFile to the file %s. Please open this file to see where the logfiles are created.
 
-LogbackConfigXmlMissing = At program start via logback.configurationFile for the configuration the file% s was specified, which can not be found. Therefore the file logback.xml from the plugin ch.elexis.core.logging.default_configuration is used and the log files go to $ HOME / elexis / logs /
+LogbackConfigXmlMissing = At program start via logback.configurationFile for the configuration the file %s was specified, which can not be found. Therefore the file logback.xml from the plugin ch.elexis.core.logging.default_configuration is used and the log files go to $ HOME / elexis / logs /
 
 LoginDialog_0 = User name
 
@@ -3539,7 +3539,7 @@ MergeLabItemDialog_title = Combine laboratory parameters
 
 MergeLabItemDialog_titleWarningDialog = warning
 
-MergeLabItemDialog_toolTipResultsCount = Laboratory parameter has% s results.
+MergeLabItemDialog_toolTipResultsCount = Laboratory parameter has%s results.
 
 MoneyInput_InvalidAmountCaption = Invalid amount
 
@@ -4953,13 +4953,13 @@ TimeTool_aug = August
 
 TimeTool_august = August
 
-TimeTool_dayAgoFormat = before% d day
+TimeTool_dayAgoFormat = before %d day
 
-TimeTool_dayToFormat = in% d day
+TimeTool_dayToFormat = in %d day
 
-TimeTool_daysAgoFormat = % d days ago
+TimeTool_daysAgoFormat =  %d days ago
 
-TimeTool_daysToFormat = in% d days
+TimeTool_daysToFormat = in %d days
 
 TimeTool_dec = December
 
@@ -4995,13 +4995,13 @@ TimeTool_mo = Mo
 
 TimeTool_monday = Monday
 
-TimeTool_monthAgoFormat = % d month ago
+TimeTool_monthAgoFormat =  %d month ago
 
-TimeTool_monthToFormat = in% d month
+TimeTool_monthToFormat = in %d month
 
-TimeTool_monthsAgoFormat = % d months ago
+TimeTool_monthsAgoFormat =  %d months ago
 
-TimeTool_monthsToFormat = in% d months
+TimeTool_monthsToFormat = in %d months
 
 TimeTool_nov = November
 
@@ -5037,21 +5037,21 @@ TimeTool_we = Wed.
 
 TimeTool_wednesday = Wednesday
 
-TimeTool_weekAgoFormat = % d week ago
+TimeTool_weekAgoFormat =  %d week ago
 
-TimeTool_weekToFormat = in% d week
+TimeTool_weekToFormat = in %d week
 
-TimeTool_weeksAgoFormat = before% d weeks
+TimeTool_weeksAgoFormat = before %d weeks
 
-TimeTool_weeksToFormat = in% d weeks
+TimeTool_weeksToFormat = in %d weeks
 
-TimeTool_yearAgoFormat = before% d year
+TimeTool_yearAgoFormat = before %d year
 
-TimeTool_yearToFormat = in% d year
+TimeTool_yearToFormat = in %d year
 
-TimeTool_yearsAgoFormat = % d years ago
+TimeTool_yearsAgoFormat =  %d years ago
 
-TimeTool_yearsToFormat = in% d years
+TimeTool_yearsToFormat = in %d years
 
 ToggleVerrechenbarFavoriteAction_DeFavorize = De Favor
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
@@ -1247,7 +1247,7 @@ EditLabResultDialog_labelUnit = Unit\u00E9
 
 EditLabResultDialog_labelValue = Valeur
 
-EditLabResultDialog_message = R\u00E9sultat de laboratoire% s \nde \u00E9dition% s.
+EditLabResultDialog_message = R\u00E9sultat de laboratoire %s \nde \u00E9dition %s.
 
 EditLabResultDialog_shellTitle = LabResult
 
@@ -4943,13 +4943,13 @@ TimeTool_aug = ao\u00FBt
 
 TimeTool_august = ao\u00FBt
 
-TimeTool_dayAgoFormat = % D jours
+TimeTool_dayAgoFormat =  %d jours
 
-TimeTool_dayToFormat = en% le jour d
+TimeTool_dayToFormat = en %d jour
 
-TimeTool_daysAgoFormat = % D jours
+TimeTool_daysAgoFormat =  %d jours
 
-TimeTool_daysToFormat = en% d jours
+TimeTool_daysToFormat = en %d jours
 
 TimeTool_dec = d\u00E9cembre
 
@@ -4985,13 +4985,13 @@ TimeTool_mo = Mo
 
 TimeTool_monday = lundi
 
-TimeTool_monthAgoFormat = % D mois
+TimeTool_monthAgoFormat =  %d mois
 
-TimeTool_monthToFormat = en% le mois d
+TimeTool_monthToFormat = en %d le mois
 
-TimeTool_monthsAgoFormat = % mois d
+TimeTool_monthsAgoFormat = %d mois
 
-TimeTool_monthsToFormat = en% d mois
+TimeTool_monthsToFormat = en %d mois
 
 TimeTool_nov = novembre
 
@@ -5027,21 +5027,21 @@ TimeTool_we = MER.
 
 TimeTool_wednesday = mercredi
 
-TimeTool_weekAgoFormat = il y a d semaines%
+TimeTool_weekAgoFormat = il y a %d semaines
 
-TimeTool_weekToFormat = en% d semaines
+TimeTool_weekToFormat = en %d semaines
 
-TimeTool_weeksAgoFormat = il y a d semaines%
+TimeTool_weeksAgoFormat = il y a %d semaines
 
-TimeTool_weeksToFormat = en% d semaines
+TimeTool_weeksToFormat = en %d semaines
 
-TimeTool_yearAgoFormat = % d ans
+TimeTool_yearAgoFormat =  %d ans
 
-TimeTool_yearToFormat = en% ann\u00E9es d
+TimeTool_yearToFormat = en %d ann\u00E9es
 
-TimeTool_yearsAgoFormat = % d ans
+TimeTool_yearsAgoFormat =  %d ans
 
-TimeTool_yearsToFormat = en% ann\u00E9es d
+TimeTool_yearsToFormat = en %d ann\u00E9es
 
 ToggleVerrechenbarFavoriteAction_DeFavorize = de faveur
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
@@ -1247,7 +1247,7 @@ EditLabResultDialog_labelUnit = Unit\u00E0
 
 EditLabResultDialog_labelValue = Valore
 
-EditLabResultDialog_message = risultato di laboratorio% s\nof modifica% s.
+EditLabResultDialog_message = risultato di laboratorio %s\nof modifica %s.
 
 EditLabResultDialog_shellTitle = LabResult
 
@@ -3343,7 +3343,7 @@ LogbackConfigDetails = Informazioni dettagliate sulla registrazione sono disponi
 
 LogbackConfigXmlExists = E 'stato sottolineato s all'avvio tramite logback.configurationFile il file %s. Si prega di aprire questo file per vedere dove vengono creati i file di log.
 
-LogbackConfigXmlMissing = All'avvio del programma tramite logback.configurationFile per la configurazione \u00E8 stato specificato il file% s, che non pu\u00F2 essere trovato. Pertanto, viene utilizzato il file logback.xml dal plugin ch.elexis.core.logging.default_configuration e i file di registro vanno a $ HOME / elexis / logs /
+LogbackConfigXmlMissing = All'avvio del programma tramite logback.configurationFile per la configurazione \u00E8 stato specificato il file %s, che non pu\u00F2 essere trovato. Pertanto, viene utilizzato il file logback.xml dal plugin ch.elexis.core.logging.default_configuration e i file di registro vanno a $ HOME / elexis / logs /
 
 LoginDialog_0 = Nome utente
 
@@ -3531,7 +3531,7 @@ MergeLabItemDialog_title = Fusione parametri di laboratorio
 
 MergeLabItemDialog_titleWarningDialog = Avvertimento
 
-MergeLabItemDialog_toolTipResultsCount = Parametri di laboratorio ha% s risultati.
+MergeLabItemDialog_toolTipResultsCount = Parametri di laboratorio ha %s risultati.
 
 MoneyInput_InvalidAmountCaption = importo non valido
 
@@ -4933,13 +4933,13 @@ TimeTool_aug = agosto
 
 TimeTool_august = agosto
 
-TimeTool_dayAgoFormat = % D giorni
+TimeTool_dayAgoFormat =  %d giorni
 
-TimeTool_dayToFormat = in% d giorno
+TimeTool_dayToFormat = in %d giorno
 
-TimeTool_daysAgoFormat = % D giorni
+TimeTool_daysAgoFormat =  %d giorni
 
-TimeTool_daysToFormat = tra% d giorni
+TimeTool_daysToFormat = tra %d giorni
 
 TimeTool_dec = dicembre
 
@@ -4975,13 +4975,13 @@ TimeTool_mo = momento
 
 TimeTool_monday = lunedi
 
-TimeTool_monthAgoFormat = % D mesi
+TimeTool_monthAgoFormat =  %d mesi
 
-TimeTool_monthToFormat = in% d mesi
+TimeTool_monthToFormat = in %d mesi
 
-TimeTool_monthsAgoFormat = % d mesi
+TimeTool_monthsAgoFormat =  %d mesi
 
-TimeTool_monthsToFormat = tra% d mesi
+TimeTool_monthsToFormat = tra %d mesi
 
 TimeTool_nov = novembre
 
@@ -5019,19 +5019,19 @@ TimeTool_wednesday = mercoled\u00EC
 
 TimeTool_weekAgoFormat = d settimane fa%
 
-TimeTool_weekToFormat = tra% d settimane
+TimeTool_weekToFormat = tra %d settimane
 
 TimeTool_weeksAgoFormat = d settimane fa%
 
-TimeTool_weeksToFormat = tra% d settimane
+TimeTool_weeksToFormat = tra %d settimane
 
-TimeTool_yearAgoFormat = % d anni
+TimeTool_yearAgoFormat =  %d anni
 
-TimeTool_yearToFormat = tra% d anni
+TimeTool_yearToFormat = tra %d anni
 
-TimeTool_yearsAgoFormat = % d anni
+TimeTool_yearsAgoFormat =  %d anni
 
-TimeTool_yearsToFormat = tra% d anni
+TimeTool_yearsToFormat = tra %d anni
 
 ToggleVerrechenbarFavoriteAction_DeFavorize = de favore
 

--- a/bundles/ch.rgw.utility/src/ch/rgw/tools/TimeTool.java
+++ b/bundles/ch.rgw.utility/src/ch/rgw/tools/TimeTool.java
@@ -18,12 +18,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 /**
  * Klasse zur einfachen Datum- und Zeitberarbeitung
@@ -1020,6 +1023,19 @@ public class TimeTool extends GregorianCalendar {
 		GregorianCalendar gc = new GregorianCalendar();
 		gc.setTimeInMillis(getTimeInMillis());
 		return gc.toZonedDateTime().toLocalDateTime();
+	}
+	
+	/**
+	 * A helper function for the RCPTT GUI-tests
+	 * 
+	 * @since 3.8
+	 * @param days number of days compared to today may be positive (in the future) or negative (in the past)
+	 * @return a String in the format dd.MM.yyyy
+	 */
+	public static String daysFromNow(int days) {
+		TimeTool newTime = new TimeTool();
+		newTime.addDays(days);
+		return newTime.toString(TimeTool.DATE_GER);
 	}
 	
 	public String toDBString(final boolean full){

--- a/tests/ch.rgw.utility.tests/src/ch/rgw/tools/Test_TimeTool.java
+++ b/tests/ch.rgw.utility.tests/src/ch/rgw/tools/Test_TimeTool.java
@@ -134,6 +134,13 @@ public class Test_TimeTool {
 		assertNotNull(timeTool.toString(), split[1]);
 		assertTrue(printFailure(timeTool, duration, split),
 			duration.startsWith(split[0]) && duration.endsWith(split[1]));
+		String in5Days = TimeTool.daysFromNow(5);
+		String before5Days = TimeTool.daysFromNow(-5);
+		String pattern = "\\d\\d\\.\\d\\d\\.\\d\\d\\d\\d";
+		assertTrue(before5Days.matches(pattern));
+		assertTrue(in5Days.matches(pattern));
+		String today = TimeTool.daysFromNow(0);
+		assertTrue(today.contentEquals(new TimeTool().toString(TimeTool.DATE_GER)));
 	}
 	
 	@Test


### PR DESCRIPTION
I have added an RCPTT GUI-Test which changes the kons date to exercise all differents variants (before, after,day,week,month,year).
To be able to run the RCPTT I adde a new helper function daysFromNow in TimeTools .