### PR TITLE
[16648] Synchronizität von PO#ExtInfo und NoPo#ExtInfo ist nicht gegeben

### DIFF
--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/AbstractIdModelAdapter.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/AbstractIdModelAdapter.java
@@ -8,13 +8,17 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import ch.elexis.core.jpa.entities.EntityWithExtInfo;
 import ch.elexis.core.jpa.entities.EntityWithId;
+import ch.elexis.core.jpa.model.adapter.mixin.ExtInfoHandler;
 import ch.elexis.core.model.Identifiable;
+import ch.elexis.core.model.WithExtInfo;
 import ch.elexis.core.services.IModelService;
 
 public abstract class AbstractIdModelAdapter<T extends EntityWithId> implements Identifiable {
 	
 	protected List<Identifiable> changedList;
+	protected ExtInfoHandler extInfoHandler;
 	
 	/**
 	 * Used in json serialization
@@ -26,6 +30,8 @@ public abstract class AbstractIdModelAdapter<T extends EntityWithId> implements 
 	
 	private boolean dirty;
 	
+	
+	@SuppressWarnings("unchecked")
 	public AbstractIdModelAdapter(T entity){
 		this.dirty = false;
 		this.entity = entity;
@@ -35,6 +41,9 @@ public abstract class AbstractIdModelAdapter<T extends EntityWithId> implements 
 			throw new IllegalStateException(
 				"Model " + entity + " is no subclass of "
 					+ EntityWithId.class.getSimpleName());
+		}
+		if (this instanceof WithExtInfo && entity instanceof EntityWithExtInfo) {
+			extInfoHandler = new ExtInfoHandler((AbstractIdModelAdapter<? extends EntityWithExtInfo>) this);
 		}
 	}
 	
@@ -73,6 +82,9 @@ public abstract class AbstractIdModelAdapter<T extends EntityWithId> implements 
 	public void setEntity(EntityWithId entity){
 		if (!dirty) {
 			this.entity = (T) entity;
+		}
+		if (extInfoHandler != null) {
+			extInfoHandler.resetExtInfo();
 		}
 	}
 	

--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/mixin/ExtInfoHandler.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/mixin/ExtInfoHandler.java
@@ -45,6 +45,10 @@ public class ExtInfoHandler {
 		withExtInfo.getEntityMarkDirty().setExtInfo(JpaModelUtil.extInfoToBytes(extInfo));
 	}
 	
+	public void resetExtInfo(){
+		extInfo = null;
+	}
+	
 	/**
 	 * @return modifications to this map are not persisted. Use {@link #setExtInfo(Object, Object)}
 	 *         to handle persistent sets

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Contact.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Contact.java
@@ -12,7 +12,6 @@ import ch.elexis.core.jpa.entities.KontaktAdressJoint;
 import ch.elexis.core.jpa.entities.ZusatzAdresse;
 import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.jpa.model.adapter.AbstractIdModelAdapter;
-import ch.elexis.core.jpa.model.adapter.mixin.ExtInfoHandler;
 import ch.elexis.core.model.format.PostalAddress;
 import ch.elexis.core.model.service.holder.CoreModelServiceHolder;
 import ch.elexis.core.model.util.internal.ModelUtil;
@@ -20,13 +19,10 @@ import ch.elexis.core.types.Country;
 
 public class Contact extends AbstractIdDeleteModelAdapter<Kontakt> implements IdentifiableWithXid, IContact {
 
-	private ExtInfoHandler extInfoHandler;
-
 	public Contact(Kontakt entity) {
 		super(entity);
-		extInfoHandler = new ExtInfoHandler(this);
 	}
-
+	
 	@Override
 	public boolean isMandator() {
 		return getEntity().isMandator();

--- a/tests/ch.elexis.core.model.test/src/ch/elexis/core/model/AllModelTests.java
+++ b/tests/ch.elexis.core.model.test/src/ch/elexis/core/model/AllModelTests.java
@@ -13,7 +13,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	ArticleTest.class, UserConfigTest.class, XidTest.class, BillingSystemFactorTest.class,
 	LocalServiceTest.class, DiagnosisReferenceTest.class, BilledTest.class, PrescriptionTest.class,
 	FreeTextDiagnosisTest.class, RecipeTest.class, DefaultSignatureTest.class, PersonTest.class,
-	MessageTest.class
+	MessageTest.class, MandatorTest.class
 })
 public class AllModelTests {
 	

--- a/tests/ch.elexis.core.model.test/src/ch/elexis/core/model/MandatorTest.java
+++ b/tests/ch.elexis.core.model.test/src/ch/elexis/core/model/MandatorTest.java
@@ -1,0 +1,122 @@
+package ch.elexis.core.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.elexis.core.model.service.holder.CoreModelServiceHolder;
+import ch.elexis.core.test.AbstractTest;
+
+public class MandatorTest extends AbstractTest {
+
+	@Before
+	public void before() {
+		super.before();
+		createMandator();
+	}
+
+	@After
+	public void after() {
+		super.after();
+	}
+
+
+	@Test
+	public void extInfoWithRefetch() {
+		assertTrue(person.isMandator());
+		assertTrue(person.getExtInfo("testKey") == null);
+		person.setMobile("011");
+		person.setExtInfo("testKey", "testValue");
+		
+		Optional<IMandator> loaded = coreModelService.load(person.getId(), IMandator.class);
+		
+		// refetch
+		assertTrue(loaded.get().getMobile() == null);
+		assertTrue(loaded.get().getExtInfo("testKey") == null);
+		
+		coreModelService.save(person);
+
+		assertEquals("011", loaded.get().getMobile()); // works
+		// the issue [16648] happened here - because of refetch the value of testKey was null if extInfoHandler won't be reseted after entity change
+		assertEquals("testValue", loaded.get().getExtInfo("testKey"));
+	}
+	
+	@Test
+	public void extInfoWithoutRefetch() {
+		// working solution without refetch
+		assertTrue(person.isMandator());
+		assertTrue(person.getExtInfo("testKey") == null);
+		assertTrue(person.getMobile() == null);
+		person.setMobile("01");
+		person.setExtInfo("testKey", "testValue");
+	
+		Optional<IMandator> loaded = coreModelService.load(person.getId(), IMandator.class);
+		// no refetch save directly
+		coreModelService.save(person);
+		
+		assertEquals("01", loaded.get().getMobile());
+		assertEquals("testValue", loaded.get().getExtInfo("testKey"));
+	}	
+	
+	@Test
+	public void extInfoMutlipleSaveAndRefresh() {
+		assertTrue(person.isMandator());
+		assertTrue(person.getExtInfo("testKey") == null);
+		assertTrue(person.getMobile() == null);
+		person.setMobile("01");
+		person.setExtInfo("testKey1", "testValue1");
+	
+		Optional<IMandator> loaded = coreModelService.load(person.getId(), IMandator.class);
+		coreModelService.save(person);
+
+		assertEquals("01", loaded.get().getMobile());
+		assertEquals("testValue1", loaded.get().getExtInfo("testKey1"));
+		
+		// some more value changes
+		person.setExtInfo("testKey2", "testValue2");
+		person.setExtInfo("testKey3", "testValue3");
+		person.setMobile("02");
+		
+		// refresh changed object and db object
+		CoreModelServiceHolder.get().refresh(person);
+		loaded = coreModelService.load(person.getId(), IMandator.class);
+		CoreModelServiceHolder.get().refresh(loaded.get());
+
+		// check changes is still present 
+		assertTrue(person.getExtInfo("testKey2") != null);
+		assertEquals("02", person.getMobile());
+		
+		// db object should consist db values
+		assertTrue(loaded.get().getExtInfo("testKey2") == null);
+		assertEquals("01", loaded.get().getMobile());
+		
+		// save changes to synchronize changed object with db object
+		coreModelService.save(person);
+		
+		assertEquals("02", loaded.get().getMobile());
+		assertEquals("testValue1", loaded.get().getExtInfo("testKey1"));
+		assertEquals("testValue2", loaded.get().getExtInfo("testKey2"));
+		assertEquals("testValue3", loaded.get().getExtInfo("testKey3"));
+		
+		// refresh again to ensure nothing get changed
+		CoreModelServiceHolder.get().refresh(loaded.get());
+		
+		assertEquals("02", loaded.get().getMobile());
+		assertEquals("testValue1", loaded.get().getExtInfo("testKey1"));
+		assertEquals("testValue2", loaded.get().getExtInfo("testKey2"));
+		assertEquals("testValue3", loaded.get().getExtInfo("testKey3"));
+		
+		// load again to ensure nothing get changed
+		loaded = coreModelService.load(person.getId(), IMandator.class);
+		
+		assertEquals("02", loaded.get().getMobile());
+		assertEquals("testValue1", loaded.get().getExtInfo("testKey1"));
+		assertEquals("testValue2", loaded.get().getExtInfo("testKey2"));
+		assertEquals("testValue3", loaded.get().getExtInfo("testKey3"));
+	}	
+}


### PR DESCRIPTION
@Thomas Bitte beachte die Kommentare im Code. Der Reset sollte auch für weitere Entitäten erfolgen (ca 14 stück), evt könnte man das etwas globaler lösen, daher habe ich es dzt nur für Kontakt gemacht.
Der Testfall extInfoWithRefetch() verdeutlicht den Fehler und konnte nach dem Fix beseitigt werden.