### PR TITLE
[15019] Fix loading german demoDB_elexis_3.8.0.zip with nl fr_CH

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
@@ -302,7 +302,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 				String newval = ((Text) e.getSource()).getText();
 				IFall fall = getSelectedFall();
 				if (fall != null) {
-					fall.set(LABEL, newval);
+					fall.set(Fall.FLD_BEZEICHNUNG, newval);
 					fireSelectedFallUpdateEvent();
 				}
 				super.focusLost(e);
@@ -964,7 +964,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 			String newValue = tBezeichnung.getText();
 			if (newValue != null && !newValue.isEmpty()
 				&& !newValue.equals(Messages.FallDetailBlatt2_29)) {
-				actFall.set(LABEL, newValue);
+				actFall.set(Fall.FLD_BEZEICHNUNG, newValue);
 			}
 			if (dpBis.getSelection() == null) {
 				// This must be called to enable the user to delete a given endDate


### PR DESCRIPTION
This avoids

* NPE when using http://download.elexis.info/demoDB/demoDB_elexis_3.8.0.zip and starting Elexis with -nl fr_CH.
This NPE show up when accessing the patient Duck Dagobert.
I still see the warning

      c.e.c.j.e.c.PrescriptionEntryTypeConverter - Unknown entry type [null] using UNKNOWN

in the log

* NPE when loading the view "Cas choisi" (aka Fall in germ ). As on must set the DB field "Bezeichnung" but display the label "Désignation"