### PR TITLE
Ensure that Elexis3 can start with a clean H2 database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ language: java
 
 install: mvn -V -DskipTests=true -Dmaven.javadoc.skip=true -B validate
 
-script: mvn -V --quiet clean verify -Dall-archs=true && find . -name "*.zip"
+script:
+  - mvn -V --quiet clean verify -Dall-archs=true
 
 notifications:
   email:

--- a/ch.elexis.core.p2site/pom.xml
+++ b/ch.elexis.core.p2site/pom.xml
@@ -14,6 +14,9 @@
         <property>
            <name>!skipTests</name>
         </property>
+        <os>
+          <name>Linux</name>
+        </os>
       </activation>
       <build>
         <plugins>

--- a/ch.elexis.core.p2site/pom.xml
+++ b/ch.elexis.core.p2site/pom.xml
@@ -9,12 +9,11 @@
 	<packaging>eclipse-repository</packaging>
   <profiles>
     <profile>
-      <id>linux-x86_64</id>
+      <id>verify-elexis-startup</id>
       <activation>
-        <os>
-          <name>Linux</name>
-          <arch>amd64</arch>
-        </os>
+        <property>
+           <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -27,20 +26,12 @@
                     <id>verify-elexis-startup</id>
                     <phase>verify</phase>
                     <configuration>
-                        <tasks>
-                             <exec executable="/bin/echo">
-                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
-                            </exec>
-                            <exec executable="/bin/ls">
-                              <arg value="-lrt" />
-                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
-                            </exec>
-                           <exec executable="/bin/pwd">
-                            </exec>
-                           <exec executable="/bin/bash">
-                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
-                            </exec>
-                        </tasks>
+                    <target>
+                        <exec executable="/bin/bash" failonerror="true">
+                          <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
+                          <arg value="${project.build.directory}/products/ch.elexis.core.application.ElexisApp/${classifier}/Elexis3" />
+                        </exec>
+                      </target>
                     </configuration>
                     <goals>
                         <goal>run</goal>

--- a/ch.elexis.core.p2site/pom.xml
+++ b/ch.elexis.core.p2site/pom.xml
@@ -7,7 +7,52 @@
 	</parent>
 	<artifactId>ch.elexis.core.p2site</artifactId>
 	<packaging>eclipse-repository</packaging>
-	<build>
+  <profiles>
+    <profile>
+      <id>linux-x86_64</id>
+      <activation>
+        <os>
+          <name>Linux</name>
+          <arch>amd64</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <executions>
+                <execution>
+                    <id>verify-elexis-startup</id>
+                    <phase>verify</phase>
+                    <configuration>
+                        <tasks>
+                             <exec executable="/bin/echo">
+                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
+                            </exec>
+                            <exec executable="/bin/ls">
+                              <arg value="-lrt" />
+                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
+                            </exec>
+                           <exec executable="/bin/pwd">
+                            </exec>
+                           <exec executable="/bin/bash">
+                              <arg value="${project.basedir}/start_h2_first_linux_x86_64.sh" />
+                            </exec>
+                        </tasks>
+                    </configuration>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  <build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho </groupId>

--- a/ch.elexis.core.p2site/start_h2_first_linux_x86_64.sh
+++ b/ch.elexis.core.p2site/start_h2_first_linux_x86_64.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -v
+echo running $0 in $PWD
+APP=../ch.elexis.core.p2site/target/products/ch.elexis.core.application.ElexisApp/linux/gtk/x86_64/Elexis3
+LOG_FILE=start_h2_first_linux_x86_64.log
+rm -rfv $PWD/test_db.*.db
+rm -rfv $HOME/elexis/demoDB
+ls -l $APP
+$APP  -consoleLog -nl en_US -vmargs \
+-Duser.language=en -Duser.region=US \
+-Dch.elexis.dbFlavor=h2 -Dch.elexis.dbSpec=jdbc:h2:$PWD/test_db -Dch.elexis.dbUser=sa -Dch.elexis.dbPw= \
+-Dch.elexis.firstMandantName=mustermann -Dch.elexis.firstMandantPassword=elexisTest -Dch.elexis.firstMandantEmail=mmustermann@elexis.info \
+-Dch.elexis.username=mustermann -Dch.elexis.password=elexisTest 2>&1 | tee $LOG_FILE &
+sleep 5
+# kill restarted Elexis, -9 is needed to suppress confirmation at exit
+ps -ef | grep $APP | cut -c 10-15 | xargs kill -9
+nr_connections=`egrep -c 'ch.elexis.data.DBConnection.*(Connecting|Verbunden).*jdbc:h2.*test_db' $LOG_FILE` 
+echo Elexis connected $nr_connections times to the Database
+if [  $nr_connections -ne 2 ]; then
+  echo FAILURE!! Why did connect Elexis  $nr_connections times to the Database? We expected 2 successfull connections
+  exit 3
+else
+  echo Elexis connected succesfully $nr_connections times to the Database
+  rm -rfv $PWD/test_db.*.db
+fi

--- a/ch.elexis.core.p2site/start_h2_first_linux_x86_64.sh
+++ b/ch.elexis.core.p2site/start_h2_first_linux_x86_64.sh
@@ -1,24 +1,65 @@
 #!/bin/bash -v
