### PR TITLE
[15402] Perspektive "Schwarzes Brett" unbrauchbar

### DIFF
--- a/bundles/ch.elexis.core.application/plugin.xml
+++ b/bundles/ch.elexis.core.application/plugin.xml
@@ -420,6 +420,12 @@
             id="ch.elexis.core.application.perspectives.StockManagementPerspective"
             name="%elexis.stockManagementPerspective">
       </perspective>
+      <perspective
+            class="ch.elexis.core.application.perspectives.BBSPerspective"
+            icon="platform:/plugin/ch.elexis.core.ui.icons/icons/16x16/tafel.jpg"
+            id="ch.elexis.SchwarzesBrettV1.0"
+            name="%elexis.bbsView">
+      </perspective>
    </extension>
    <extension
          id="ElexisApp"
@@ -458,7 +464,7 @@
             icon="rechnung_perspective"
             name="%sidebar.bills"/>
       <Perspektive
-            ID="ch.elexis.SchwarzesBrett"
+            ID="ch.elexis.SchwarzesBrettV1.0"
             icon="bbs_perspective"
             name="%sidebar.bbs"/>
       <Perspektive

--- a/bundles/ch.elexis.core.application/src/ch/elexis/core/application/perspectives/BBSPerspective.java
+++ b/bundles/ch.elexis.core.application/src/ch/elexis/core/application/perspectives/BBSPerspective.java
@@ -12,7 +12,6 @@
 
 package ch.elexis.core.application.perspectives;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveFactory;
 
@@ -26,13 +25,14 @@ import ch.elexis.core.ui.views.BBSView;
  * 
  */
 public class BBSPerspective implements IPerspectiveFactory {
-	public static final String ID = "ch.elexis.SchwarzesBrett"; //$NON-NLS-1$
+	public static final String ID = "ch.elexis.SchwarzesBrettV1.0"; //$NON-NLS-1$
 	
 	public void createInitialLayout(IPageLayout layout){
 		String editorArea = layout.getEditorArea();
 		layout.setEditorAreaVisible(false);
 		layout.setFixed(true);
-		layout.addView(BBSView.ID, SWT.RIGHT, 0.9f, editorArea);
+		layout.addView(BBSView.ID,  IPageLayout.RIGHT, 0.9f, editorArea);
+
 		
 	}
 	


### PR DESCRIPTION
Die ID musste auf "ch.elexis.SchwarzesBrettV1.0" verändert werden, da sonst der Perspektiven Code nicht ausgeführt wird, wenn diese Perspektive schon in dem Model vorhanden ist. Die "fehlerhafte" Perspektive kann mit dem PerspektivenManagement entfernt werden. Zusätzlich habe ich auch ein Code im ElexisProzessor bereitgestellt der die Fehlerhafte Perspektive "ch.elexis.SchwarzesBrett" aus dem Model automatisch entfernt.