### PR TITLE
[15471] Cleanup MySQL Driver. Use com.mysql.cj.jdb.

### DIFF
--- a/bundles/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
+++ b/bundles/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
@@ -109,9 +109,9 @@ public class Desk implements IApplication {
 		if (connection != null && connection.isPresent()) {
 			String noPoConnectString = connection.get().connectionString;
 			if (!poConnectString.equalsIgnoreCase(noPoConnectString)) {
-				log.error("Connection string differ po [{}] nopo [{}]", poConnectString, noPoConnectString);
-				System.err
-						.println("Connection string differ po [" + poConnectString + "] nopo [" + noPoConnectString + "]");
+				String msg = String.format("Connection string differ po [%s] nopo [%s]", poConnectString, noPoConnectString);
+				log.error(msg);
+				System.err.println(msg);
 			}
 		}
 		// check for initialization parameters

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/preferences/CorePreferenceInitializer.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/preferences/CorePreferenceInitializer.java
@@ -31,18 +31,7 @@ public class CorePreferenceInitializer extends AbstractPreferenceInitializer {
 	public void initializeDefaultPreferences(){
 		
 		// Datenbank
-		/*
-		 * CoreHub.localCfg.set(PreferenceConstants.DB_NAME,"hsql"); //$NON-NLS-1$
-		 * CoreHub.localCfg.set(PreferenceConstants.DB_CLASS,"org.hsqldb.jdbcDriver"); //$NON-NLS-1$
-		 * String base=getDefaultDBPath();
-		 * 
-		 * CoreHub.localCfg.set(PreferenceConstants.DB_CONNECT,"jdbc:hsqldb:"+base+"/db");
-		 * //$NON-NLS-1$ //$NON-NLS-2$ CoreHub.localCfg.set(PreferenceConstants.DB_USERNAME,"sa");
-		 * //$NON-NLS-1$ CoreHub.localCfg.set(PreferenceConstants.DB_PWD,""); //$NON-NLS-1$
-		 * CoreHub.localCfg.set(PreferenceConstants.DB_TYP,"hsqldb"); //$NON-NLS-1$
-		 */
 		CoreHub.localCfg.set(Preferences.DB_NAME + SETTINGS_PREFERENCE_STORE_DEFAULT, "h2");
-		//CoreHub.localCfg.set(PreferenceConstants.DB_CLASS,"org.h2.Driver"); //$NON-NLS-1$
 		String base = getDefaultDBPath();
 		
 		CoreHub.localCfg.set(Preferences.DB_CONNECT + SETTINGS_PREFERENCE_STORE_DEFAULT,

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
@@ -124,11 +124,11 @@ public class DBConnection {
 		logger.info(msg);
 		
 		if (dbFlavor.equalsIgnoreCase("mysql"))
-			dbDriver = "com.mysql.jdbc.Driver";
+			dbDriver = JdbcLink.MYSQL_DRIVER_CLASS_NAME;
 		else if (dbFlavor.equalsIgnoreCase("postgresql"))
-			dbDriver = "org.postgresql.Driver";
+			dbDriver = JdbcLink.POSTGRESQL_DRIVER_CLASS_NAME;
 		else if (dbFlavor.equalsIgnoreCase("h2"))
-			dbDriver = "org.h2.Driver";
+			dbDriver = JdbcLink.H2_DRIVER_CLASS_NAME;
 		else
 			dbDriver = "invalid";
 		if (!dbDriver.equalsIgnoreCase("invalid")) {

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CheckExec.java
@@ -11,8 +11,8 @@ import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLinkSyntaxException;
 
 public abstract class CheckExec {
-	public static String MYSQL_DB = "com.mysql.jdbc.Driver";
-	public static String POSTG_DB = "org.postgresql.Driver";
+	public static String MYSQL_DB = JdbcLink.MYSQL_DRIVER_CLASS_NAME;
+	public static String POSTG_DB = JdbcLink.POSTGRESQL_DRIVER_CLASS_NAME;
 	
 	/** Holds connection to database. */
 	protected static Connection conn;

--- a/bundles/ch.elexis.core/src/ch/elexis/core/common/DBConnection.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/common/DBConnection.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package ch.elexis.core.common;
 
+import ch.rgw.tools.JdbcLink;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,9 +47,9 @@ public class DBConnection implements Serializable {
 	@XmlEnum(String.class)
 	public enum DBType {
 		@XmlEnumValue("MYSQL")
-		MySQL("com.mysql.jdbc.Driver", "mySQl", "3306"), @XmlEnumValue("PostgreSQL")
-		PostgreSQL("org.postgresql.Driver", "PostgreSQL", "5432"), @XmlEnumValue("H2")
-		H2("org.h2.Driver", "H2", "");
+		MySQL(JdbcLink.MYSQL_DRIVER_CLASS_NAME, "mySQl", "3306"), @XmlEnumValue("PostgreSQL")
+		PostgreSQL(JdbcLink.POSTGRESQL_DRIVER_CLASS_NAME, "PostgreSQL", "5432"), @XmlEnumValue("H2")
+		H2(JdbcLink.H2_DRIVER_CLASS_NAME, "H2", "");
 
 		public final String driverName;
 		public final String dbType;

--- a/bundles/ch.rgw.utility/META-INF/MANIFEST.MF
+++ b/bundles/ch.rgw.utility/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: ch.qos.logback.classic;bundle-version="1.0.0",
  ch.elexis.core.l10n;bundle-version="3.5.0",
  org.apache.commons.dbcp;bundle-version="1.4.0",
  org.apache.commons.pool;bundle-version="1.6.0"
-Import-Package: com.mysql.jdbc;version="5.1.0",
+Import-Package: com.mysql.cj.jdbc;version="8.0.13",
  org.bouncycastle.x509,
  org.h2;version="1.3.170",
  org.postgresql,

--- a/bundles/ch.rgw.utility/src/ch/rgw/tools/JdbcLink.java
+++ b/bundles/ch.rgw.utility/src/ch/rgw/tools/JdbcLink.java
@@ -47,6 +47,9 @@ public class JdbcLink {
 		return "3.2.1";
 	}
 	
+	public final static String MYSQL_DRIVER_CLASS_NAME = "com.mysql.cj.jdbc.Driver";
+	public final static String POSTGRESQL_DRIVER_CLASS_NAME = "org.postgresql.Driver";
+	public final static String H2_DRIVER_CLASS_NAME =  "org.h2.Driver";
 	public int lastErrorCode;
 	public String lastErrorString;
 	public int verMajor = 0;
@@ -56,7 +59,6 @@ public class JdbcLink {
 	private String sConn;
 	private String sUser;
 	private String sPwd;
-	
 	private PoolingDataSource dataSource;
 	private GenericObjectPool<Connection> connectionPool;
 	// prepared statements are not released properly up until now, so keep 1 connection open
@@ -122,28 +124,14 @@ public class JdbcLink {
 	 */
 	public static JdbcLink createMySqlLink(String host, String database){
 		log.log(Level.INFO, "Creating MySQL-Link");
-		String driver = "com.mysql.jdbc.Driver";
 		String[] hostdetail = host.split(":");
 		String hostname = hostdetail[0];
 		String hostport = hostdetail.length > 1 ? hostdetail[1] : "3306";
+		String driver = MYSQL_DRIVER_CLASS_NAME;
 		
 		String connect = "jdbc:mysql://" + hostname + ":" + hostport + "/" + database
-			+ "?autoReconnect=true&useSSL=false";
-		if (getDriverMajorVersion(driver) > 7) {
-			connect = "jdbc:mysql://" + hostname + ":" + hostport + "/" + database
 				+ "?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Europe/Zurich";
-		}
 		return new JdbcLink(driver, connect, DBFLAVOR_MYSQL);
-	}
-	
-	private static int getDriverMajorVersion(String driverName){
-		try {
-			Driver driver = (Driver) Class.forName(driverName).newInstance();
-			return driver.getMajorVersion();
-		} catch (Exception e) {
-			LoggerFactory.getLogger(JdbcLink.class).error("Error getting driver version", e);
-		}
-		return 0;
 	}
 	
 	/**
@@ -184,7 +172,6 @@ public class JdbcLink {
 	 */
 	public static JdbcLink createH2Link(String database){
 		log.log(Level.INFO, "Creating H2-Link");
-		String driver = "org.h2.Driver";
 		String prefix = "jdbc:h2:";
 		if (database.contains(".zip!")) {
 			prefix += "zip:";
@@ -196,7 +183,7 @@ public class JdbcLink {
 		} else {
 			connect = prefix + database + ";AUTO_SERVER=TRUE";
 		}
-		return new JdbcLink(driver, connect, DBFLAVOR_H2);
+		return new JdbcLink(H2_DRIVER_CLASS_NAME, connect, DBFLAVOR_H2);
 	}
 	
 	/**
@@ -221,13 +208,12 @@ public class JdbcLink {
 	 */
 	public static JdbcLink createPostgreSQLLink(String host, String database){
 		log.log(Level.INFO, "Creating PostgreSQL-Link");
-		String driver = "org.postgresql.Driver";
 		String[] hostdetail = host.split(":");
 		String hostname = hostdetail[0];
 		String hostport = hostdetail.length > 1 ? hostdetail[1] : "5432";
 		
 		String connect = "jdbc:postgresql://" + hostname + ":" + hostport + "/" + database;
-		return new JdbcLink(driver, connect, DBFLAVOR_POSTGRESQL);
+		return new JdbcLink(POSTGRESQL_DRIVER_CLASS_NAME, connect, DBFLAVOR_POSTGRESQL);
 	}
 	
 	public static JdbcLink createODBCLink(String dsn){


### PR DESCRIPTION
This avoids error about the obsolete mysql driver when running the ch.elexis.core.data.tests