-echo running $0 in $PWD
-APP=../ch.elexis.core.p2site/target/products/ch.elexis.core.application.ElexisApp/linux/gtk/x86_64/Elexis3
+echo running: $0 $1
+APP=$1
+if [ -z "$APP" ]; then
+    echo "You must pass the full name of the elexs executable as first parameter!"
+    exit 4
+fi
+if [ -x "$APP" ]; then
+    echo "$APP is executable."
+else
+    echo "$APP ist not executable!"
+    exit 4
+fi
+
+# see https://coderwall.com/p/q-ovnw/killing-all-child-processes-in-a-shell-script
+shutdown() {
+  # Get our process group id
+  PGID=$(ps -o pgid= $$ | grep -o [0-9]*)
+
+  # Kill it in a new new process group
+  setsid kill -- -$PGID
+  exit 0
+}
+trap "shutdown" SIGINT SIGTERM
+
 LOG_FILE=start_h2_first_linux_x86_64.log
 rm -rfv $PWD/test_db.*.db
 rm -rfv $HOME/elexis/demoDB
+rm -rfv $HOMe/elexis/*lock
 ls -l $APP
 $APP  -consoleLog -nl en_US -vmargs \
 -Duser.language=en -Duser.region=US \
 -Dch.elexis.dbFlavor=h2 -Dch.elexis.dbSpec=jdbc:h2:$PWD/test_db -Dch.elexis.dbUser=sa -Dch.elexis.dbPw= \
 -Dch.elexis.firstMandantName=mustermann -Dch.elexis.firstMandantPassword=elexisTest -Dch.elexis.firstMandantEmail=mmustermann@elexis.info \
 -Dch.elexis.username=mustermann -Dch.elexis.password=elexisTest 2>&1 | tee $LOG_FILE &
-sleep 5
-# kill restarted Elexis, -9 is needed to suppress confirmation at exit
-ps -ef | grep $APP | cut -c 10-15 | xargs kill -9
-nr_connections=`egrep -c 'ch.elexis.data.DBConnection.*(Connecting|Verbunden).*jdbc:h2.*test_db' $LOG_FILE` 
-echo Elexis connected $nr_connections times to the Database
-if [  $nr_connections -ne 2 ]; then
-  echo FAILURE!! Why did connect Elexis  $nr_connections times to the Database? We expected 2 successfull connections
-  exit 3
-else
-  echo Elexis connected succesfully $nr_connections times to the Database
-  rm -rfv $PWD/test_db.*.db
-fi
+MAX_WAIT=50
+for counter in $(seq 1 $MAX_WAIT)
+do
+  sleep 1
+  echo Checking $counter time
+  nr_connections=`egrep -c 'ch.elexis.data.DBConnection.*(Connecting|Verbunden).*jdbc:h2.*test_db' $LOG_FILE`
+  echo $counter/$MAX_WAIT: Elexis connected $nr_connections times to the Database
+  if [  $nr_connections -eq 2 ]; then
+    echo After $counter seconds Elexis connected $nr_connections times to the Database
+    sleep 1 # Just to see the rest of the startup
+    break
+  fi
+  if [ $counter -eq "$MAX_WAIT" ]; then
+    echo FAILURE!! Why did connect Elexis  $nr_connections times to the Database? We expected 2 successfull connections
+    exit $counter
+  fi
+done
+
+rm -rfv $PWD/test_db.*.db
+
+kill_descendent_pids() {
+    pids=$(pgrep -P $1)
+    for pid in $pids; do
+        kill_descendent_pids $pid
+        # echo "Killing descendant $pid (forcing termination to skip confirmation dialog)"
+        kill -9 $pid
+    done
+}
+kill_descendent_pids $$
+exit 0

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
 					<arch>x86</arch>
 				</os>
 			</activation>
+			<properties>
+				<classifier>win32/win32/x86</classifier>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -96,6 +99,9 @@
 					<arch>amd64</arch>
 				</os>
 			</activation>
+			<properties>
+				<classifier>win32/win32/x86_64</classifier>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -124,6 +130,9 @@
 					<arch>amd64</arch>
 				</os>
 			</activation>
+			<properties>
+				<classifier>linux/gtk/x86_64</classifier>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -153,6 +162,9 @@
 					<arch>x86</arch>
 				</os>
 			</activation>
+			<properties>
+				<classifier>linux/gtk/x86</classifier>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -180,6 +192,9 @@
 					<family>mac</family>
 				</os>
 			</activation>
+			<properties>
+				<classifier>macosx/cocoa/x86_64</classifier>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
Ich habe mich immer wieder geärgert, wenn (was for allem in NoPo-Branch vorkam) die erstellte Elexis3 Applikation nicht mal aufstartet und meine RCPTT-GUI-Tests dann nicht laufen.

Deshalb habe ich ein kleines Skript geschrieben, das (allerdings nur unter Linux x86-64) Elexis3 mit einer leeren DB startet, einen ersten Mandanten anlegt. Wenn nicht schlägt es fehl.

Deshalb sollten danach die gitlab und travis build fehlschlagen, wenn man Elexis3 nicht korrekt aufstarten kann.

In einem zweiten Schritt werde ich dann die Travis-Builds noch ausbauen, dass sowohl mit Java8 als auch mit Java11 getestet wird.