### PR TITLE
[15402] Möglichkeit alte Application-Model-Elemente zu entfernen (BETA)

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/processor/ElexisProcessor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/processor/ElexisProcessor.java
@@ -42,14 +42,9 @@ public class ElexisProcessor {
 
 	private void updateModelVersions(MApplication mApplication, EModelService eModelService){
 		try {
-			MTrimmedWindow mWindow = (MTrimmedWindow) eModelService.find("IDEWindow", mApplication);
-			if (mWindow == null) {
-				List<MWindow> windows = mApplication.getChildren();
-				if (!windows.isEmpty() && windows.get(0) instanceof MTrimmedWindow) {
-					mWindow = (MTrimmedWindow) windows.get(0);
-				}
-			}
-			if (mWindow != null) {
+			List<MWindow> windows = mApplication.getChildren();
+			if (!windows.isEmpty() && windows.get(0) instanceof MTrimmedWindow) {
+				MTrimmedWindow mWindow = (MTrimmedWindow) windows.get(0);
 				// remove old model elements like perspectives etc
 				for (String modelElementId : removeModelElements) {
 					MUIElement element = eModelService.find(modelElementId, mApplication);
@@ -66,7 +61,6 @@ public class ElexisProcessor {
 						}
 					}
 				}
-				
 			} else {
 				logger.warn("cannot find active window");
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/processor/ElexisProcessor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/processor/ElexisProcessor.java
@@ -1,12 +1,23 @@
 package ch.elexis.core.ui.processor;
 
+import java.util.List;
+
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.MElementContainer;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MTrimBar;
+import org.eclipse.e4.ui.model.application.ui.basic.MTrimmedWindow;
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ElexisProcessor {
 	
+	private static final Logger logger = LoggerFactory.getLogger(ElexisProcessor.class);
+	private static String [] removeModelElements = new String[]{"ch.elexis.SchwarzesBrett"};
 	public ElexisProcessor(){}
 	
 	@Execute
@@ -23,6 +34,44 @@ public class ElexisProcessor {
 			(MTrimBar) eModelService.find("org.eclipse.ui.main.toolbar", mApplication);
 		if (mTrimBar != null && mTrimBar.getChildren() != null) {
 			mTrimBar.getChildren().clear();
+		}
+		if (eModelService != null) {
+			updateModelVersions(mApplication, eModelService);
+		}
+	}
+
+	private void updateModelVersions(MApplication mApplication, EModelService eModelService){
+		try {
+			MTrimmedWindow mWindow = (MTrimmedWindow) eModelService.find("IDEWindow", mApplication);
+			if (mWindow == null) {
+				List<MWindow> windows = mApplication.getChildren();
+				if (!windows.isEmpty() && windows.get(0) instanceof MTrimmedWindow) {
+					mWindow = (MTrimmedWindow) windows.get(0);
+				}
+			}
+			if (mWindow != null) {
+				// remove old model elements like perspectives etc
+				for (String modelElementId : removeModelElements) {
+					MUIElement element = eModelService.find(modelElementId, mApplication);
+					if (element != null) {
+						if (element instanceof MPerspective) {
+							eModelService.removePerspectiveModel((MPerspective) element, mWindow);
+							logger.info(
+								"model element (perspective): " + modelElementId + " removed!");
+						} else {
+							MElementContainer<MUIElement> parent = element.getParent();
+							parent.getChildren().remove(element);
+							element.setToBeRendered(false);
+							logger.info("model element: " + modelElementId + " removed!");
+						}
+					}
+				}
+				
+			} else {
+				logger.warn("cannot find active window");
+			}
+		} catch (Exception e) {
+			logger.error("unexpected exception - cannot do updates on models", e);
 		}
 	}
 }


### PR DESCRIPTION
Über den Perspektivenmanagement lassen sich "alte" Perspektiven entfernen. Doch eine automatisierte Lösung dafür wäre vermutlich komfortabler.
Dies veranschaulicht eine Möglichkeit alte Model-Elemente in der Workbench.xmi zu entfernen. Wie die Lösung genau sein soll, gehört auspezifiziert. Vl über eine seperate Einstellungssteite, über ein VM-Param, oder wie diese Lösung statisch beim Programmstart.