### PR TITLE
Replace wherever possible string constant by expressions from ch.rgw.tools.ScriptTool

### DIFF
--- a/bundles/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
+++ b/bundles/ch.elexis.core.application/src/ch/elexis/core/application/Desk.java
@@ -39,6 +39,7 @@ import ch.elexis.core.utils.CoreUtil;
 import ch.elexis.data.PersistentObject;
 import ch.rgw.io.FileTool;
 
+import ch.rgw.tools.StringTool;
 public class Desk implements IApplication {
 	
 	private Logger log = LoggerFactory.getLogger(Desk.class);
@@ -80,7 +81,7 @@ public class Desk implements IApplication {
 					log.error(PersistentObject.class.getName() + " po data initialization failed.");
 				}
 			} else {
-				String connstring = (connection.isPresent()) ? connection.get().connectionString : "";
+				String connstring = (connection.isPresent()) ? connection.get().connectionString : StringTool.leer;
 				log.error(
 					"Can not connect to database, datasource or connection configuration missing. Datasource ["
 						+ datasource + "] Connection [" + connstring + "]");
@@ -96,7 +97,7 @@ public class Desk implements IApplication {
 			sb.append("Message: " + pe.getMessage() + "\n\n");
 			while (pe.getCause() != null) {
 				pe = pe.getCause();
-				sb.append("Reason: " + pe.getMessage() + "\n");
+				sb.append("Reason: " + pe.getMessage() + StringTool.lf);
 			}
 			sb.append("\n\nWould you like to re-configure the database connection?");
 			boolean retVal = MessageDialog.openQuestion(shell,
@@ -188,7 +189,7 @@ public class Desk implements IApplication {
 			localLock.unlock();
 		}
 		// TODO add elexis OID if available
-		CoreHub.localCfg.set(ch.elexis.core.constants.Preferences.SOFTWARE_OID, "");
+		CoreHub.localCfg.set(ch.elexis.core.constants.Preferences.SOFTWARE_OID, StringTool.leer);
 		CoreHub.localCfg.flush();
 	}
 	

--- a/bundles/ch.elexis.core.application/src/ch/elexis/core/application/advisors/ApplicationWorkbenchWindowAdvisor.java
+++ b/bundles/ch.elexis.core.application/src/ch/elexis/core/application/advisors/ApplicationWorkbenchWindowAdvisor.java
@@ -29,6 +29,7 @@ import ch.elexis.core.ui.actions.ScannerEvents;
  * Hier können Funktionen aufgerufen werden, die unmittelbar vor dem öffnen des Hauptfensters
  * erfolgen sollen. Im Wesentlichen werden hier die Menue und Toolbars gesetzt
  */
+import ch.rgw.tools.StringTool;
 public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 	
 	public ApplicationWorkbenchWindowAdvisor(IWorkbenchWindowConfigurer configurer){
@@ -48,7 +49,7 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 		configurer.setShowCoolBar(true);
 		configurer.setShowStatusLine(true);
 		configurer.setShowProgressIndicator(true);
-		configurer.setTitle(Hub.APPLICATION_NAME + " " + CoreHub.readElexisBuildVersion());
+		configurer.setTitle(Hub.APPLICATION_NAME + StringTool.space + CoreHub.readElexisBuildVersion());
 		configurer.setShowFastViewBars(true);
 		if (CoreHub.localCfg.get(Preferences.SHOWPERSPECTIVESELECTOR, Boolean.toString(false))
 			.equals(Boolean.toString(true))) {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/admin/ACE.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/admin/ACE.java
@@ -44,6 +44,7 @@ import ch.elexis.data.Role;
  * @author gerry
  * 		
  */
+import ch.rgw.tools.StringTool;
 public class ACE implements Serializable {
 	private static final long serialVersionUID = 34320020090119L;
 	
@@ -211,7 +212,7 @@ public class ACE implements Serializable {
 		sp.append(getName());
 		ACE parent = getParent();
 		while ((parent != null) && (!parent.equals(ACE.ACE_ROOT))) {
-			sp.insert(0, parent.getName() + "/"); //$NON-NLS-1$
+			sp.insert(0, parent.getName() + StringTool.slash); //$NON-NLS-1$
 			parent = parent.getParent();
 		}
 		return sp.toString();
@@ -227,7 +228,7 @@ public class ACE implements Serializable {
 			return ACE_ROOT_LITERAL;
 		int valCan = Math.abs(getCanonicalName().hashCode());
 		int valNam = Math.abs(getName().hashCode());
-		BigInteger valI = new BigInteger(valCan + "" + valNam);
+		BigInteger valI = new BigInteger(valCan + StringTool.leer + valNam);
 		return valI.toString(16);
 	}
 	
@@ -268,7 +269,7 @@ public class ACE implements Serializable {
 	
 	@Override
 	public String toString(){
-		return getUniqueHashFromACE() + " " + getName() + " " + getCanonicalName();
+		return getUniqueHashFromACE() + StringTool.space + getName() + StringTool.space + getCanonicalName();
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.data/src/ch/elexis/admin/AccessControlImpl.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/admin/AccessControlImpl.java
@@ -349,11 +349,11 @@ public class AccessControlImpl extends AbstractAccessControl {
 	private String remove(String group, Anwender user){
 		String g = (String) user.getInfoElement(KEY_GROUPS);
 		if (g != null) {
-			g = g.replaceAll(user.getId(), ""); //$NON-NLS-1$
-			g = g.replaceAll("\\s*,*$", ""); //$NON-NLS-1$ //$NON-NLS-2$
+			g = g.replaceAll(user.getId(), StringTool.leer); //$NON-NLS-1$
+			g = g.replaceAll("\\s*,*$", StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$
 			return g;
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
@@ -168,7 +168,7 @@ public class CoreHub implements BundleActivator {
 	 *         retrieved
 	 */
 	public static String getBasePath(){
-		return FrameworkUtil.getBundle(CoreHub.class).getEntry("/").toString();
+		return FrameworkUtil.getBundle(CoreHub.class).getEntry(StringTool.slash).toString();
 	}
 	
 	/**
@@ -270,7 +270,7 @@ public class CoreHub implements BundleActivator {
 		try (InputStream inputStream = new URL(url_name).openConnection().getInputStream()) {
 			if (inputStream != null) {
 				prop.load(inputStream);
-				elexis_version = prop.getProperty("elexis.version").replace("-SNAPSHOT", "");
+				elexis_version = prop.getProperty("elexis.version").replace("-SNAPSHOT", StringTool.leer);
 			}
 		} catch (IOException e) {
 			elexis_version = plugin.Version;
@@ -304,7 +304,7 @@ public class CoreHub implements BundleActivator {
 		String config = "default"; //$NON-NLS-1$
 		for (String s : args) {
 			if (s.startsWith("--use-config=")) { //$NON-NLS-1$
-				String[] c = s.split("="); //$NON-NLS-1$
+				String[] c = s.split(StringTool.equals); //$NON-NLS-1$
 				config = c[1];
 			}
 		}
@@ -368,8 +368,8 @@ public class CoreHub implements BundleActivator {
 	
 	public static String getId(){
 		StringBuilder sb = new StringBuilder();
-		sb.append(APPLICATION_NAME).append(" v.").append(Version).append("\n")
-			.append(CoreHubHelper.getRevision(true, plugin)).append("\n")
+		sb.append(APPLICATION_NAME).append(" v.").append(Version).append(StringTool.lf)
+			.append(CoreHubHelper.getRevision(true, plugin)).append(StringTool.lf)
 			.append(System.getProperty("os.name")).append(StringConstants.SLASH)
 			.append(System.getProperty("os.version")).append(StringConstants.SLASH)
 			.append(System.getProperty("os.arch")); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/beans/ContactBean.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/beans/ContactBean.java
@@ -27,6 +27,7 @@ import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Person;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ContactBean extends BeanPersistentObject<Kontakt>
 		implements IContact, IPerson, IPatient {
 	
@@ -242,8 +243,8 @@ public class ContactBean extends BeanPersistentObject<Kontakt>
 	
 	@Override
 	public String getLabel(){
-		return getDescription1() + " " + getDescription2() + ", " + getStreet() + ", " + getZip()
-			+ " " + getCity();
+		return getDescription1() + StringTool.space + getDescription2() + ", " + getStreet() + ", " + getZip()
+			+ StringTool.space + getCity();
 	}
 	
 	@Override
@@ -360,7 +361,7 @@ public class ContactBean extends BeanPersistentObject<Kontakt>
 			vs = "u";
 			break;
 		default:
-			vs = "";
+			vs = StringTool.leer;
 		}
 		entity.set(Person.SEX, vs);
 		firePropertyChange("gender", old, value);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/beans/ContactType.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/beans/ContactType.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * @model
  * @generated
  */
+import ch.rgw.tools.StringTool;
 public enum ContactType implements Enumerator {
 		/**
 		 * The '<em><b>PERSON</b></em>' literal object. <!-- begin-user-doc --> <!-- end-user-doc
@@ -53,7 +54,7 @@ public enum ContactType implements Enumerator {
 		 * @generated
 		 * @ordered
 		 */
-		MANDATOR(2, "MANDATOR", ""),
+		MANDATOR(2, "MANDATOR", StringTool.leer),
 		/**
 		 * The '<em><b>LABORATORY</b></em>' literal object. <!-- begin-user-doc --> <!--
 		 * end-user-doc -->

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/cache/SoftCache.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/cache/SoftCache.java
@@ -27,6 +27,7 @@ import ch.rgw.tools.Log;
  * 
  * @author Gerry
  */
+import ch.rgw.tools.StringTool;
 @SuppressWarnings("unchecked")
 public class SoftCache<K> implements IPersistentObjectCache<K> {
 	private static boolean enabled = true;
@@ -128,13 +129,13 @@ public class SoftCache<K> implements IPersistentObjectCache<K> {
 		if (total != 0) {
 			StringBuilder sb = new StringBuilder();
 			sb.append("--------- cache statistics ------\n").append("Total read:\t").append(total)
-				.append("\n").append("cache hits:\t").append(hits).append(" (")
+				.append(StringTool.lf).append("cache hits:\t").append(hits).append(" (")
 				.append(hits * 100 / total).append("%)\n").append("object expired:\t")
 				.append(expired).append(" (").append(expired * 100 / total).append("%)\n")
 				.append("cache missed:\t").append(misses).append(" (").append(misses * 100 / total)
 				.append("%)\n").append("object removed:\t").append(removed).append(" (")
 				.append(removed * 100 / total).append("%)\n").append("Object inserts:\t")
-				.append(inserts).append("\n");
+				.append(inserts).append(StringTool.lf);
 			log.log(sb.toString(), Log.INFOS);
 		}
 		
@@ -161,7 +162,7 @@ public class SoftCache<K> implements IPersistentObjectCache<K> {
 			// long freeAfter = Runtime.getRuntime().freeMemory();
 			// StringBuilder sb = new StringBuilder();
 			// sb.append("Cache purge: Free memore before: ").append(freeBefore)
-			// .append(", free memory after: ").append(freeAfter).append("\n");
+			// .append(", free memory after: ").append(freeAfter).append(StringTool.lf);
 			// Hub.log.log(sb.toString(), Log.INFOS);
 			// }
 		}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/dbupdate/FallUpdatesFor36.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/dbupdate/FallUpdatesFor36.java
@@ -22,6 +22,7 @@ import ch.elexis.data.BillingSystem;
 import ch.elexis.data.Fall;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class FallUpdatesFor36 {
 	
 	protected static Logger log = LoggerFactory.getLogger(FallUpdatesFor36.class);
@@ -84,7 +85,7 @@ public class FallUpdatesFor36 {
 								log.error("Could not resolve law [{}] from billing systeem [{}]",
 									abrechnungsSystemGesetz, abrechnungssystem);
 								errors.append(
-									"Fehler Gesetz-Konfiguration für " + abrechnungssystem + "\n");
+									"Fehler Gesetz-Konfiguration für " + abrechnungssystem + StringTool.lf);
 							}
 						} else {
 							log.error("No gesetz constant found for billing system [{}]",
@@ -97,11 +98,11 @@ public class FallUpdatesFor36 {
 						if (requirements != null && requirements.contains("Kostenträger:K")) {
 							BillingSystem.moveCostBearerFromExtinfoToDBRow(abrechnungssystem,
 								"Kostenträger");
-							requirements = requirements.replace("Kostenträger:K:;", "");
-							requirements = requirements.replace("Kostenträger:K:", "");
-							requirements = requirements.replace("Kostenträger:K;", "");
-							requirements = requirements.replace("Kostenträger:K", "");
-							CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+							requirements = requirements.replace("Kostenträger:K:;", StringTool.leer);
+							requirements = requirements.replace("Kostenträger:K:", StringTool.leer);
+							requirements = requirements.replace("Kostenträger:K;", StringTool.leer);
+							requirements = requirements.replace("Kostenträger:K", StringTool.leer);
+							CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 								+ abrechnungssystem + "/bedingungen", requirements); //$NON-NLS-1$
 						} else {
 							log.error("Could not find cost bearer entry for billing system [{}]",

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/events/ElexisEventDispatcher.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/events/ElexisEventDispatcher.java
@@ -54,6 +54,7 @@ import ch.elexis.data.PersistentObject;
  * @since 3.7 move from Eclipse job to ScheduledExecutorService
  * @since 3.8 must explicitly {@link #start()} queue execution
  */
+import ch.rgw.tools.StringTool;
 public final class ElexisEventDispatcher implements Runnable {
 	private  Logger log = LoggerFactory.getLogger(ElexisEventDispatcher.class);
 	
@@ -420,7 +421,7 @@ public final class ElexisEventDispatcher implements Runnable {
 				&& filter.getObjectClass().getName() != null) {
 				sb.append(filter.type).append(" / ").append(filter.getObjectClass().getName());
 			}
-			sb.append("\n");
+			sb.append(StringTool.lf);
 			
 		}
 		sb.append("\n--------------\n");

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/events/PatientEventListener.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/events/PatientEventListener.java
@@ -23,6 +23,7 @@ import ch.elexis.data.Reminder;
  * {@link Hub#start(org.osgi.framework.BundleContext)}, de-registered within
  * {@link Hub#stop(org.osgi.framework.BundleContext)}
  */
+import ch.rgw.tools.StringTool;
 public class PatientEventListener extends ElexisEventListenerImpl {
 	
 	public PatientEventListener(){
@@ -42,7 +43,7 @@ public class PatientEventListener extends ElexisEventListenerImpl {
 				if (list.size() != 0) {
 					StringBuilder sb = new StringBuilder();
 					for (Reminder r : list) {
-						sb.append(r.getSubject()+"\n");
+						sb.append(r.getSubject()+StringTool.lf);
 						sb.append(r.getMessage()+"\n\n");
 					}
 					MessageEvent.fireInformation(Messages.PatientEventListener_0,

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/lab/LabResultEvaluator.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/lab/LabResultEvaluator.java
@@ -12,6 +12,7 @@ import ch.elexis.core.types.PathologicDescription;
 import ch.elexis.core.types.PathologicDescription.Description;
 import ch.elexis.data.LabResult;
 
+import ch.rgw.tools.StringTool;
 public class LabResultEvaluator {
 	
 	private LabResultEvaluationResult evaluateTextualResult(LabResult labResult,
@@ -58,7 +59,7 @@ public class LabResultEvaluator {
 		Gender gender = labResult.getPatient().getGender();
 		
 		Description description = Description.PATHO_REF;
-		String refValue = "";
+		String refValue = StringTool.leer;
 		if (Gender.MALE == gender) {
 			refValue = labResult.getRefMale();
 			if (StringUtils.isEmpty(refValue)) {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/nopo/adapter/ArtikelAdapter.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/nopo/adapter/ArtikelAdapter.java
@@ -8,6 +8,7 @@ import ch.elexis.core.model.IArticle;
 import ch.elexis.data.Artikel;
 import ch.rgw.tools.Money;
 
+import ch.rgw.tools.StringTool;
 public class ArtikelAdapter extends Artikel {
 	
 	private IArticle article;
@@ -48,7 +49,7 @@ public class ArtikelAdapter extends Artikel {
 	
 	@Override
 	public String getPharmaCode(){
-		String ret = "";
+		String ret = StringTool.leer;
 		try {
 			Method method = article.getClass().getMethod("getPHAR");
 			ret = (String) method.invoke(article);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/preferences/CorePreferenceInitializer.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/preferences/CorePreferenceInitializer.java
@@ -37,7 +37,7 @@ public class CorePreferenceInitializer extends AbstractPreferenceInitializer {
 		CoreHub.localCfg.set(Preferences.DB_CONNECT + SETTINGS_PREFERENCE_STORE_DEFAULT,
 			"jdbc:h2:" + base + "/db;MODE=MySQL"); //$NON-NLS-1$ //$NON-NLS-2$
 		CoreHub.localCfg.set(Preferences.DB_USERNAME + SETTINGS_PREFERENCE_STORE_DEFAULT, "sa"); //$NON-NLS-1$
-		CoreHub.localCfg.set(Preferences.DB_PWD + SETTINGS_PREFERENCE_STORE_DEFAULT, ""); //$NON-NLS-1$
+		CoreHub.localCfg.set(Preferences.DB_PWD + SETTINGS_PREFERENCE_STORE_DEFAULT, StringTool.leer); //$NON-NLS-1$
 		CoreHub.localCfg.set(Preferences.DB_TYP + SETTINGS_PREFERENCE_STORE_DEFAULT, "mysql"); //$NON-NLS-1$
 		// Ablauf
 		File userhome = new File(System.getProperty("user.home") + File.separator + "elexis"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -65,12 +65,12 @@ public class CorePreferenceInitializer extends AbstractPreferenceInitializer {
 		// Texterstellung
 		if (System.getProperty("os.name").toLowerCase().startsWith("win")) { //$NON-NLS-1$ //$NON-NLS-2$
 			if (CoreHub.localCfg.get(Preferences.P_TEXTMODUL, null) == null
-				|| CoreHub.localCfg.get(Preferences.P_TEXTMODUL, "").equals(StringTool.leer)) {
+				|| CoreHub.localCfg.get(Preferences.P_TEXTMODUL, StringTool.leer).equals(StringTool.leer)) {
 				CoreHub.localCfg.set(Preferences.P_TEXTMODUL, "NOA-Text"); //$NON-NLS-1$
 			}
 		} else {
 			if (CoreHub.localCfg.get(Preferences.P_TEXTMODUL, null) == null
-				|| CoreHub.localCfg.get(Preferences.P_TEXTMODUL, "").equals(StringTool.leer)) {
+				|| CoreHub.localCfg.get(Preferences.P_TEXTMODUL, StringTool.leer).equals(StringTool.leer)) {
 				CoreHub.localCfg.set(Preferences.P_TEXTMODUL, "OpenOffice Wrapper");
 			}
 		}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/service/internal/LocalLockService.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/service/internal/LocalLockService.java
@@ -49,6 +49,7 @@ import ch.elexis.data.User;
  * @author marco
  * 
  */
+import ch.rgw.tools.StringTool;
 @Component
 public class LocalLockService implements ILocalLockService {
 	
@@ -83,7 +84,7 @@ public class LocalLockService implements ILocalLockService {
 		inst.setUuid(getSystemUuid());
 		inst.setVersion(CoreHub.readElexisBuildVersion());
 		inst.setOperatingSystem(
-			System.getProperty("os.name") + "/" + System.getProperty("os.version") + "/"
+			System.getProperty("os.name") + StringTool.slash + System.getProperty("os.version") + StringTool.slash
 				+ System.getProperty("os.arch") + "/J" + System.getProperty("java.version"));
 	}
 	
@@ -95,8 +96,8 @@ public class LocalLockService implements ILocalLockService {
 			logger.info("Operating against elexis-server instance on " + restUrl);
 			ils = new ElexisServerLockService(restUrl);
 			iis = new ElexisServerInstanceService(restUrl);
-			String identId = CoreHub.localCfg.get(Preferences.STATION_IDENT_ID, "");
-			String identTxt = CoreHub.localCfg.get(Preferences.STATION_IDENT_TEXT, "");
+			String identId = CoreHub.localCfg.get(Preferences.STATION_IDENT_ID, StringTool.leer);
+			String identTxt = CoreHub.localCfg.get(Preferences.STATION_IDENT_TEXT, StringTool.leer);
 			inst.setIdentifier(identTxt + " [" + identId + "]");
 		} else {
 			standalone = true;

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/AllDataAccessor.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/AllDataAccessor.java
@@ -23,6 +23,7 @@ import ch.elexis.data.PersistentObject;
 import ch.rgw.tools.Result;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 @SuppressWarnings("deprecation")
 public class AllDataAccessor implements IDataAccess {
 	
@@ -96,18 +97,18 @@ public class AllDataAccessor implements IDataAccess {
 				sb.append(date.toString(TimeTool.DATE_GER));
 				
 				if (withFall) {
-					sb.append(" ");
+					sb.append(StringTool.space);
 					sb.append(kons.getMandant().getLabel(false));
 					sb.append(" - ");
 					sb.append(fall.getBezeichnung());
-					sb.append(" ");
+					sb.append(StringTool.space);
 				}
 				
-				sb.append("\n"); //$NON-NLS-1$
+				sb.append(StringTool.lf); //$NON-NLS-1$
 				
 				Samdas samdas = new Samdas(kons.getEintrag().getHead());
 				sb.append(samdas.getRecordText());
-				sb.append("\n"); //$NON-NLS-1$
+				sb.append(StringTool.lf); //$NON-NLS-1$
 			}
 		}
 		

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/BenchmarkTimer.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/BenchmarkTimer.java
@@ -3,6 +3,7 @@ package ch.elexis.core.data.util;
 /**
  * This class can be used for simple benchmarks.
  */
+import ch.rgw.tools.StringTool;
 public class BenchmarkTimer {
 	
 	private long startTime = 0;
@@ -41,15 +42,15 @@ public class BenchmarkTimer {
 		if (seconds < 10)
 			sec = "0" + seconds;
 		else
-			sec = "" + seconds;
+			sec = StringTool.leer + seconds;
 		if (minutes < 10)
 			min = "0" + minutes;
 		else
-			min = "" + minutes;
+			min = StringTool.leer + minutes;
 		if (hours < 10)
 			hrs = "0" + hours;
 		else
-			hrs = "" + hours;
+			hrs = StringTool.leer + hours;
 		
 		if (hours == 0)
 			return min + " min, " + sec + " sec";

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/BillingUtil.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/BillingUtil.java
@@ -58,6 +58,7 @@ import ch.rgw.tools.TimeTool;
  * @author thomas
  *
  */
+import ch.rgw.tools.StringTool;
 public class BillingUtil {
 	
 	public static String BILLINGCHECK_ENABLED_CFG = "ch.elexis.core.data/billablecheck/";
@@ -926,7 +927,7 @@ public class BillingUtil {
 					msg message : rechnungResult.getMessages()) {
 						if (message.getSeverity() != SEVERITY.OK) {
 							if (output.length() > 0) {
-								output.append("\n");
+								output.append(StringTool.lf);
 							}
 							output.append(message.getText());
 						}
@@ -979,7 +980,7 @@ public class BillingUtil {
 		
 		private void addToOutput(StringBuilder output, String warning){
 			if (output.length() > 0) {
-				output.append("\n");
+				output.append(StringTool.lf);
 			}
 			if (warning.length() > 0) {
 				output.append(warning);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/DBUpdate.java
@@ -43,6 +43,7 @@ import ch.rgw.tools.VersionInfo;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class DBUpdate {
 	
 	private static final String ALTER_TABLE = "ALTER TABLE ";
@@ -535,7 +536,7 @@ public class DBUpdate {
 		
 		try (InputStream inputStream = DBUpdate.class.getResourceAsStream(resourceName)) {
 			return new BufferedReader(new InputStreamReader(inputStream)).lines()
-				.filter(s -> !s.startsWith("#")).collect(Collectors.joining("\n"));
+				.filter(s -> !s.startsWith("#")).collect(Collectors.joining(StringTool.lf));
 		} catch (IOException e) {
 			log.error("Error reading input file [{}] for version [{}]." + resourceName, version);
 			return null;

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/DatabaseCleaner.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/DatabaseCleaner.java
@@ -32,6 +32,7 @@ import ch.rgw.tools.ExHandler;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class DatabaseCleaner {
 	
 	OutputStream osw;
@@ -84,7 +85,7 @@ public class DatabaseCleaner {
 			if (true) {
 				blame(rn, Messages.DatabaseCleaner_NoCaseForBill); //$NON-NLS-1$
 				Query<Konsultation> qk = new Query<Konsultation>(Konsultation.class);
-				qk.add("RechnungsID", "=", rn.getId());
+				qk.add("RechnungsID", StringTool.equals, rn.getId());
 				List<Konsultation> lk = qk.execute();
 				for (Konsultation k : lk) {
 					Fall f = k.getFall();
@@ -105,7 +106,7 @@ public class DatabaseCleaner {
 	
 	void blame(PersistentObject o, String msg){
 		try {
-			osw.write(("\r\n" + msg + ": " + o.getId() + ", " + o.getLabel() + "\r\n").getBytes("iso-8859-1")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+			osw.write((StringTool.crlf + msg + ": " + o.getId() + ", " + o.getLabel() + StringTool.crlf).getBytes("iso-8859-1")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 			purgeList.add(o);
 		} catch (Exception ex) {
 			ExHandler.handle(ex);
@@ -114,7 +115,7 @@ public class DatabaseCleaner {
 	
 	void note(String msg){
 		try {
-			osw.write(("  -- " + msg + "\r\n").getBytes("iso-8859-1")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			osw.write(("  -- " + msg + StringTool.crlf).getBytes("iso-8859-1")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} catch (Exception ex) {
 			ExHandler.handle(ex);
 		}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/FallDataAccessor.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/FallDataAccessor.java
@@ -10,6 +10,7 @@ import ch.elexis.data.Kontakt;
 import ch.elexis.data.PersistentObject;
 import ch.rgw.tools.Result;
 
+import ch.rgw.tools.StringTool;
 public class FallDataAccessor implements IDataAccess {
 	private static final String KOSTENTRAEGER_UMLAUT = Fall.FLD_EXT_KOSTENTRAEGER;
 	private static final String KOSTENTRAEGER_KUERZEL_UMLAUT = "KostenträgerKürzel";
@@ -54,7 +55,7 @@ public class FallDataAccessor implements IDataAccess {
 	@Override
 	public Result<Object> getObject(String descriptor, PersistentObject dependentObject,
 		String dates, String[] params){
-		Result<Object> result = new Result<Object>(""); //$NON-NLS-1$
+		Result<Object> result = new Result<Object>(StringTool.leer); //$NON-NLS-1$
 		
 		Fall fall = (Fall) ElexisEventDispatcher.getSelected(Fall.class);
 		Kontakt costBearer = fall.getCostBearer();

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/FileUtility.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/FileUtility.java
@@ -19,6 +19,7 @@ import ch.elexis.core.utils.FileUtil;
  * @author med1
  *
  */
+import ch.rgw.tools.StringTool;
 public class FileUtility {
 	public static String DIRECTORY_SEPARATOR = File.separator;
 	
@@ -26,7 +27,7 @@ public class FileUtility {
 	
 	private static String getCorrectSeparators(final String pathOrFilename){
 		return pathOrFilename.replace("\\", DIRECTORY_SEPARATOR).replace("//", //$NON-NLS-1$ //$NON-NLS-2$
-			DIRECTORY_SEPARATOR).replace("/", DIRECTORY_SEPARATOR); //$NON-NLS-1$
+			DIRECTORY_SEPARATOR).replace(StringTool.slash, DIRECTORY_SEPARATOR); //$NON-NLS-1$
 	}
 	
 	private static String removeMultipleSeparators(String pathOrFilename){
@@ -45,7 +46,7 @@ public class FileUtility {
 	 */
 	public static String getCorrectPath(String path) throws IllegalArgumentException{
 		if (path == null) {
-			return ""; //$NON-NLS-1$
+			return StringTool.leer; //$NON-NLS-1$
 		}
 		path = getCorrectSeparators(path);
 		path = removeMultipleSeparators(path);
@@ -87,7 +88,7 @@ public class FileUtility {
 		String correctFilenamePath = getCorrectSeparators(filenamePath);
 		
 		if (correctFilenamePath.indexOf(DIRECTORY_SEPARATOR) < 0) {
-			return ""; //$NON-NLS-1$
+			return StringTool.leer; //$NON-NLS-1$
 		}
 		return correctFilenamePath.substring(0,
 			correctFilenamePath.lastIndexOf(DIRECTORY_SEPARATOR));
@@ -132,6 +133,6 @@ public class FileUtility {
 			
 		}
 		
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 }

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/MultiplikatorList.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/MultiplikatorList.java
@@ -207,7 +207,7 @@ public class MultiplikatorList {
 	
 	private static String[] getEigenleistungUseMultiSystems(){
 		String systems =
-			CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_EIGENLEISTUNG_USEMULTI_SYSTEMS, "");
+			CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_EIGENLEISTUNG_USEMULTI_SYSTEMS, StringTool.leer);
 		return systems.split("\\|\\|");
 	}
 	
@@ -223,7 +223,7 @@ public class MultiplikatorList {
 	
 	public static void setEigenleistungUseMulti(String system){
 		String systems =
-			CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_EIGENLEISTUNG_USEMULTI_SYSTEMS, "");
+			CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_EIGENLEISTUNG_USEMULTI_SYSTEMS, StringTool.leer);
 		if (!systems.isEmpty()) {
 			systems = systems.concat("||");
 		}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/PatientDataAccessor.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/PatientDataAccessor.java
@@ -10,6 +10,7 @@ import ch.elexis.data.Patient;
 import ch.elexis.data.PersistentObject;
 import ch.rgw.tools.Result;
 
+import ch.rgw.tools.StringTool;
 public class PatientDataAccessor implements IDataAccess {
 	private static final String GESETZVERTRETER_UMLAUT = "Gesetzlicher Vertreter";
 	private static final String GESETZVERTRETER_KUERZEL_UMLAUT = "Gesetzlicher Vertreter Kürzel";
@@ -67,7 +68,7 @@ public class PatientDataAccessor implements IDataAccess {
 	@Override
 	public Result<Object> getObject(String descriptor, PersistentObject dependentObject,
 		String dates, String[] params){
-		Result<Object> result = new Result<Object>("");
+		Result<Object> result = new Result<Object>(StringTool.leer);
 		
 		Patient patient = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
 		

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/PlatformHelper.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/PlatformHelper.java
@@ -24,17 +24,18 @@ import org.eclipse.core.runtime.Platform;
  * @deprecated moved to ch.elexis.core.utils
  *
  */
+import ch.rgw.tools.StringTool;
 public class PlatformHelper {
 	public static String getBasePath(String pluginID){
 		try {
-			URL url = Platform.getBundle(pluginID).getEntry("/");
+			URL url = Platform.getBundle(pluginID).getEntry(StringTool.slash);
 			url = FileLocator.toFileURL(url);
 			String bundleLocation = url.getPath();
 			File file = new File(bundleLocation);
 			bundleLocation = file.getAbsolutePath();
 			return bundleLocation;
 		} catch (Throwable throwable) {
-			return "";
+			return StringTool.leer;
 		}
 	}
 }

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/ProcessController.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/ProcessController.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class ProcessController {
 	private String proc_result;
 	private String proc_err;
@@ -46,7 +47,7 @@ public class ProcessController {
 	public boolean run(String program, String command, String inputStr){
 		Process p;
 		
-		log.info("executing " + program + " " + command + ", " + inputStr);
+		log.info("executing " + program + StringTool.space + command + ", " + inputStr);
 		
 		try {
 			p = Runtime.getRuntime().exec(new String[] {
@@ -106,7 +107,7 @@ public class ProcessController {
 		
 		OutputStream os;
 		
-		String fullLine = "";
+		String fullLine = StringTool.leer;
 		
 		/**
 		 * Constructor for the ProcessStreamReader object
@@ -145,7 +146,7 @@ public class ProcessController {
 				BufferedReader br = new BufferedReader(isr);
 				String line = null;
 				while ((line = br.readLine()) != null) {
-					fullLine = fullLine + line + "\n";
+					fullLine = fullLine + line + StringTool.lf;
 				}
 				
 			} catch (IOException ioe) {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/UtilFile.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/util/UtilFile.java
@@ -12,6 +12,7 @@ package ch.elexis.core.data.util;
 
 import java.io.File;
 
+import ch.rgw.tools.StringTool;
 public class UtilFile {
 	public static String DIRECTORY_SEPARATOR = File.separator;
 	
@@ -19,7 +20,7 @@ public class UtilFile {
 	
 	private static String getCorrectSeparators(final String pathOrFilename){
 		return pathOrFilename.replace("\\", DIRECTORY_SEPARATOR).replace("//", //$NON-NLS-1$ //$NON-NLS-2$
-			DIRECTORY_SEPARATOR).replace("/", DIRECTORY_SEPARATOR); //$NON-NLS-1$
+			DIRECTORY_SEPARATOR).replace(StringTool.slash, DIRECTORY_SEPARATOR); //$NON-NLS-1$
 	}
 	
 	private static String removeMultipleSeparators(String pathOrFilename){
@@ -38,7 +39,7 @@ public class UtilFile {
 	 */
 	public static String getCorrectPath(String path) throws IllegalArgumentException{
 		if (path == null) {
-			return ""; //$NON-NLS-1$
+			return StringTool.leer; //$NON-NLS-1$
 		}
 		path = getCorrectSeparators(path);
 		path = removeMultipleSeparators(path);
@@ -68,7 +69,7 @@ public class UtilFile {
 		String correctFilenamePath = getCorrectSeparators(filenamePath);
 		
 		if (correctFilenamePath.indexOf(DIRECTORY_SEPARATOR) < 0) {
-			return "";
+			return StringTool.leer;
 		}
 		return correctFilenamePath.substring(0,
 			correctFilenamePath.lastIndexOf(DIRECTORY_SEPARATOR));

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/AccountTransaction.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/AccountTransaction.java
@@ -50,14 +50,14 @@ public class AccountTransaction extends PersistentObject {
 		private int numeric;
 		private String name;
 		
-		public static Account UNKNOWN = new Account(-1, "");
+		public static Account UNKNOWN = new Account(-1, StringTool.leer);
 		private static HashMap<Integer, Account> localCache;
 		
 		private static List<Account> loadAccounts(){
 			List<Account> ret = new ArrayList<>();
 			ret.add(UNKNOWN);
 			if (CoreHub.globalCfg != null) {
-				String accountsString = CoreHub.globalCfg.get(ACCOUNTS_CONFIG, ""); //$NON-NLS-1$
+				String accountsString = CoreHub.globalCfg.get(ACCOUNTS_CONFIG, StringTool.leer); //$NON-NLS-1$
 				if (accountsString != null && !accountsString.isEmpty()) {
 					String[] accounts = accountsString.split("\\|\\|"); //$NON-NLS-1$
 					for (String string : accounts) {
@@ -105,7 +105,7 @@ public class AccountTransaction extends PersistentObject {
 		
 		public static void addAccount(Account newAccount){
 			if (CoreHub.globalCfg != null) {
-				String existingString = CoreHub.globalCfg.get(ACCOUNTS_CONFIG, "");
+				String existingString = CoreHub.globalCfg.get(ACCOUNTS_CONFIG, StringTool.leer);
 				StringBuilder sb = new StringBuilder();
 				sb.append(existingString);
 				if (sb.length() > 0) {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Anwender.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Anwender.java
@@ -170,7 +170,7 @@ public class Anwender extends Person {
 			hashSet.remove(m);
 		}
 		List<String> edList = hashSet.stream().map(p -> p.getLabel()).collect(Collectors.toList());
-		setExtInfoStoredObjectByKey(FLD_EXTINFO_MANDATORS, edList.isEmpty() ? "" : ts(edList));
+		setExtInfoStoredObjectByKey(FLD_EXTINFO_MANDATORS, edList.isEmpty() ? StringTool.leer : ts(edList));
 	}
 
 	@Override

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/ArticleDefaultSignature.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/ArticleDefaultSignature.java
@@ -11,6 +11,7 @@ import ch.rgw.tools.TimeTool;
  * Stores the default signature for an ATC code or a specific article
  *
  */
+import ch.rgw.tools.StringTool;
 public class ArticleDefaultSignature extends PersistentObject {
 	
 	public static final String FLD_ATC_CODE = "atccode";
@@ -99,7 +100,7 @@ public class ArticleDefaultSignature extends PersistentObject {
 			sb.append("ARTICLE [" + article.getLabel() + "] ");
 		}
 		sb.append(getSignatureMorning()).append("-").append(getSignatureNoon()).append("-")
-			.append(getSignatureEvening()).append("-").append(getSignatureNight()).append(" ")
+			.append(getSignatureEvening()).append("-").append(getSignatureNight()).append(StringTool.space)
 			.append(getSignatureComment());
 		return null;
 	}
@@ -229,7 +230,7 @@ public class ArticleDefaultSignature extends PersistentObject {
 	
 	public void setSignatureFreeText(String text){
 		if (text == null) {
-			text = "";
+			text = StringTool.leer;
 		}
 		setExtInfoStoredObjectByKey(EXT_FLD_FREETEXT, text);
 	}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/BillingSystem.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/BillingSystem.java
@@ -50,15 +50,15 @@ public class BillingSystem {
 	
 	public static String getConfigurationValue(String billingSystemName, String attributeName,
 		String defaultIfNotDefined){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
-			+ billingSystemName + "/" + attributeName, defaultIfNotDefined); //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
+			+ billingSystemName + StringTool.slash + attributeName, defaultIfNotDefined); //$NON-NLS-1$
 		return ret;
 	}
 	
 	public static void setConfigurationValue(String billingSystemName, String attributeName,
 		String attributeValue){
-		String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + billingSystemName; //$NON-NLS-1$
-		CoreHub.globalCfg.set(key + "/" + attributeName, attributeValue);
+		String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + billingSystemName; //$NON-NLS-1$
+		CoreHub.globalCfg.set(key + StringTool.slash + attributeName, attributeValue);
 	}
 	
 	/**
@@ -68,7 +68,7 @@ public class BillingSystem {
 	 *            String, the name of the billing system to be tested
 	 */
 	public static boolean isDisabled(final String billingSystemName){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystemName + "/disabled", "0"); //$NON-NLS-1$ //$NON-NLS-2$
 		return !ret.equalsIgnoreCase("0");
 	}
@@ -86,7 +86,7 @@ public class BillingSystem {
 	 * @since 3.6 moved from {@link Fall}
 	 */
 	public static String getUnused(final String billingSystem){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/unused", null); //$NON-NLS-1$
 		return ret;
 	}
@@ -103,7 +103,7 @@ public class BillingSystem {
 	 * @since 3.6 moved from {@link Fall}
 	 */
 	public static String getOptionals(final String billingSystem){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/fakultativ", null); //$NON-NLS-1$
 		return ret;
 	}
@@ -122,7 +122,7 @@ public class BillingSystem {
 	 * @deprecated use {@link ch.elexis.core.services.BillingSystemService#getRequirements(ch.elexis.core.model.IBillingSystem)}
 	 */
 	public static String getRequirements(final String billingSystem){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/bedingungen", null); //$NON-NLS-1$
 		return ret;
 	}
@@ -134,7 +134,7 @@ public class BillingSystem {
 	 * @since 3.6 moved from {@link Fall}
 	 */
 	public static String[] getBillingSystemConstants(final String billingSystem){
-		String bc = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String bc = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/constants", null); //$NON-NLS-1$
 		if (bc == null) {
 			return new String[0];
@@ -154,12 +154,12 @@ public class BillingSystem {
 		final String constant){
 		String[] c = getBillingSystemConstants(billingSystem);
 		for (String bc : c) {
-			String[] val = bc.split("="); //$NON-NLS-1$
+			String[] val = bc.split(StringTool.equals); //$NON-NLS-1$
 			if (val[0].equalsIgnoreCase(constant)) {
 				return val[1];
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	/**
@@ -173,14 +173,14 @@ public class BillingSystem {
 	 */
 	public static void addBillingSystemConstant(final String billingSystem, final String constant){
 		if (constant.indexOf('=') != -1) {
-			String bc = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+			String bc = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 				+ billingSystem + "/constants", null); //$NON-NLS-1$
 			if (bc != null) {
 				bc += "#" + constant; //$NON-NLS-1$
 			} else {
 				bc = constant;
 			}
-			CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + "/" + billingSystem //$NON-NLS-1$
+			CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + billingSystem //$NON-NLS-1$
 				+ "/constants", bc); //$NON-NLS-1$
 		}
 	}
@@ -193,15 +193,15 @@ public class BillingSystem {
 	 */
 	public static void removeBillingSystemConstant(final String billingSystem,
 		final String constant){
-		String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/constants";
 		String bc = CoreHub.globalCfg.get(key, null); //$NON-NLS-1$
 		if (bc != null) {
-			bc = bc.replaceAll(constant, ""); //$NON-NLS-1$
+			bc = bc.replaceAll(constant, StringTool.leer); //$NON-NLS-1$
 			bc = bc.replaceAll("##", "#"); //$NON-NLS-1$ //$NON-NLS-2$
-			bc = bc.replaceFirst("#$", ""); //$NON-NLS-1$ //$NON-NLS-2$
-			bc = bc.replaceFirst("^#", ""); //$NON-NLS-1$ //$NON-NLS-2$
-			CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + "/" + billingSystem //$NON-NLS-1$
+			bc = bc.replaceFirst("#$", StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$
+			bc = bc.replaceFirst("^#", StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$
+			CoreHub.globalCfg.set(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + billingSystem //$NON-NLS-1$
 				+ "/constants", bc); //$NON-NLS-1$
 		} else {
 			log.error("[" + key + "] is null");
@@ -367,7 +367,7 @@ public class BillingSystem {
 	 */
 	public static void createAbrechnungssystem(final String systemname, final String codesystem,
 		final String ausgabe, final String... requirements){
-		String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + systemname; //$NON-NLS-1$
+		String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + systemname; //$NON-NLS-1$
 		CoreHub.globalCfg.set(key + "/name", systemname); //$NON-NLS-1$
 		CoreHub.globalCfg.set(key + "/leistungscodes", codesystem); //$NON-NLS-1$
 		CoreHub.globalCfg.set(key + "/standardausgabe", ausgabe); //$NON-NLS-1$
@@ -381,7 +381,7 @@ public class BillingSystem {
 	 * @since 3.6 moved from {@link Fall}
 	 */
 	public static void removeAbrechnungssystem(final String systemName){
-		CoreHub.globalCfg.remove(Preferences.LEISTUNGSCODES_CFG_KEY + "/" + systemName); //$NON-NLS-1$
+		CoreHub.globalCfg.remove(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + systemName); //$NON-NLS-1$
 		CoreHub.globalCfg.flush();
 	}
 	
@@ -392,11 +392,11 @@ public class BillingSystem {
 	 * @since 3.6 moved from {@link Fall}
 	 */
 	public static String getCodeSystem(final String billingSystem){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/leistungscodes", null); //$NON-NLS-1$
 		if (ret == null) { // compatibility
 			BillingSystem.getAbrechnungsSysteme();
-			ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+			ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 				+ billingSystem + "/leistungscodes", "?"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return ret;
@@ -411,11 +411,11 @@ public class BillingSystem {
 	 * @deprecated use {@link ch.elexis.core.services.BillingSystemService#getDefaultPrintSystem)}
 	 */
 	public static String getDefaultPrintSystem(final String billingSystem){
-		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/standardausgabe", null); //$NON-NLS-1$
 		if (ret == null) { // compatibility
 			BillingSystem.getAbrechnungsSysteme();
-			ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+			ret = CoreHub.globalCfg.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 				+ billingSystem + "/standardausgabe", "?"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return ret;
@@ -429,7 +429,7 @@ public class BillingSystem {
 	 */
 	public static String getRequirementsBySystem(String abrechnungsSystem){
 		String req = BillingSystem.getRequirements(abrechnungsSystem);
-		return req == null ? "" : req;
+		return req == null ? StringTool.leer : req;
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Brief.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Brief.java
@@ -101,7 +101,7 @@ public class Brief extends PersistentObject {
 				bhdl = bh.getId();
 				pat = bh.getFall().getPatient().getId();
 			}
-			String dst = "";
+			String dst = StringTool.leer;
 			if (dest != null) {
 				dst = dest.getId();
 			}
@@ -309,7 +309,7 @@ public class Brief extends PersistentObject {
 			
 			@Override
 			public String read(){
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override
@@ -476,7 +476,7 @@ public class Brief extends PersistentObject {
 				byte[] ret = CompEx.expand(raw);
 				return StringTool.createString(ret);
 			}
-			return "";
+			return StringTool.leer;
 		}
 		
 		public void save(String contents){
@@ -485,7 +485,7 @@ public class Brief extends PersistentObject {
 		}
 		
 		public void save(byte[] contents){
-			System.out.println("Setting binary of " + getId() + " " + contents.length);
+			System.out.println("Setting binary of " + getId() + StringTool.space + contents.length);
 			setBinary(CONTENTS, contents);
 		}
 		

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
@@ -120,7 +120,7 @@ public class DBConnection {
 	 * @return
 	 */
 	public boolean directConnect(){
-		String msg = "Connecting to DB using " + dbFlavor + " " + dbConnectString + " " + dbUser;
+		String msg = "Connecting to DB using " + dbFlavor + StringTool.space + dbConnectString + StringTool.space + dbUser;
 		logger.info(msg);
 		
 		if (dbFlavor.equalsIgnoreCase("mysql"))

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/DayMessage.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/DayMessage.java
@@ -16,6 +16,7 @@ package ch.elexis.data;
 
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class DayMessage extends PersistentObject {
 	public boolean isNew = false;
 	static {
@@ -44,7 +45,7 @@ public class DayMessage extends PersistentObject {
 	}
 	
 	public String getLabel(){
-		return get("Date") + " " + getMessage();
+		return get("Date") + StringTool.space + getMessage();
 	}
 	
 	public static DayMessage load(String day){

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Fall.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Fall.java
@@ -162,7 +162,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 		String reqs = BillingSystem.getRequirements(getAbrechnungsSystem());
 		if (reqs != null) {
 			for (String req : reqs.split(";")) { //$NON-NLS-1$
-				String localReq = ""; //$NON-NLS-1$
+				String localReq = StringTool.leer; //$NON-NLS-1$
 				String[] r = req.split(":"); //$NON-NLS-1$
 				if ((r[1].equalsIgnoreCase("X")) && (r.length > 2)) { //$NON-NLS-1$
 					// *** support for additional field types (checkboxes with
@@ -437,7 +437,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 	
 	/** Feststellen, ob der Fall noch offen ist */
 	public boolean isOpen(){
-		if (getEndDatum().equals("")) { //$NON-NLS-1$
+		if (getEndDatum().equals(StringTool.leer)) { //$NON-NLS-1$
 			return true;
 		}
 		return false;
@@ -473,7 +473,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 	
 	public String getRequirements(){
 		String req = BillingSystem.getRequirements(getAbrechnungsSystem());
-		return req == null ? "" : req; //$NON-NLS-1$
+		return req == null ? StringTool.leer : req; //$NON-NLS-1$
 	}
 	
 	/**
@@ -488,7 +488,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 	
 	public String getOptionals(){
 		String req = BillingSystem.getOptionals(getAbrechnungsSystem());
-		return req == null ? "" : req; //$NON-NLS-1$
+		return req == null ? StringTool.leer : req; //$NON-NLS-1$
 	}
 	
 	/**
@@ -504,7 +504,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 	
 	public String getUnused(){
 		String req = BillingSystem.getUnused(getAbrechnungsSystem());
-		return req == null ? "" : req; //$NON-NLS-1$
+		return req == null ? StringTool.leer : req; //$NON-NLS-1$
 	}
 	
 	/**
@@ -674,7 +674,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 			return checkNull((String) extinfo.get(name));
 		log.warn("Invalid object in Fall.getInfoString(" + name + "), not castable to String: "
 			+ extinfo.get(name), new Throwable("Invalid object"));
-		return "";
+		return StringTool.leer;
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -737,7 +737,7 @@ public class Fall extends PersistentObject implements IFall, ITransferable<FallD
 	 */
 	public String getRequirements(final String billingSystem){
 		String req = BillingSystem.getRequirements(getAbrechnungsSystem());
-		return req == null ? "" : req; //$NON-NLS-1$
+		return req == null ? StringTool.leer : req; //$NON-NLS-1$
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Konsultation.java
@@ -302,9 +302,9 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 		String recText = record.getText();
 		if ((pos == -1) || pos > recText.length()) {
 			pos = recText.length();
-			recText += "\n" + text;
+			recText += StringTool.lf + text;
 		} else {
-			recText = recText.substring(0, pos) + "\n" + text + recText.substring(pos);
+			recText = recText.substring(0, pos) + StringTool.lf + text + recText.substring(pos);
 		}
 		record.setText(recText);
 		// ++pos because \n has been added
@@ -646,7 +646,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	}
 	
 	public String getStatusText(){
-		String statusText = "";
+		String statusText = StringTool.leer;
 		
 		Rechnung rechnung = getRechnung();
 		if (rechnung != null) {
@@ -669,7 +669,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	
 	public String getVerboseLabel(){
 		StringBuilder ret = new StringBuilder();
-		ret.append(getFall().getPatient().getName()).append(" ")
+		ret.append(getFall().getPatient().getName()).append(StringTool.space)
 			.append(getFall().getPatient().getVorname()).append(", ")
 			.append(getFall().getPatient().getGeburtsdatum()).append(" - ").append(getDatum());
 		return ret.toString();
@@ -780,7 +780,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 			if (dgid == null) {
 				log.warn(
 					"Requested delete of diagnosis which could not be resolved [{}] in consultation [{}]",
-					dg.getCode() + "/" + dg.getClass().getName(), getId());
+					dg.getCode() + StringTool.slash + dg.getClass().getName(), getId());
 			} else {
 				StringBuilder sql = new StringBuilder();
 				sql.append("DELETE FROM BEHDL_DG_JOINT WHERE BehandlungsID=").append(getWrappedId())
@@ -955,7 +955,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	 * @return Username of the author or an empty string.
 	 */
 	public String getAuthor(){
-		String author = "";
+		String author = StringTool.leer;
 		VersionedResource resource = this.getEintrag();
 		if (resource != null) {
 			ResourceItem item = resource.getVersion(resource.getHeadVersion());
@@ -1232,7 +1232,7 @@ public class Konsultation extends PersistentObject implements Comparable<Konsult
 	
 	public static IDiagnose getDefaultDiagnose(){
 		IDiagnose ret = null;
-		String diagnoseId = CoreHub.userCfg.get(Preferences.USR_DEFDIAGNOSE, "");
+		String diagnoseId = CoreHub.userCfg.get(Preferences.USR_DEFDIAGNOSE, StringTool.leer);
 		if (diagnoseId.length() > 1) {
 			ret = (IDiagnose) CoreHub.poFactory.createFromString(diagnoseId);
 		}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Kontakt.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Kontakt.java
@@ -472,7 +472,7 @@ public class Kontakt extends PersistentObject {
 	 * 
 	 * @param elem
 	 *            Name des Elements
-	 * @return Wert oder "" wenn das Element nicht vorhanden ist oder die Rechte nicht zum Lesen
+	 * @return Wert oder StringTool.leer wenn das Element nicht vorhanden ist oder die Rechte nicht zum Lesen
 	 *         ausreichen
 	 */
 	public String getInfoString(String elem){

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/LabItem.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/LabItem.java
@@ -278,7 +278,7 @@ public class LabItem extends PersistentObject implements Comparable<LabItem>, IL
 			String var = matcher.group();
 			String[] fields = var.split("\\."); //$NON-NLS-1$
 			if (fields.length > 1) {
-				String repl = "\"" + pat.get(fields[1].replaceFirst("\\]", StringTool.leer)) + "\""; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				String repl = StringTool.backslash + pat.get(fields[1].replaceFirst("\\]", StringTool.leer)) + StringTool.backslash; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				// formel=matcher.replaceFirst(repl);
 				matcher.appendReplacement(sb, repl);
 				bMatched = true;
@@ -423,7 +423,7 @@ public class LabItem extends PersistentObject implements Comparable<LabItem>, IL
 		
 		if (formula == null || formula.isEmpty()) {
 			String[] refWEntry = get(REF_FEMALE_OR_TEXT).split("##");
-			formula = refWEntry.length > 1 ? refWEntry[1] : "";
+			formula = refWEntry.length > 1 ? refWEntry[1] : StringTool.leer;
 			
 			if (formula != null && !formula.isEmpty()) {
 				setFormula(formula);
@@ -458,7 +458,7 @@ public class LabItem extends PersistentObject implements Comparable<LabItem>, IL
 		get(fields, vals);
 		sb.append(vals[0]).append(", ").append(vals[1]); //$NON-NLS-1$
 		if (StringConstants.ZERO.equals(vals[5])) {
-			sb.append(" (").append(vals[2]).append("/").append(getRefW()).append(StringTool.space) //$NON-NLS-1$ //$NON-NLS-2$
+			sb.append(" (").append(vals[2]).append(StringTool.slash).append(getRefW()).append(StringTool.space) //$NON-NLS-1$ //$NON-NLS-2$
 				.append(vals[4]).append(")"); //$NON-NLS-1$
 		} else {
 			sb.append(" (").append(getRefW()).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -544,23 +544,23 @@ public class LabItem extends PersistentObject implements Comparable<LabItem>, IL
 		String refW, String unit){
 		Query<LabItem> qbe = new Query<LabItem>(LabItem.class);
 		if (laborId != null && laborId.length() > 0) {
-			qbe.add("LaborID", "=", laborId); //$NON-NLS-1$ //$NON-NLS-2$
+			qbe.add("LaborID", StringTool.equals, laborId); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (shortDesc != null && shortDesc.length() > 0) {
 			// none case sensitive matching for kuerzel
-			qbe.add("kuerzel", "=", shortDesc, true); //$NON-NLS-1$ //$NON-NLS-2$
+			qbe.add("kuerzel", StringTool.equals, shortDesc, true); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (refM != null && refM.length() > 0) {
 			// none case sensitive matching for ref male
-			qbe.add("RefMann", "=", refM, true); //$NON-NLS-1$ //$NON-NLS-2$
+			qbe.add("RefMann", StringTool.equals, refM, true); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (refW != null && refW.length() > 0) {
 			// none case sensitive matching for ref female
-			qbe.add("RefFrauOrTx", "=", refW, true); //$NON-NLS-1$ //$NON-NLS-2$
+			qbe.add("RefFrauOrTx", StringTool.equals, refW, true); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (unit != null && unit.length() > 0) {
 			// none case sensitive matching for unit
-			qbe.add("Einheit", "=", unit, true); //$NON-NLS-1$ //$NON-NLS-2$
+			qbe.add("Einheit", StringTool.equals, unit, true); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return qbe.execute();
 	}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/LabMapping.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/LabMapping.java
@@ -14,6 +14,7 @@ import ch.elexis.core.types.LabItemTyp;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.VersionInfo;
 
+import ch.rgw.tools.StringTool;
 public class LabMapping extends PersistentObject {
 	
 	private static Logger logger = LoggerFactory.getLogger(LabMapping.class);
@@ -255,7 +256,7 @@ public class LabMapping extends PersistentObject {
 				notImported.append(line);
 				notImported.append(" -> "); //$NON-NLS-1$
 				notImported.append(reason);
-				notImported.append("\n"); //$NON-NLS-1$
+				notImported.append(StringTool.lf); //$NON-NLS-1$
 				continue;
 			} else if (parts[0].equalsIgnoreCase("CONTACT_NAME")) { //$NON-NLS-1$
 				// skip description line
@@ -273,7 +274,7 @@ public class LabMapping extends PersistentObject {
 				notImported.append(line);
 				notImported.append(" -> "); //$NON-NLS-1$
 				notImported.append(reason);
-				notImported.append("\n"); //$NON-NLS-1$
+				notImported.append(StringTool.lf); //$NON-NLS-1$
 				continue;
 			} else {
 				labor = origins.get(0);
@@ -288,7 +289,7 @@ public class LabMapping extends PersistentObject {
 			String labItemUnit = parts[7];
 			String labItemTyp = parts[8];
 			String labItemGroup = parts[9];
-			String labItemBillingCode = "";
+			String labItemBillingCode = StringTool.leer;
 			if (parts.length > 10) {
 				labItemBillingCode = parts[10];
 			}
@@ -300,7 +301,7 @@ public class LabMapping extends PersistentObject {
 				notImported.append(line);
 				notImported.append(" -> "); //$NON-NLS-1$
 				notImported.append(reason);
-				notImported.append("\n"); //$NON-NLS-1$
+				notImported.append(StringTool.lf); //$NON-NLS-1$
 				continue;
 			}
 			
@@ -324,7 +325,7 @@ public class LabMapping extends PersistentObject {
 				notImported.append(line);
 				notImported.append(" -> "); //$NON-NLS-1$
 				notImported.append(reason);
-				notImported.append("\n"); //$NON-NLS-1$
+				notImported.append(StringTool.lf); //$NON-NLS-1$
 				continue;
 			} else {
 				labItem = items.get(0);
@@ -396,7 +397,7 @@ public class LabMapping extends PersistentObject {
 		List<LabItem> labItems = null;
 		if (loinc != null && !loinc.isEmpty()) {
 			Query<LabItem> qli = new Query<LabItem>(LabItem.class);
-			qli.add(LabItem.LOINCCODE, "=", loinc.trim()); //$NON-NLS-1$
+			qli.add(LabItem.LOINCCODE, StringTool.equals, loinc.trim()); //$NON-NLS-1$
 			labItems = qli.execute();
 			if (labItems.size() == 1) {
 				return labItems;

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/LabOrder.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/LabOrder.java
@@ -21,6 +21,7 @@ import ch.rgw.tools.JdbcLink.Stm;
 import ch.rgw.tools.TimeTool;
 import ch.rgw.tools.VersionInfo;
 
+import ch.rgw.tools.StringTool;
 public class LabOrder extends PersistentObject implements Comparable<LabOrder>, ILabOrder {
 	
 	public static final String FLD_USER = "userid"; //$NON-NLS-1$
@@ -175,14 +176,14 @@ public class LabOrder extends PersistentObject implements Comparable<LabOrder>, 
 	}
 	
 	public LabResult createResult(){
-		LabResult result = new LabResult(getPatient(), null, getLabItem(), "", null);
+		LabResult result = new LabResult(getPatient(), null, getLabItem(), StringTool.leer, null);
 		result.setObservationTime(getObservationTime());
 		setLabResult(result);
 		return result;
 	}
 	
 	public LabResult createResult(Kontakt origin){
-		LabResult result = new LabResult(getPatient(), null, getLabItem(), "", null, origin);
+		LabResult result = new LabResult(getPatient(), null, getLabItem(), StringTool.leer, null, origin);
 		result.setObservationTime(getObservationTime());
 		setLabResult(result);
 		return result;
@@ -235,7 +236,7 @@ public class LabOrder extends PersistentObject implements Comparable<LabOrder>, 
 		for (Reminder reminder : reminders) {
 			String params = reminder.get(Reminder.FLD_PARAMS);
 			if (params.startsWith(LabOrder.FLD_ORDERID)) {
-				String[] parts = params.split("="); //$NON-NLS-1$
+				String[] parts = params.split(StringTool.equals); //$NON-NLS-1$
 				if (parts.length == 2) {
 					if (parts[1].equals(get(FLD_ORDERID))) {
 						reminder.setStatus(ProcessStatus.CLOSED);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/LabResult.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/LabResult.java
@@ -96,7 +96,7 @@ public class LabResult extends PersistentObject implements ILabResult {
 		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT LW.ID, LW." + OBSERVATIONTIME + ", LW." + DATE + ", LW." + TIME + ", ");
 		sb.append("LI." + LabItem.GROUP + ", LI." + LabItem.SHORTNAME + ", ");
-		sb.append("LW." + PATHODESC + ", LW." + ITEM_ID  + ", LW." + FLAGS + ", LW." + RESULT + " ");
+		sb.append("LW." + PATHODESC + ", LW." + ITEM_ID  + ", LW." + FLAGS + ", LW." + RESULT + StringTool.space);
 		sb.append("FROM " + TABLENAME + " AS LW LEFT JOIN ");
 		sb.append(LabItem.LABITEMS + " AS LI ON LW." + ITEM_ID + "=LI.ID ");
 		sb.append("WHERE LW." + PATIENT_ID + " LIKE ? AND LW.DELETED = '0'");
@@ -419,7 +419,7 @@ public class LabResult extends PersistentObject implements ILabResult {
 	 * @since 3.1
 	 */
 	private static TimeTool translateDateTime(String time, String date){
-		if ((time == null) || ("".equals(time))) //$NON-NLS-1$
+		if ((time == null) || (StringTool.leer.equals(time))) //$NON-NLS-1$
 			time = "000000"; //$NON-NLS-1$
 		while (time.length() < 6) {
 			time += StringConstants.ZERO;
@@ -904,7 +904,7 @@ public class LabResult extends PersistentObject implements ILabResult {
 		if (origin != null && origin.exists()) {
 			set(ORIGIN_ID, origin.getId());
 		} else {
-			set(ORIGIN_ID, ""); //$NON-NLS-1$
+			set(ORIGIN_ID, StringTool.leer); //$NON-NLS-1$
 		}
 	}
 	
@@ -1035,7 +1035,7 @@ public class LabResult extends PersistentObject implements ILabResult {
 	private static String getNotNull(ResultSet set, int index) throws SQLException{
 		String ret = set.getString(index);
 		if (ret == null) {
-			ret = "";
+			ret = StringTool.leer;
 		}
 		return ret;
 	}

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Mandant.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Mandant.java
@@ -24,6 +24,7 @@ import ch.rgw.tools.JdbcLink;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class Mandant extends Anwender {
 	
 	public static final String BILLER = "Rechnungssteller";
@@ -122,7 +123,7 @@ public class Mandant extends Anwender {
 	}
 	
 	public String getMandantLabel(){
-		return getName() + " " + getVorname() + " (" + getLabel() + ")";
+		return getName() + StringTool.space + getVorname() + " (" + getLabel() + ")";
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/NamedBlob.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/NamedBlob.java
@@ -32,6 +32,7 @@ import ch.rgw.tools.TimeTool;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class NamedBlob extends PersistentObject {
 	
 	public static final String TABLENAME = "HEAP";
@@ -69,7 +70,7 @@ public class NamedBlob extends PersistentObject {
 	public String getString(){
 		byte[] comp = getBinary(CONTENTS);
 		if ((comp == null) || (comp.length == 0)) {
-			return "";
+			return StringTool.leer;
 		}
 		byte[] exp = CompEx.expand(comp);
 		try {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/NamedBlob2.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/NamedBlob2.java
@@ -24,6 +24,7 @@ import ch.rgw.tools.TimeTool;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class NamedBlob2 extends PersistentObject {
 	public static final String FLD_DATUM = "Datum";
 	public static final String FLD_CONTENTS = "Contents";
@@ -87,7 +88,7 @@ public class NamedBlob2 extends PersistentObject {
 	public String getString(){
 		byte[] comp = getBinary(FLD_CONTENTS);
 		if ((comp == null) || (comp.length == 0)) {
-			return "";
+			return StringTool.leer;
 		}
 		byte[] exp = CompEx.expand(comp);
 		try {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Organisation.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Organisation.java
@@ -44,7 +44,7 @@ public class Organisation extends Kontakt {
 	static {
 		addMapping(
 			Kontakt.TABLENAME, 
-			FLD_NAME +	"="+	Kontakt.FLD_NAME1,
+			FLD_NAME +	StringTool.equals+	Kontakt.FLD_NAME1,
 			FLD_ZUSATZ1 + 					"=Bezeichnung2", //$NON-NLS-1$
 			FLD_ZUSATZ2 +					"=ExtInfo", //$NON-NLS-1$
 			FLD_CONTACT_PERSON +			"=Bezeichnung3",

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Patient.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Patient.java
@@ -315,7 +315,7 @@ public class Patient extends Person {
 		}
 		
 		if (konsDate != null) {
-			qbe.add("Datum", "=", new TimeTool(konsDate).toString(TimeTool.DATE_COMPACT));
+			qbe.add("Datum", StringTool.equals, new TimeTool(konsDate).toString(TimeTool.DATE_COMPACT));
 		}
 		
 		Fall[] faelle = getFaelle();

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
@@ -174,7 +174,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	
 	/**
 	 * the possible states of a tristate checkbox: true/checked, false/unchecked, undefined/ "filled
-	 * with a square"/"partly selected"
+	 * with a squareStringTool.slashpartly selected"
 	 * 
 	 * @since 3.0.0
 	 */
@@ -207,7 +207,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	 * If the property elexis-run-mode is set to RunFromScratch then the connected database will be
 	 * wiped out and initialized with default values for the mandant (007, topsecret). For mysql and
 	 * postgresql this will only work if the database is empty! Therefore you mus call something
-	 * like ""drop database miniDB; create dabase miniDB;" before starting Elexis.
+	 * like StringTool.leerdrop database miniDB; create dabase miniDB;" before starting Elexis.
 	 * 
 	 * @return true on success
 	 *
@@ -676,7 +676,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	 * @return ein Constraint für eine Select-Abfrage
 	 */
 	protected String getConstraint(){
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -832,7 +832,7 @@ public abstract class PersistentObject implements IPersistentObject {
 		if (res.size() > 0) {
 			return res.get(0).get(Xid.FLD_ID_IN_DOMAIN);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -1134,7 +1134,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			int ix = mapped.indexOf(':', 5);
 			if (ix == -1) {
 				log.error("Fehlerhaftes Mapping bei " + field);
-				return MAPPING_ERROR_MARKER + " " + field + "**";
+				return MAPPING_ERROR_MARKER + StringTool.space + field + "**";
 			}
 			table = mapped.substring(4, ix);
 			mapped = mapped.substring(ix + 1);
@@ -1150,7 +1150,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				PersistentObjectFactory fac = new PersistentObjectFactory();
 				for (String[] s : list) {
 					PersistentObject po = fac.createFromString(objdef + s[0], getDBConnection());
-					sb.append(po.getLabel()).append("\n");
+					sb.append(po.getLabel()).append(StringTool.lf);
 				}
 				return sb.toString();
 			}
@@ -1164,7 +1164,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				PersistentObjectFactory fac = new PersistentObjectFactory();
 				for (String s : list) {
 					PersistentObject po = fac.createFromString(objdef + s, getDBConnection());
-					sb.append(po.getLabel()).append("\n");
+					sb.append(po.getLabel()).append(StringTool.lf);
 				}
 				return sb.toString();
 			}
@@ -1191,7 +1191,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				Method mx = getClass().getMethod(method, new Class[0]);
 				Object ro = mx.invoke(this, new Object[0]);
 				if (ro == null) {
-					return "";
+					return StringTool.leer;
 				} else if (ro instanceof String) {
 					return (String) ro;
 				} else if (ro instanceof Integer) {
@@ -1229,7 +1229,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				}
 				getDBConnection().getCache().put(key, res, getCacheTime());
 				if (res == null) {
-					res = "";
+					res = StringTool.leer;
 				}
 			}
 		} catch (SQLException ex) {
@@ -1438,7 +1438,7 @@ public abstract class PersistentObject implements IPersistentObject {
 		if (newVal == null)
 			throw new IllegalArgumentException(
 				"PersistentObject.setTriStateBoolean(): param newVal == null");
-		String saveVal = "";
+		String saveVal = StringTool.leer;
 		if (newVal == TristateBoolean.TRUE)
 			saveVal = StringConstants.ONE;
 		if (newVal == TristateBoolean.FALSE)
@@ -1500,7 +1500,7 @@ public abstract class PersistentObject implements IPersistentObject {
 						.append(" AND ");
 				}
 				
-				sql.append(m[1]).append("=").append(getWrappedId());
+				sql.append(m[1]).append(StringTool.equals).append(getWrappedId());
 				if (m.length > 3) {
 					sql.append(" ORDER by ").append(m[3]);
 					if (reverse) {
@@ -1544,7 +1544,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			for (String ex : extra) {
 				sql.append(",").append(ex);
 			}
-			sql.append(" FROM ").append(abfr[3]).append(" WHERE ").append(abfr[2]).append("=")
+			sql.append(" FROM ").append(abfr[3]).append(" WHERE ").append(abfr[2]).append(StringTool.equals)
 				.append(getWrappedId());
 			
 			Stm stm = getDBConnection().getStatement();
@@ -1604,7 +1604,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				mapped = mapped.substring(i + 1);
 			}
 			sql.append(mapped);
-			sql.append("=NULL, " + FLD_LASTUPDATE + "=" + Long.toString(ts) + " WHERE ID=")
+			sql.append("=NULL, " + FLD_LASTUPDATE + StringTool.equals + Long.toString(ts) + " WHERE ID=")
 				.append(getWrappedId());
 			getDBConnection().exec(sql.toString());
 			return true;
@@ -1649,7 +1649,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				params.append("[");
 				params.append(value);
 				params.append("]");
-				dbConnection.doTrace(cmd + " " + params);
+				dbConnection.doTrace(cmd + StringTool.space + params);
 			}
 			
 			pst.setLong(2, ts);
@@ -1659,7 +1659,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			return true;
 		} catch (Exception ex) {
 			ElexisStatus status = new ElexisStatus(ElexisStatus.ERROR, CoreHub.PLUGIN_ID,
-				ElexisStatus.CODE_NONE, "Fehler bei: " + cmd + "(" + field + "=" + value + ")", ex,
+				ElexisStatus.CODE_NONE, "Fehler bei: " + cmd + "(" + field + StringTool.equals + value + ")", ex,
 				ElexisStatus.LOG_ERRORS);
 			throw new PersistenceException(status); // See api doc. check this
 													// whether it breaks
@@ -1816,7 +1816,7 @@ public abstract class PersistentObject implements IPersistentObject {
 						.append(getDBConnection().getJdbcLink().wrapFlavored(objectId));
 					if (extra != null) {
 						for (String s : extra) {
-							String[] def = s.split("=");
+							String[] def = s.split(StringTool.equals);
 							if (def.length != 2) {
 								log.error("Fehlerhafter Aufruf addToList " + s);
 								return 0;
@@ -1877,7 +1877,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			// Name Joint
 			if (m.length > 3) {
 				StringBuilder sql = new StringBuilder(200);
-				sql.append("DELETE FROM ").append(m[3]).append(" WHERE ").append(m[2]).append("=")
+				sql.append("DELETE FROM ").append(m[3]).append(" WHERE ").append(m[2]).append(StringTool.equals)
 					.append(getWrappedId());
 				if (dbConnection.isTrace()) {
 					String sq = sql.toString();
@@ -1908,8 +1908,8 @@ public abstract class PersistentObject implements IPersistentObject {
 			//m: m[1] FremdID, m[2] eigene ID, m[3] table
 			if (m.length > 3) {
 				StringBuilder sql = new StringBuilder(200);
-				sql.append("DELETE FROM ").append(m[3]).append(" WHERE ").append(m[2]).append("=")
-					.append(getWrappedId()).append(" AND ").append(m[1]).append("=")
+				sql.append("DELETE FROM ").append(m[3]).append(" WHERE ").append(m[2]).append(StringTool.equals)
+					.append(getWrappedId()).append(" AND ").append(m[1]).append(StringTool.equals)
 					.append(getDBConnection().getJdbcLink().wrapFlavored(oID));
 				if (dbConnection.isTrace()) {
 					String sq = sql.toString();
@@ -2092,7 +2092,7 @@ public abstract class PersistentObject implements IPersistentObject {
 		}
 		String[] m = mapped.split(":");// m[1] FremdID, m[2] eigene ID, m[3]
 		// Name Joint
-		getDBConnection().exec("DELETE FROM " + m[3] + " WHERE " + m[2] + "=" + getWrappedId());
+		getDBConnection().exec("DELETE FROM " + m[3] + " WHERE " + m[2] + StringTool.equals + getWrappedId());
 		return true;
 	}
 	
@@ -2158,7 +2158,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			params.append("[");
 			params.append(StringTool.join(values, ", "));
 			params.append("]");
-			dbConnection.doTrace(cmd + " " + params);
+			dbConnection.doTrace(cmd + StringTool.space + params);
 		}
 		try {
 			pst.setLong(fields.length + 1, System.currentTimeMillis());
@@ -2170,7 +2170,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			StringBuilder sb = new StringBuilder();
 			sb.append("Fehler bei ").append(cmd).append("\nFelder:\n");
 			for (int i = 0; i < fields.length; i++) {
-				sb.append(fields[i]).append("=").append(values[i]).append("\n");
+				sb.append(fields[i]).append(StringTool.equals).append(values[i]).append(StringTool.lf);
 			}
 			ElexisStatus status = new ElexisStatus(ElexisStatus.ERROR, CoreHub.PLUGIN_ID,
 				ElexisStatus.CODE_NONE, sb.toString(), ex, ElexisStatus.LOG_ERRORS);
@@ -2189,7 +2189,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	/**
 	 * @param checkNulls
 	 *            wether the returned values should be <code>null</code> safe, that is no
-	 *            <code>null</code> values, but only ""
+	 *            <code>null</code> values, but only StringTool.leer
 	 * @param fields
 	 * @return array containing the required fields in order
 	 * @since 3.1
@@ -2291,13 +2291,13 @@ public abstract class PersistentObject implements IPersistentObject {
 				case 'D':
 					String dat = rs.getString(mapped.substring(4));
 					if (dat == null) {
-						return "";
+						return StringTool.leer;
 					}
 					TimeTool t = new TimeTool();
 					if (t.set(dat) == true) {
 						return t.toString(TimeTool.DATE_GER);
 					} else {
-						return "";
+						return StringTool.leer;
 					}
 				case 'N':
 					int val = rs.getInt(mapped.substring(4));
@@ -2305,7 +2305,7 @@ public abstract class PersistentObject implements IPersistentObject {
 				case 'C':
 					InputStream is = rs.getBinaryStream(mapped.substring(4));
 					if (is == null) {
-						return "";
+						return StringTool.leer;
 					}
 					byte[] exp = CompEx.expand(is);
 					return exp != null ? StringTool.createString(exp) : null;
@@ -2343,8 +2343,8 @@ public abstract class PersistentObject implements IPersistentObject {
 						ret = t.toString(TimeTool.DATE_COMPACT);
 						pst.setString(num, ret);
 					} else {
-						ret = "";
-						pst.setString(num, "");
+						ret = StringTool.leer;
+						pst.setString(num, StringTool.leer);
 					}
 					
 				} else if (typ.startsWith("C")) { // string enocding
@@ -2556,14 +2556,14 @@ public abstract class PersistentObject implements IPersistentObject {
 	 * 
 	 * @param in
 	 *            name of the field to retrieve
-	 * @return the field contents or "" if it was null
+	 * @return the field contents or StringTool.leer if it was null
 	 */
 	public static String checkNull(final Object in){
 		if (in == null) {
-			return "";
+			return StringTool.leer;
 		}
 		if (!(in instanceof String)) {
-			return "";
+			return StringTool.leer;
 		}
 		return (String) in;
 	}
@@ -2637,7 +2637,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	 * @since 3.1
 	 */
 	public void refreshLastUpdateAndSendUpdateEvent(@Nullable String updatedAttribute){
-		getDBConnection().exec("UPDATE " + getTableName() + " SET " + FLD_LASTUPDATE + "="
+		getDBConnection().exec("UPDATE " + getTableName() + " SET " + FLD_LASTUPDATE + StringTool.equals
 			+ Long.toString(System.currentTimeMillis()) + " WHERE ID=" + getWrappedId());
 		ElexisEventDispatcher.getInstance()
 			.fire(new ElexisEvent(this, getClass(), ElexisEvent.EVENT_UPDATE, updatedAttribute));
@@ -3143,7 +3143,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			// und dort nicht die System-Variable lower_case_table_names nicht
 			// gesetzt ist
 			// Anmerkung von Niklaus Giger
-			log.error("Tabelle " + tableName + " " + nrFounds + "-mal gefunden!!");
+			log.error("Tabelle " + tableName + StringTool.space + nrFounds + "-mal gefunden!!");
 		}
 		return nrFounds == 1;
 	}
@@ -3160,7 +3160,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	 */
 	public static String ts(Object in){
 		if (in == null)
-			return "";
+			return StringTool.leer;
 		if (in instanceof String)
 			return (String) in;
 		if (in instanceof Boolean) {
@@ -3184,7 +3184,7 @@ public abstract class PersistentObject implements IPersistentObject {
 			return (String) inList.stream().map(o -> o.toString())
 				.reduce((u, t) -> u + StringConstants.COMMA + t).get();
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -3200,7 +3200,7 @@ public abstract class PersistentObject implements IPersistentObject {
 	public void putInCache(String field, Object value){
 		String key = getKey(field);
 		if (value == null)
-			value = "";
+			value = StringTool.leer;
 		getDBConnection().getCache().put(key, value, getCacheTime());
 	}
 	

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectUtil.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectUtil.java
@@ -20,6 +20,7 @@ import ch.rgw.tools.TimeTool;
  * @since 3.8
  * @author Niklaus Giger <niklaus.giger@member.fsf.org>
  */
+import ch.rgw.tools.StringTool;
 class PersistentObjectUtil {
 
 	/**
@@ -56,9 +57,9 @@ class PersistentObjectUtil {
 					"0061 555 55 55", //$NON-NLS-1$
 					"0061 555 55 56", "10, Baker Street", "9999", "Elexikon"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		} else {
-			String firstMandantName = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_NAME, ""); //$NON-NLS-1$
-			String firstMandantEmail = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_EMAIL, ""); //$NON-NLS-1$
-			String firstMandantPassword = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_PASSWORD, ""); //$NON-NLS-1$
+			String firstMandantName = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_NAME, StringTool.leer); //$NON-NLS-1$
+			String firstMandantEmail = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_EMAIL, StringTool.leer); //$NON-NLS-1$
+			String firstMandantPassword = System.getProperty(ElexisSystemPropertyConstants.FIRST_MANDANT_PASSWORD, StringTool.leer); //$NON-NLS-1$
 			// The FirstMandantDialog requires
 			// * a name
 			// * a password

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Person.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Person.java
@@ -40,7 +40,7 @@ public class Person extends Kontakt {
 	public static final String FEMALE = "w"; //$NON-NLS-1$
 	
 	static {
-		addMapping(Kontakt.TABLENAME, NAME + "=" + Kontakt.FLD_NAME1, FIRSTNAME + "="
+		addMapping(Kontakt.TABLENAME, NAME + StringTool.equals + Kontakt.FLD_NAME1, FIRSTNAME + StringTool.equals
 			+ Kontakt.FLD_NAME2, "Zusatz 		=" + Kontakt.FLD_NAME3,
 			BIRTHDATE + "=	S:D:Geburtsdatum", SEX, MOBILE + "=NatelNr", //$NON-NLS-1$ //$NON-NLS-2$
 			Kontakt.FLD_IS_PERSON, TITLE, FLD_TITLE_SUFFIX);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Plz.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Plz.java
@@ -46,7 +46,7 @@ public class Plz extends PersistentObject {
 			"Plz", "Ort", "Kanton"
 		}, f);
 		StringBuilder ret = new StringBuilder();
-		ret.append(f[0]).append(" ").append(f[1]).append(" ").append(f[2]);
+		ret.append(f[0]).append(StringTool.space).append(f[1]).append(StringTool.space).append(f[2]);
 		return ret.toString();
 	}
 	

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Prescription.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Prescription.java
@@ -168,7 +168,7 @@ public class Prescription extends PersistentObject {
 			TimeTool timetool = new TimeTool(timestamp);
 			return timetool.toString(TimeTool.DATE_GER);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	public String getBeginTime(){
@@ -177,7 +177,7 @@ public class Prescription extends PersistentObject {
 			TimeTool timetool = new TimeTool(timestamp);
 			return timetool.toString(TimeTool.FULL_GER);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	public void setEndDate(String date){
@@ -194,7 +194,7 @@ public class Prescription extends PersistentObject {
 			TimeTool timetool = new TimeTool(timestamp);
 			return timetool.toString(TimeTool.DATE_GER);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	public String getEndTime(){
@@ -203,12 +203,12 @@ public class Prescription extends PersistentObject {
 			TimeTool timetool = new TimeTool(timestamp);
 			return timetool.toString(TimeTool.FULL_GER);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override
 	public String getLabel(){
-		return getSimpleLabel() + " " + getDosis();
+		return getSimpleLabel() + StringTool.space + getDosis();
 	}
 	
 	public String getSimpleLabel(){
@@ -274,7 +274,7 @@ public class Prescription extends PersistentObject {
 			// Match stuff like '1/2', '7/8', '~1,2'
 			// System.out.println(dosis.matches(special_num_at_start));
 			if (dosis.matches(special_num_at_start))  {
-				list.add(getNum(dosis.replace("~", "")));
+				list.add(getNum(dosis.replace("~", StringTool.leer)));
 			} else if (dosis.matches("[0-9½¼]+([xX][0-9]+(/[0-9]+)?|)")) { //$NON-NLS-1$
 				String[] dose = dosis.split("[xX]"); //$NON-NLS-1$
 				float count = getNum(dose[0]);
@@ -289,8 +289,8 @@ public class Prescription extends PersistentObject {
 			    {
 					return sub_list;
 			    }
-				sub_list = getDoseAsFloats(dosis, "/");
-			    if (StringUtils.countMatches(dosis, "/") > 1 && sub_list.size() > 0)
+				sub_list = getDoseAsFloats(dosis, StringTool.slash);
+			    if (StringUtils.countMatches(dosis, StringTool.slash) > 1 && sub_list.size() > 0)
 			    {
 					return sub_list;
 			    }
@@ -344,7 +344,7 @@ public class Prescription extends PersistentObject {
 	/**
 	 * 
 	 * @return the signature split into a string array with 4 elements; will always return an array
-	 *         of 4 elements, where empty entries are of type String ""
+	 *         of 4 elements, where empty entries are of type String StringTool.leer
 	 * @since 3.1.0
 	 * @since 3.2.0 relocated to {@link Methods#getSignatureAsStringArray(String)}
 	 */
@@ -561,7 +561,7 @@ public class Prescription extends PersistentObject {
 			}
 			// matching for values like 2x1, 2,5x1 or 20x1
 			else if (n.toLowerCase().matches("^[0-9][,.]*[0-9]*x[0-9][,.]*[0-9]*$")) {
-				n = n.replace("\\s", "");
+				n = n.replace("\\s", StringTool.leer);
 				String[] nums = n.toLowerCase().split("x");
 				float num1 = Float.parseFloat(nums[0].replace(",", "."));
 				float num2 = Float.parseFloat(nums[1].replace(",", "."));
@@ -575,7 +575,7 @@ public class Prescription extends PersistentObject {
 			// any other digit-letter combination. replaces comma with dot and removes all non-digit chars. i.e. 1,5 p. Day becomes 1.5
 			else {
 				n = n.replace(",", ".");
-				n = n.replaceAll("[^\\d.]", "");
+				n = n.replaceAll("[^\\d.]", StringTool.leer);
 				if (n.endsWith(".")) {
 					n = n.substring(0, n.length() - 1);
 				}
@@ -693,7 +693,7 @@ public class Prescription extends PersistentObject {
 			// this is necessary due to a past impl. where self dispensed was not set as entry type
 			if (rezeptId.equals(Prescription.FLD_REZEPTID_VAL_DIREKTABGABE)) {
 				setEntryType(EntryType.SELF_DISPENSED);
-				set(FLD_REZEPT_ID, "");
+				set(FLD_REZEPT_ID, StringTool.leer);
 				return EntryType.SELF_DISPENSED;
 			}
 			setEntryType(EntryType.RECIPE);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Query.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Query.java
@@ -51,7 +51,7 @@ import ch.rgw.tools.TimeTool;
 public class Query<T> {
 	private static Logger log = LoggerFactory.getLogger(Query.class);
 	
-	public static final String EQUALS = "=";
+	public static final String EQUALS = StringTool.equals;
 	public static final String GREATER = ">";
 	public static final String LESS = "<";
 	public static final String LESS_OR_EQUAL = "<=";
@@ -66,7 +66,7 @@ public class Query<T> {
 	private StringBuilder sql;
 	private PersistentObject template;
 	private Method load;
-	private String lastQuery = "";
+	private String lastQuery = StringTool.leer;
 	private final LinkedList<IFilter> postQueryFilters = new LinkedList<IFilter>();
 	private String ordering;
 	private final ArrayList<String> exttables = new ArrayList<String>(2);
@@ -269,7 +269,7 @@ public class Query<T> {
 		sql.append(" FROM ").append(table);
 		
 		String cns = template.getConstraint();
-		if (cns.equals("")) {
+		if (cns.equals(StringTool.leer)) {
 			if (includeDeletedEntriesInQuery) {
 				link = " WHERE ";
 			} else {
@@ -346,7 +346,7 @@ public class Query<T> {
 	 * @param feld
 	 *            Das Feld, für das die Bedingung gilt
 	 * @param operator
-	 *            Vergleich (z.B. "=", "LIKE", ">", "<")
+	 *            Vergleich (z.B. StringTool.equals, "LIKE", ">", "<")
 	 * @param wert
 	 *            Der Wert, der gesucht wird. Für Wildcard suche kann der Wert % enthalten, der
 	 *            Operator muss dann aber "LIKE" sein.
@@ -369,7 +369,7 @@ public class Query<T> {
 			wert = (wert == null) ? StringConstants.EMPTY : wert;
 			if (operator.equalsIgnoreCase("LIKE") && !wert.matches("[0-9]{8,8}")) {
 				StringBuilder sb = null;
-				wert = wert.replaceAll("%", "");
+				wert = wert.replaceAll("%", StringTool.leer);
 				final String filler = "%%%%%%%%";
 				// are we looking for the year?
 				if (wert.matches("[0-9]{3,}")) {
@@ -381,7 +381,7 @@ public class Query<T> {
 					// as in 01.02.1932
 					wert = wert.replaceAll("[^0-9]([0-9])\\.", "0$1.");
 					// remove dots
-					sb = new StringBuilder(wert.replaceAll("\\.", ""));
+					sb = new StringBuilder(wert.replaceAll("\\.", StringTool.leer));
 					// String must consist of 8 or more digits (ddmmYYYY)
 					sb.append(filler);
 					// convert to YYYYmmdd format
@@ -426,9 +426,9 @@ public class Query<T> {
 		}
 		
 		if (wert == null) {
-			if (operator.equalsIgnoreCase("is") || operator.equals("=")) {
+			if (operator.equalsIgnoreCase("is") || operator.equals(StringTool.equals)) {
 				// let's be a bit fault tolerant
-				operator = "";
+				operator = StringTool.leer;
 			} else if(NOT_EQUAL.equalsIgnoreCase(operator)){
 				operator = "NOT";
 			}
@@ -509,7 +509,7 @@ public class Query<T> {
 	 *            Die Felder, die in die abfrage eingesetzt werden sollen
 	 * @param values
 	 *            die Werte, nach denen gesucht werden soll. Wenn values für ein Feld leer ist (null
-	 *            oder ""), dann wird dieses Feld aus der Abfrage weggelassen
+	 *            oder StringTool.leer), dann wird dieses Feld aus der Abfrage weggelassen
 	 * @param exact
 	 *            false, wenn die Abfrage mit LIKE erfolgen soll, sonst mit =
 	 * @return eine Liste mit den gefundenen Objekten

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Rechnung.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Rechnung.java
@@ -144,7 +144,7 @@ public class Rechnung extends PersistentObject {
 							+ pat.getVorname()
 							+ ", "
 							+ pat.getGeburtsdatum()
-							+ "\n"
+							+ StringTool.lf
 							+ "fehlte das Häkchen für 'Person' in der Kontaktdatenbank.\n\nIch korrigiere das selbst.");
 				pat.set(Kontakt.FLD_IS_PERSON, StringConstants.ONE);
 			}
@@ -166,7 +166,7 @@ public class Rechnung extends PersistentObject {
 						String msg =
 							"Eine Konsultation vom " + b.getDatum().toString()
 								+ " für\nPatient Nr. " + pat.getPatCode() + ", " + pat.getName()
-								+ ", " + pat.getVorname() + ", " + pat.getGeburtsdatum() + "\n"
+								+ ", " + pat.getVorname() + ", " + pat.getGeburtsdatum() + StringTool.lf
 								+ "enthält mindestens eine Leistung zum Preis 0.00.\n"
 								+ "\nDie Ärztekasse würde so eine Rechnung zurückgeben.\n\n";
 						if (cod.openQuestion("WARNUNG: Leistung zu Fr. 0.00 !", msg
@@ -386,7 +386,7 @@ public class Rechnung extends PersistentObject {
 	/** Eine Liste aller Konsultationen dieser Rechnung holen */
 	public List<Konsultation> getKonsultationen(){
 		Query<Konsultation> qbe = new Query<Konsultation>(Konsultation.class);
-		qbe.add("RechnungsID", "=", getId());
+		qbe.add("RechnungsID", StringTool.equals, getId());
 		qbe.orderBy(false, new String[] {
 			"Datum"
 		});
@@ -929,10 +929,10 @@ public class Rechnung extends PersistentObject {
 		String[] vals = get(true, CASE_ID, BILL_NUMBER, BILL_DATE, BILL_AMOUNT_CENTS);
 		
 		StringBuilder sb = new StringBuilder();
-		sb.append(vals[1]).append(" ").append(vals[2]);
+		sb.append(vals[1]).append(StringTool.space).append(vals[2]);
 		Fall fall = Fall.load(vals[0]);
 		if ((fall != null) && fall.exists()) {
-			sb.append(": ").append(fall.getPatient().getLabel()).append(" ");
+			sb.append(": ").append(fall.getPatient().getLabel()).append(StringTool.space);
 		}
 		int value = checkZero(vals[3]);
 		sb.append(new Money(value));

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Reminder.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Reminder.java
@@ -104,7 +104,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 			} else if (text.equals(LASTNAME.toString())) {
 				return Kontakt.FLD_NAME1;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 	}
@@ -209,7 +209,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 		
 		StringBuilder sb = new StringBuilder();
 		if (vals[1].length() > 0) {
-			sb.append(vals[1] + " ");
+			sb.append(vals[1] + StringTool.space);
 		}
 		sb.append("(" + getConfiguredKontaktLabel(k, isPatientRelatedReminder) + "): ");
 		sb.append((vals[3].length() > 1) ? vals[3] : vals[2]);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Rezept.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Rezept.java
@@ -109,7 +109,7 @@ public class Rezept extends PersistentObject {
 		if (m == null) {
 			return getDate() + " (unbekannt)";
 		}
-		return getDate() + " " + m.getLabel();
+		return getDate() + StringTool.space + m.getLabel();
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Script.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Script.java
@@ -175,7 +175,7 @@ public class Script extends NamedBlob2 {
 						repl = repl.replace('\"', ' ');
 						repl = repl.replace('\n', ' ');
 						repl = repl.replace('\r', ' ');
-						matcher.appendReplacement(sb, "\"" + repl + "\"");
+						matcher.appendReplacement(sb, StringTool.backslash + repl + StringTool.backslash);
 						bMatched = true;
 					}
 				}
@@ -230,7 +230,7 @@ public class Script extends NamedBlob2 {
 				String[] parameters = params.split("\\s*,\\s*");
 				for (int i = 0; i < parameters.length; i++) {
 					String parm = parameters[i].trim();
-					String[] p = parm.split("=");
+					String[] p = parm.split(StringTool.equals);
 					if (p.length == 2) {
 						script = script.replaceAll("\\" + p[0], p[1]);
 					} else {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Trace.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Trace.java
@@ -13,6 +13,7 @@ import ch.rgw.tools.net.NetTool;
 /**
  * Trace actions done in the system by a user.
  */
+import ch.rgw.tools.StringTool;
 public class Trace {
 	
 	public static final String TABLENAME = "traces";
@@ -32,7 +33,7 @@ public class Trace {
 		}
 		String _workstation = (StringUtils.isEmpty(workstation)) ? "unknown"
 				: StringUtils.abbreviate(workstation, 40);
-		String _action = (StringUtils.isEmpty(action)) ? "" : action;
+		String _action = (StringUtils.isEmpty(action)) ? StringTool.leer : action;
 		
 		JdbcLink connection = PersistentObject.getConnection();
 		

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/VerrechenbarFavorites.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/VerrechenbarFavorites.java
@@ -15,6 +15,7 @@ import ch.elexis.core.data.events.ElexisEventListenerImpl;
 import ch.elexis.core.jdt.Nullable;
 import ch.elexis.core.data.interfaces.IPersistentObject;
 
+import ch.rgw.tools.StringTool;
 public class VerrechenbarFavorites {
 	
 	public static final String USER_CFG_FAVORITES = "verrechenbar/favoriten";
@@ -42,7 +43,7 @@ public class VerrechenbarFavorites {
 		if (favorites == null) {
 			favorites = new ArrayList<VerrechenbarFavorites.Favorite>();
 			
-			String favs = CoreHub.userCfg.get(USER_CFG_FAVORITES, "");
+			String favs = CoreHub.userCfg.get(USER_CFG_FAVORITES, StringTool.leer);
 			String[] entries = favs.split(";");
 			for (int i = 0; i < entries.length; i++) {
 				String entry = entries[i];
@@ -88,7 +89,7 @@ public class VerrechenbarFavorites {
 			} else {
 				storeToString = po.storeToString();
 			}
-			VerrechenbarFavorites.getFavorites().add(new Favorite(storeToString, "", 0));
+			VerrechenbarFavorites.getFavorites().add(new Favorite(storeToString, StringTool.leer, 0));
 		} else {
 			if (fav == null)
 				return;
@@ -106,7 +107,7 @@ public class VerrechenbarFavorites {
 	 */
 	public static Favorite isFavorite(IPersistentObject po){
 		for (Favorite favorite : getFavorites()) {
-			String comparator = "";
+			String comparator = StringTool.leer;
 			if (po instanceof Leistungsblock) {
 				comparator =
 					Leistungsblock.class.getName() + StringConstants.DOUBLECOLON + po.getId();

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/XML2Database.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/XML2Database.java
@@ -43,6 +43,7 @@ import ch.rgw.tools.Log;
  * </ARTIKEL> <br>
  * 
  */
+import ch.rgw.tools.StringTool;
 public class XML2Database {
 	// TODO -> to delete?
 	protected static Log log = Log.get(XML2Database.class.getName());
@@ -92,7 +93,7 @@ public class XML2Database {
 		private void writeCloseSign(boolean newLine){
 			buffer.append(">");
 			if (newLine) {
-				buffer.append("\n");
+				buffer.append(StringTool.lf);
 			}
 			elementOpened = false;
 		}
@@ -117,9 +118,9 @@ public class XML2Database {
 		
 		private void addAttribute(final String attribute, final String value){
 			if (elementOpened) {
-				buffer.append(" " + attribute + "=\"" + value + "\"");
+				buffer.append(StringTool.space + attribute + "=\"" + value + StringTool.backslash);
 			} else {
-				throw new IllegalAddException("");
+				throw new IllegalAddException(StringTool.leer);
 			}
 		}
 		
@@ -204,7 +205,7 @@ public class XML2Database {
 				tableNode.getAttributes().getNamedItem(CLASS_ATTRIBUTE).getNodeValue();
 			Class javaClass = Class.forName(className);
 			String uidValue = null;
-			String uidVersion = "";
+			String uidVersion = StringTool.leer;
 			
 			// Read fields
 			List<DataField> fieldList = new Vector<DataField>();

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Xid.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Xid.java
@@ -54,6 +54,7 @@ import ch.rgw.tools.VersionInfo;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class Xid extends PersistentObject implements IXid {
 	
 	public static final String FLD_OBJECT = "object";
@@ -107,7 +108,7 @@ public class Xid extends PersistentObject implements IXid {
 				if (spl.length < 2) {
 					log.log("Fehler in XID-Domain " + dom, Log.ERRORS);
 				}
-				String simpleName = "";
+				String simpleName = StringTool.leer;
 				if (spl.length >= 3) {
 					simpleName = spl[2];
 				}
@@ -333,7 +334,7 @@ public class Xid extends PersistentObject implements IXid {
 			if (domain.matches(".*[;#].*")) {
 				log.log("XID Domain " + domain + " ungültig", Log.ERRORS);
 			} else {
-				domains.put(domain, new XIDDomain(domain, simpleName == null ? "" : simpleName,
+				domains.put(domain, new XIDDomain(domain, simpleName == null ? StringTool.leer : simpleName,
 					quality, "Kontakt"));
 				if (simpleName != null) {
 					domainMap.put(simpleName, domain);

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/CodeElementDTO.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/CodeElementDTO.java
@@ -2,6 +2,7 @@ package ch.elexis.data.dto;
 
 import ch.elexis.core.data.interfaces.ICodeElement;
 
+import ch.rgw.tools.StringTool;
 public class CodeElementDTO implements ICodeElement {
 	
 	private String codeSystemName;
@@ -55,6 +56,6 @@ public class CodeElementDTO implements ICodeElement {
 	
 	@Override
 	public String toString(){
-		return this.codeSystemName + " (" + this.code + ") " + (text != null ? text : "");
+		return this.codeSystemName + " (" + this.code + ") " + (text != null ? text : StringTool.leer);
 	}
 }

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/FallDTO.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/FallDTO.java
@@ -16,6 +16,7 @@ import ch.elexis.data.Patient;
 import ch.elexis.data.PersistentObject;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class FallDTO implements IFall {
 	private final IFall iFall; // source
 	
@@ -142,7 +143,7 @@ public class FallDTO implements IFall {
 		if (value instanceof String) {
 			return (String) value;
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/InvoiceHistoryEntryDTO.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/InvoiceHistoryEntryDTO.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import ch.elexis.core.data.interfaces.IFall;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceHistoryEntryDTO {
 	Object base;
 	Object item;
@@ -247,6 +248,6 @@ public class InvoiceHistoryEntryDTO {
 			return leistungDTOs.stream().map(item -> item.getText())
 				.collect(Collectors.joining(", "));
 		}
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/ZusatzAdresseDTO.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/dto/ZusatzAdresseDTO.java
@@ -3,16 +3,17 @@ package ch.elexis.data.dto;
 
 import ch.elexis.core.types.AddressType;
 
+import ch.rgw.tools.StringTool;
 public class ZusatzAdresseDTO {
-	private String id = "";
-	private String kontaktId = "";
-	private String street1 = "";
-	private String street2 = "";
+	private String id = StringTool.leer;
+	private String kontaktId = StringTool.leer;
+	private String street1 = StringTool.leer;
+	private String street2 = StringTool.leer;
 	private AddressType addressType = AddressType.PRINCIPAL_RESIDENCE;
-	private String place = "";
-	private String zip = "";
-	private String country = "";
-	private String postalAddress = "";
+	private String place = StringTool.leer;
+	private String zip = StringTool.leer;
+	private String country = StringTool.leer;
+	private String postalAddress = StringTool.leer;
 	
 	public void setId(String id){
 		this.id = id;

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7Reader.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7Reader.java
@@ -82,7 +82,7 @@ public abstract class HL7Reader {
 				.append(":\n")
 				.append(Messages.HL7_Lab).append(lastName).append(StringTool.space)
 				.append(firstName).append("(").append(sex).append("),").append(birthDate)
-				.append("\n").append(Messages.HL7_Database).append(pat.getLabel());
+				.append(StringTool.lf).append(Messages.HL7_Database).append(pat.getLabel());
 			pat = null;
 			logger.warn(sb.toString());
 			
@@ -118,8 +118,8 @@ public abstract class HL7Reader {
 	
 	public String parseTextValue(String value){
 		String text = value;
-		text = text.replaceAll("\\\\.br\\\\", "\n");
-		text = text.replaceAll("\\\\.BR\\\\", "\n");
+		text = text.replaceAll("\\\\.br\\\\", StringTool.lf);
+		text = text.replaceAll("\\\\.BR\\\\", StringTool.lf);
 		
 		// only return parsed value if it contains reasonable input
 		if (text != null && !text.isEmpty()) {
@@ -180,7 +180,7 @@ public abstract class HL7Reader {
 			if (name2 != null) {
 				orcMessage.getNames().add(name2);
 				if (name != null) {
-					orcMessage.getNames().add(name + " " + name2);
+					orcMessage.getNames().add(name + StringTool.space + name2);
 				}
 			}
 		}

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7ReaderFactory.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7ReaderFactory.java
@@ -34,6 +34,7 @@ import ch.elexis.hl7.v2x.HL7ReaderV25;
 import ch.elexis.hl7.v2x.HL7ReaderV251;
 import ch.elexis.hl7.v2x.HL7ReaderV26;
 
+import ch.rgw.tools.StringTool;
 public enum HL7ReaderFactory {
 		
 		INSTANCE;
@@ -127,7 +128,7 @@ public enum HL7ReaderFactory {
 		String separator = "\r";
 		String[] splitted = hl7Message.split(separator);
 		if (splitted.length < 2) {
-			separator = "\n";
+			separator = StringTool.lf;
 			splitted = hl7Message.split(separator);
 		}
 		

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7Writer.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/HL7Writer.java
@@ -13,15 +13,16 @@ import ch.elexis.hl7.data.HL7Mandant;
 import ch.elexis.hl7.data.HL7Patient;
 import ch.elexis.hl7.util.HL7Helper;
 
+import ch.rgw.tools.StringTool;
 public abstract class HL7Writer {
 	List<String> errorList = new Vector<String>();
 	List<String> warnList = new Vector<String>();
 	
-	protected String sendingApplication1 = ""; //$NON-NLS-1$
-	protected String sendingApplication3 = ""; //$NON-NLS-1$
-	protected String receivingApplication1 = ""; //$NON-NLS-1$
-	protected String receivingApplication3 = ""; //$NON-NLS-1$
-	protected String receivingFacility = ""; //$NON-NLS-1$
+	protected String sendingApplication1 = StringTool.leer; //$NON-NLS-1$
+	protected String sendingApplication3 = StringTool.leer; //$NON-NLS-1$
+	protected String receivingApplication1 = StringTool.leer; //$NON-NLS-1$
+	protected String receivingApplication3 = StringTool.leer; //$NON-NLS-1$
+	protected String receivingFacility = StringTool.leer; //$NON-NLS-1$
 	
 	static {
 		System.setProperty(WithdrawnDatatypeRule.PROP_DISABLE_RULE, "true");
@@ -108,7 +109,7 @@ public abstract class HL7Writer {
 		// in der Verantwortung des jeweiligen Systemadministrators. Nimm diesen Text: CHELEXIS
 		msh.getMsh3_SendingApplication().getHd1_NamespaceID().setValue(this.sendingApplication1); //$NON-NLS-1$
 		if (this.sendingApplication3 != null) {
-			msh.getMsh3_SendingApplication().getHd2_UniversalID().setValue(""); //$NON-NLS-1$
+			msh.getMsh3_SendingApplication().getHd2_UniversalID().setValue(StringTool.leer); //$NON-NLS-1$
 			msh.getMsh3_SendingApplication().getHd3_UniversalIDType()
 				.setValue(this.sendingApplication3); //$NON-NLS-1$
 		}
@@ -123,7 +124,7 @@ public abstract class HL7Writer {
 		msh.getMsh5_ReceivingApplication().getHd1_NamespaceID()
 			.setValue(this.receivingApplication1);
 		if (this.receivingApplication3 != null) {
-			msh.getMsh5_ReceivingApplication().getHd2_UniversalID().setValue(""); //$NON-NLS-1$
+			msh.getMsh5_ReceivingApplication().getHd2_UniversalID().setValue(StringTool.leer); //$NON-NLS-1$
 			msh.getMsh5_ReceivingApplication().getHd3_UniversalIDType()
 				.setValue(this.receivingApplication3); //$NON-NLS-1$
 		}
@@ -132,10 +133,10 @@ public abstract class HL7Writer {
 		// MSH-6: PRAXIS
 		msh.getMsh6_ReceivingFacility().getHd1_NamespaceID().setValue(this.receivingFacility);
 		msh.getMsh7_DateTimeOfMessage().setValue(HL7Helper.dateToString(new Date()));
-		msh.getMsh8_Security().setValue(""); //$NON-NLS-1$
+		msh.getMsh8_Security().setValue(StringTool.leer); //$NON-NLS-1$
 		msh.getMsh9_MessageType().getMessageCode().setValue(messageId);
 		msh.getMsh9_MessageType().getTriggerEvent().setValue(event);
-		msh.getMsh9_MessageType().getMessageStructure().setValue(""); //$NON-NLS-1$
+		msh.getMsh9_MessageType().getMessageStructure().setValue(StringTool.leer); //$NON-NLS-1$
 		// Eindeutige Nachrichtennummer: GUID
 		if (uniqueMessageControlID != null) {
 			msh.getMsh10_MessageControlID().setValue(uniqueMessageControlID);
@@ -161,7 +162,7 @@ public abstract class HL7Writer {
 		// in der Verantwortung des jeweiligen Systemadministrators. Nimm diesen Text: CHELEXIS
 		msh.getMsh3_SendingApplication().getHd1_NamespaceID().setValue(this.sendingApplication1); //$NON-NLS-1$
 		if (this.sendingApplication3 != null) {
-			msh.getMsh3_SendingApplication().getHd2_UniversalID().setValue(""); //$NON-NLS-1$
+			msh.getMsh3_SendingApplication().getHd2_UniversalID().setValue(StringTool.leer); //$NON-NLS-1$
 			msh.getMsh3_SendingApplication().getHd3_UniversalIDType()
 				.setValue(this.sendingApplication3); //$NON-NLS-1$
 		}
@@ -176,7 +177,7 @@ public abstract class HL7Writer {
 		msh.getMsh5_ReceivingApplication().getHd1_NamespaceID()
 			.setValue(this.receivingApplication1);
 		if (this.receivingApplication3 != null) {
-			msh.getMsh5_ReceivingApplication().getHd2_UniversalID().setValue(""); //$NON-NLS-1$
+			msh.getMsh5_ReceivingApplication().getHd2_UniversalID().setValue(StringTool.leer); //$NON-NLS-1$
 			msh.getMsh5_ReceivingApplication().getHd3_UniversalIDType()
 				.setValue(this.receivingApplication3); //$NON-NLS-1$
 		}
@@ -186,10 +187,10 @@ public abstract class HL7Writer {
 		msh.getMsh6_ReceivingFacility().getHd1_NamespaceID().setValue(this.receivingFacility);
 		msh.getMsh7_DateTimeOfMessage().getTs1_TimeOfAnEvent()
 			.setValue(HL7Helper.dateToString(new Date()));
-		msh.getMsh8_Security().setValue(""); //$NON-NLS-1$
+		msh.getMsh8_Security().setValue(StringTool.leer); //$NON-NLS-1$
 		msh.getMsh9_MessageType().getMessageType().setValue(messageId);
 		msh.getMsh9_MessageType().getTriggerEvent().setValue(event);
-		msh.getMsh9_MessageType().getMessageStructure().setValue(""); //$NON-NLS-1$
+		msh.getMsh9_MessageType().getMessageStructure().setValue(StringTool.leer); //$NON-NLS-1$
 		// Eindeutige Nachrichtennummer: GUID
 		if (uniqueMessageControlID != null) {
 			msh.getMsh10_MessageControlID().setValue(uniqueMessageControlID);
@@ -210,7 +211,7 @@ public abstract class HL7Writer {
 	protected void fillPID(final ca.uhn.hl7v2.model.v26.segment.PID pid, final HL7Patient patient)
 		throws DataTypeException,
 		HL7Exception{
-		String sex = ""; //$NON-NLS-1$
+		String sex = StringTool.leer; //$NON-NLS-1$
 		if (patient.isMale() != null) {
 			sex = "M"; //$NON-NLS-1$
 			if (!patient.isMale().booleanValue()) {
@@ -222,14 +223,14 @@ public abstract class HL7Writer {
 		pid.getPid3_PatientIdentifierList(0).getIDNumber().setValue(patient.getPatCode());
 		pid.getPid4_AlternatePatientIDPID(0).getIDNumber().setValue(patient.getPatCode());
 		addKontaktToXPN(pid.getPid5_PatientName(0), patient);
-		pid.getPid16_MaritalStatus().getCwe1_Identifier().setValue(""); //$NON-NLS-1$
+		pid.getPid16_MaritalStatus().getCwe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 		pid.getPid7_DateTimeOfBirth().setValue(HL7Helper.dateToString(patient.getBirthdate()));
 		
 		pid.getPid8_AdministrativeSex().setValue(sex);
-		pid.getPid9_PatientAlias(0).getXpn1_FamilyName().getFn1_Surname().setValue(""); //$NON-NLS-1$
-		pid.getPid10_Race(0).getCwe1_Identifier().setValue(""); //$NON-NLS-1$
+		pid.getPid9_PatientAlias(0).getXpn1_FamilyName().getFn1_Surname().setValue(StringTool.leer); //$NON-NLS-1$
+		pid.getPid10_Race(0).getCwe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 		addAddressToXAD(pid.getPid11_PatientAddress(0), patient);
-		pid.getPid12_CountyCode().setValue(""); //$NON-NLS-1$
+		pid.getPid12_CountyCode().setValue(StringTool.leer); //$NON-NLS-1$
 		addPhone1ToXTN(pid.getPid13_PhoneNumberHome(0), patient);
 		addPhone2ToXTN(pid.getPid14_PhoneNumberBusiness(0), patient);
 	}
@@ -244,7 +245,7 @@ public abstract class HL7Writer {
 	 */
 	protected void fillPID(final ca.uhn.hl7v2.model.v231.segment.PID pid, final HL7Patient patient)
 		throws DataTypeException, HL7Exception{
-		String sex = ""; //$NON-NLS-1$
+		String sex = StringTool.leer; //$NON-NLS-1$
 		if (patient.isMale() != null) {
 			sex = "M"; //$NON-NLS-1$
 			if (!patient.isMale().booleanValue()) {
@@ -256,15 +257,15 @@ public abstract class HL7Writer {
 		pid.getPid3_PatientIdentifierList(0).getID().setValue(patient.getPatCode());
 		pid.getPid4_AlternatePatientIDPID(0).getID().setValue(patient.getPatCode());
 		addKontaktToXPN(pid.getPid5_PatientName(0), patient);
-		pid.getPid16_MaritalStatus().getCe1_Identifier().setValue(""); //$NON-NLS-1$
+		pid.getPid16_MaritalStatus().getCe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 		pid.getPid7_DateTimeOfBirth().getTs1_TimeOfAnEvent()
 			.setValue(HL7Helper.dateToString(patient.getBirthdate()));
 		
 		pid.getPid8_Sex().setValue(sex);
-		pid.getPid9_PatientAlias(0).getXpn1_FamilyLastName().getFn1_FamilyName().setValue(""); //$NON-NLS-1$
-		pid.getPid10_Race(0).getCe1_Identifier().setValue(""); //$NON-NLS-1$
+		pid.getPid9_PatientAlias(0).getXpn1_FamilyLastName().getFn1_FamilyName().setValue(StringTool.leer); //$NON-NLS-1$
+		pid.getPid10_Race(0).getCe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 		addAddressToXAD(pid.getPid11_PatientAddress(0), patient);
-		pid.getPid12_CountyCode().setValue(""); //$NON-NLS-1$
+		pid.getPid12_CountyCode().setValue(StringTool.leer); //$NON-NLS-1$
 		addPhone1ToXTN(pid.getPid13_PhoneNumberHome(0), patient);
 	}
 	
@@ -296,9 +297,9 @@ public abstract class HL7Writer {
 	 */
 	protected void addKontaktToXPN(ca.uhn.hl7v2.model.v26.datatype.XPN xpn,
 		final HL7Kontakt kontakt) throws DataTypeException{
-		String name = ""; //$NON-NLS-1$
-		String vorname = ""; //$NON-NLS-1$
-		String title = ""; //$NON-NLS-1$
+		String name = StringTool.leer; //$NON-NLS-1$
+		String vorname = StringTool.leer; //$NON-NLS-1$
+		String title = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			name = kontakt.getName();
 			vorname = kontakt.getFirstname();
@@ -306,13 +307,13 @@ public abstract class HL7Writer {
 		}
 		xpn.getXpn1_FamilyName().getSurname().setValue(name);
 		xpn.getXpn2_GivenName().setValue(vorname);
-		xpn.getXpn3_SecondAndFurtherGivenNamesOrInitialsThereof().setValue(""); //$NON-NLS-1$
-		xpn.getXpn4_SuffixEgJRorIII().setValue(""); //$NON-NLS-1$
-		xpn.getXpn5_PrefixEgDR().setValue(""); //$NON-NLS-1$
+		xpn.getXpn3_SecondAndFurtherGivenNamesOrInitialsThereof().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn4_SuffixEgJRorIII().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn5_PrefixEgDR().setValue(StringTool.leer); //$NON-NLS-1$
 		xpn.getXpn6_DegreeEgMD().setValue(title);
-		xpn.getXpn7_NameTypeCode().setValue(""); //$NON-NLS-1$
-		xpn.getXpn8_NameRepresentationCode().setValue(""); //$NON-NLS-1$
-		xpn.getXpn9_NameContext().getCwe1_Identifier().setValue(""); //$NON-NLS-1$
+		xpn.getXpn7_NameTypeCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn8_NameRepresentationCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn9_NameContext().getCwe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 	}
 	
 	/**
@@ -324,9 +325,9 @@ public abstract class HL7Writer {
 	 */
 	protected void addKontaktToXPN(ca.uhn.hl7v2.model.v231.datatype.XPN xpn,
 		final HL7Kontakt kontakt) throws DataTypeException{
-		String name = ""; //$NON-NLS-1$
-		String vorname = ""; //$NON-NLS-1$
-		String title = ""; //$NON-NLS-1$
+		String name = StringTool.leer; //$NON-NLS-1$
+		String vorname = StringTool.leer; //$NON-NLS-1$
+		String title = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			name = kontakt.getName();
 			vorname = kontakt.getFirstname();
@@ -334,11 +335,11 @@ public abstract class HL7Writer {
 		}
 		xpn.getXpn1_FamilyLastName().getFamilyName().setValue(name);
 		xpn.getXpn2_GivenName().setValue(vorname);
-		xpn.getXpn4_SuffixEgJRorIII().setValue(""); //$NON-NLS-1$
-		xpn.getXpn5_PrefixEgDR().setValue(""); //$NON-NLS-1$
+		xpn.getXpn4_SuffixEgJRorIII().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn5_PrefixEgDR().setValue(StringTool.leer); //$NON-NLS-1$
 		xpn.getXpn6_DegreeEgMD().setValue(title);
-		xpn.getXpn7_NameTypeCode().setValue(""); //$NON-NLS-1$
-		xpn.getXpn8_NameRepresentationCode().setValue(""); //$NON-NLS-1$
+		xpn.getXpn7_NameTypeCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xpn.getXpn8_NameRepresentationCode().setValue(StringTool.leer); //$NON-NLS-1$
 	}
 	
 	/**
@@ -350,11 +351,11 @@ public abstract class HL7Writer {
 	 */
 	protected void addAddressToXAD(ca.uhn.hl7v2.model.v26.datatype.XAD xad,
 		final HL7Kontakt kontakt) throws DataTypeException{
-		String street = ""; //$NON-NLS-1$
-		String other = ""; //$NON-NLS-1$
-		String city = ""; //$NON-NLS-1$
-		String zip = ""; //$NON-NLS-1$
-		String country = ""; //$NON-NLS-1$
+		String street = StringTool.leer; //$NON-NLS-1$
+		String other = StringTool.leer; //$NON-NLS-1$
+		String city = StringTool.leer; //$NON-NLS-1$
+		String zip = StringTool.leer; //$NON-NLS-1$
+		String country = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			street = kontakt.getAddress1();
 			other = kontakt.getAddress2();
@@ -365,7 +366,7 @@ public abstract class HL7Writer {
 		xad.getXad1_StreetAddress().getSad1_StreetOrMailingAddress().setValue(street);
 		xad.getXad2_OtherDesignation().setValue(other);
 		xad.getXad3_City().setValue(city);
-		xad.getXad4_StateOrProvince().setValue(""); //$NON-NLS-1$
+		xad.getXad4_StateOrProvince().setValue(StringTool.leer); //$NON-NLS-1$
 		xad.getXad5_ZipOrPostalCode().setValue(zip);
 		xad.getXad6_Country().setValue(country);
 	}
@@ -379,11 +380,11 @@ public abstract class HL7Writer {
 	 */
 	protected void addAddressToXAD(ca.uhn.hl7v2.model.v231.datatype.XAD xad,
 		final HL7Kontakt kontakt) throws DataTypeException{
-		String street = ""; //$NON-NLS-1$
-		String other = ""; //$NON-NLS-1$
-		String city = ""; //$NON-NLS-1$
-		String zip = ""; //$NON-NLS-1$
-		String country = ""; //$NON-NLS-1$
+		String street = StringTool.leer; //$NON-NLS-1$
+		String other = StringTool.leer; //$NON-NLS-1$
+		String city = StringTool.leer; //$NON-NLS-1$
+		String zip = StringTool.leer; //$NON-NLS-1$
+		String country = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			street = kontakt.getAddress1();
 			other = kontakt.getAddress2();
@@ -394,7 +395,7 @@ public abstract class HL7Writer {
 		xad.getXad1_StreetAddress().setValue(street);
 		xad.getXad2_OtherDesignation().setValue(other);
 		xad.getXad3_City().setValue(city);
-		xad.getXad4_StateOrProvince().setValue(""); //$NON-NLS-1$
+		xad.getXad4_StateOrProvince().setValue(StringTool.leer); //$NON-NLS-1$
 		xad.getXad5_ZipOrPostalCode().setValue(zip);
 		xad.getXad6_Country().setValue(country);
 	}
@@ -408,9 +409,9 @@ public abstract class HL7Writer {
 	 */
 	protected void addPhone1ToXTN(ca.uhn.hl7v2.model.v26.datatype.XTN xtn, final HL7Kontakt kontakt)
 		throws DataTypeException{
-		String phone1 = ""; //$NON-NLS-1$
-		String email = ""; //$NON-NLS-1$
-		String fax = ""; //$NON-NLS-1$
+		String phone1 = StringTool.leer; //$NON-NLS-1$
+		String email = StringTool.leer; //$NON-NLS-1$
+		String fax = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			phone1 = kontakt.getPhone1();
 			email = kontakt.getEmail();
@@ -425,12 +426,12 @@ public abstract class HL7Writer {
 			xtn.getXtn3_TelecommunicationEquipmentType().setValue("Internet"); //$NON-NLS-1$
 			xtn.getXtn4_CommunicationAddress().setValue(email);
 		}
-		xtn.getXtn5_CountryCode().setValue(""); //$NON-NLS-1$
-		xtn.getXtn6_AreaCityCode().setValue(""); //$NON-NLS-1$
-		xtn.getXtn7_LocalNumber().setValue(""); //$NON-NLS-1$
-		xtn.getXtn8_Extension().setValue(""); //$NON-NLS-1$
-		xtn.getXtn9_AnyText().setValue(""); //$NON-NLS-1$
-		xtn.getXtn10_ExtensionPrefix().setValue(""); //$NON-NLS-1$
+		xtn.getXtn5_CountryCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn6_AreaCityCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn7_LocalNumber().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn8_Extension().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn9_AnyText().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn10_ExtensionPrefix().setValue(StringTool.leer); //$NON-NLS-1$
 		xtn.getXtn11_SpeedDialCode().setValue(fax);
 	}
 	
@@ -443,27 +444,27 @@ public abstract class HL7Writer {
 	 */
 	protected void addPhone1ToXTN(ca.uhn.hl7v2.model.v231.datatype.XTN xtn,
 		final HL7Kontakt kontakt) throws DataTypeException{
-		String phone1 = ""; //$NON-NLS-1$
-		String email = ""; //$NON-NLS-1$
-		String fax = ""; //$NON-NLS-1$
+		String phone1 = StringTool.leer; //$NON-NLS-1$
+		String email = StringTool.leer; //$NON-NLS-1$
+		String fax = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			phone1 = kontakt.getPhone1();
 			email = kontakt.getEmail();
 			fax = kontakt.getFax();
 		}
 		if (phone1 != null) {
-			phone1 = phone1.replaceAll("[^\\d.]", "");
+			phone1 = phone1.replaceAll("[^\\d.]", StringTool.leer);
 			xtn.getPhoneNumber().setValue(phone1);
 		}
 		if (email != null) {
 			xtn.getEmailAddress().setValue(email);
 		}
-		xtn.getXtn2_TelecommunicationUseCode().setValue(""); //$NON-NLS-1$
-		xtn.getXtn3_TelecommunicationEquipmentType().setValue(""); //$NON-NLS-1$
-		xtn.getXtn5_CountryCode().setValue(""); //$NON-NLS-1$
-		xtn.getXtn6_AreaCityCode().setValue(""); //$NON-NLS-1$
-		xtn.getXtn8_Extension().setValue(""); //$NON-NLS-1$
-		xtn.getXtn9_AnyText().setValue(""); //$NON-NLS-1$
+		xtn.getXtn2_TelecommunicationUseCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn3_TelecommunicationEquipmentType().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn5_CountryCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn6_AreaCityCode().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn8_Extension().setValue(StringTool.leer); //$NON-NLS-1$
+		xtn.getXtn9_AnyText().setValue(StringTool.leer); //$NON-NLS-1$
 	}
 	
 	/**
@@ -475,7 +476,7 @@ public abstract class HL7Writer {
 	 */
 	protected void addPhone2ToXTN(ca.uhn.hl7v2.model.v26.datatype.XTN xtn, final HL7Kontakt kontakt)
 		throws DataTypeException{
-		String phone2 = ""; //$NON-NLS-1$
+		String phone2 = StringTool.leer; //$NON-NLS-1$
 		if (kontakt != null) {
 			phone2 = kontakt.getPhone2();
 		}

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/model/ObservationMessage.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/model/ObservationMessage.java
@@ -7,30 +7,31 @@ import java.util.Vector;
 
 import ch.elexis.hl7.util.HL7Helper;
 
+import ch.rgw.tools.StringTool;
 public class ObservationMessage {
 	
 	// MSH
 	String sendingApplication; // MSH-3
 	String sendingFacility; // MSH-4
 	Date dateTimeOfMessage = null; // MSH-7
-	String messageControlID = ""; // MSH-10
+	String messageControlID = StringTool.leer; // MSH-10
 	
 	// PID
 	String patientId; // PID-3
 	String alternatePatientId; // PID-4
 	String patientName; // PID-5
-	String patientLastName = ""; // PID-5-2
-	String patientFirstName = ""; // PID-5-3
-	String patientBirthdate = ""; // PID-7
-	String patientSex = ""; // PID-8
+	String patientLastName = StringTool.leer; // PID-5-2
+	String patientFirstName = StringTool.leer; // PID-5-3
+	String patientBirthdate = StringTool.leer; // PID-7
+	String patientSex = StringTool.leer; // PID-8
 	// optional NTE following PID
 	// see http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7+v2.5&segment=OBX
-	String patientNotesAndComments = "";
+	String patientNotesAndComments = StringTool.leer;
 	
 	// ORC
 	String orderNumber; // ORC-2
-	String orderNumberPlacer = ""; // ORC-2
-	String orderNumberFiller = ""; // ORC-3
+	String orderNumberPlacer = StringTool.leer; // ORC-2
+	String orderNumberFiller = StringTool.leer; // ORC-3
 	Date dateTimeOfTransaction = null; // ORC-9
 	
 	// OBX
@@ -64,7 +65,7 @@ public class ObservationMessage {
 		this.patientLastName = _patientLastName;
 		this.patientFirstName = _patientFirstName;
 		this.patientNotesAndComments = _patientNotesAndComments;
-		this.patientName = _patientLastName + " " + _patientFirstName;
+		this.patientName = _patientLastName + StringTool.space + _patientFirstName;
 		this.patientBirthdate = _patientBirthDate;
 		this.patientSex = _patientSex;
 		this.alternatePatientId = _alternatePatientId;

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/model/TextData.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/model/TextData.java
@@ -2,12 +2,13 @@ package ch.elexis.hl7.model;
 
 import java.text.ParseException;
 
+import ch.rgw.tools.StringTool;
 public class TextData extends AbstractData {
 	private String text;
 	
 	public TextData(String name, String text, String dateStr, String group, String sequence)
 		throws ParseException{
-		super(name, dateStr, "", group, sequence); //$NON-NLS-1$
+		super(name, dateStr, StringTool.leer, group, sequence); //$NON-NLS-1$
 		this.text = text;
 	}
 	

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/util/HL7Helper.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/util/HL7Helper.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import ch.rgw.tools.StringTool;
 public class HL7Helper {
 	private static final String DTM_DATE_TIME_PATTERN = "yyyyMMddHHmmss"; //$NON-NLS-1$
 	
@@ -64,7 +65,7 @@ public class HL7Helper {
 	}
 	
 	public static String determineName(List<String> possibleNames){
-		String ret = "";
+		String ret = StringTool.leer;
 		for (String possibleName : possibleNames) {
 			if (possibleName != null && !"null".equals(possibleName)) {
 				int possibleNonDigitCount = getNonDigitCharacters(possibleName);

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v22/HL7_ORU_R01.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v22/HL7_ORU_R01.java
@@ -52,6 +52,7 @@ import ch.elexis.hl7.v26.Messages;
  * @author tony
  * 
  */
+import ch.rgw.tools.StringTool;
 public class HL7_ORU_R01 extends HL7Writer {
 	
 	final String uniqueMessageControlID;
@@ -174,12 +175,12 @@ public class HL7_ORU_R01 extends HL7Writer {
 				PID pid = oru.getPATIENT_RESULT().getPATIENT().getPID();
 				String pid2_patientId =
 					pid.getPid2_PatientIDExternalID().getCk1_IDNumber().getValue();
-				if ((pid2_patientId == null) || ("".equals(pid2_patientId)))
+				if ((pid2_patientId == null) || (StringTool.leer.equals(pid2_patientId)))
 					pid2_patientId =
 						pid.getPid3_PatientIDInternalID(0).getCm_pat_id1_IDNumber().getValue();
 				String pid4_alternatePatientId = pid.getPid4_AlternatePatientID().getValue();
-				String pid5_patientLastName = "";
-				String pid5_patientFirstName = "";
+				String pid5_patientLastName = StringTool.leer;
+				String pid5_patientFirstName = StringTool.leer;
 				if (pid.getPid5_PatientName().getName() != null)
 					pid5_patientLastName = pid.getPid5_PatientName().getFamilyName().getValue();
 				if (pid.getPid5_PatientName().getFamilyName() != null)
@@ -188,7 +189,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 				String pid8_patientSex = pid.getPid8_Sex().getValue();
 				FT[] nteAfterPid_patientNotesAndCommentsArray =
 					oru.getPATIENT_RESULT().getPATIENT().getNTE().getComment();
-				String nteAfterPid_patientNotesAndComments = String.join("\n",
+				String nteAfterPid_patientNotesAndComments = String.join(StringTool.lf,
 						(nteAfterPid_patientNotesAndCommentsArray.length > 0)
 								? nteAfterPid_patientNotesAndCommentsArray[0].getValue()
 								: null);
@@ -208,19 +209,19 @@ public class HL7_ORU_R01 extends HL7Writer {
 				
 				int obscount = oru.getPATIENT_RESULT().getORDER_OBSERVATIONReps();
 				for (int j = 0; j < obscount; j++) {
-					String appendedTX = ""; //$NON-NLS-1$
+					String appendedTX = StringTool.leer; //$NON-NLS-1$
 					OBR obr = oru.getPATIENT_RESULT().getORDER_OBSERVATION(j).getOBR();
 					String obrDateOfObservation =
 						obr.getObr7_ObservationDateTime().getComponent(0).toString();
 					
-					if ((obrDateOfObservation == null) || ("".equals(obrDateOfObservation)))
+					if ((obrDateOfObservation == null) || (StringTool.leer.equals(obrDateOfObservation)))
 						obrDateOfObservation = obr.getObr22_ResultsReportStatusChangeDateTime()
 							.getComponent(0).toString();
 					
-					if ((obrDateOfObservation == null) || ("".equals(obrDateOfObservation)))
+					if ((obrDateOfObservation == null) || (StringTool.leer.equals(obrDateOfObservation)))
 						obrDateOfObservation = orc9_dateTimeOfTransaction;
 					
-					if ((obrDateOfObservation == null) || ("".equals(obrDateOfObservation)))
+					if ((obrDateOfObservation == null) || (StringTool.leer.equals(obrDateOfObservation)))
 						obrDateOfObservation = msh7_dateTimeOfMessage;
 					
 					// Order Comments
@@ -231,9 +232,9 @@ public class HL7_ORU_R01 extends HL7Writer {
 						AbstractPrimitive comment = nte.getNte3_Comment(0);
 						if (comment != null) {
 							if (orderCommentNTE != null) {
-								orderCommentNTE += "\n";
+								orderCommentNTE += StringTool.lf;
 							} else {
-								orderCommentNTE = "";
+								orderCommentNTE = StringTool.leer;
 							}
 							orderCommentNTE += comment.getValue();
 						}
@@ -255,9 +256,9 @@ public class HL7_ORU_R01 extends HL7Writer {
 							AbstractPrimitive comment = nte.getNte3_Comment(0);
 							if (comment != null) {
 								if (commentNTE != null) {
-									commentNTE += "\n";
+									commentNTE += StringTool.lf;
 								} else {
-									commentNTE = "";
+									commentNTE = StringTool.leer;
 								}
 								commentNTE += comment.getValue();
 							}
@@ -290,7 +291,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 							String name =
 								obx.getObx3_ObservationIdentifier().getCe2_Text().getValue();
 							
-							String valueST = ""; //$NON-NLS-1$
+							String valueST = StringTool.leer; //$NON-NLS-1$
 							Object value = obx.getObx5_ObservationValue().getData();
 							if (value instanceof ST) {
 								valueST =
@@ -304,20 +305,20 @@ public class HL7_ORU_R01 extends HL7Writer {
 								dateOfObservation, commentNTE, null, null);
 							observation.add(strData);
 						} else if (HL7Constants.OBX_VALUE_TYPE_TX.equals(valueType)) {
-							String valueTX = ""; //$NON-NLS-1$
+							String valueTX = StringTool.leer; //$NON-NLS-1$
 							Object value = obx.getObx5_ObservationValue().getData();
 							if (value instanceof TX) {
 								valueTX =
 									((TX) obx.getObx5_ObservationValue().getData()).getValue();
 							}
-							appendedTX += valueTX + "\n"; //$NON-NLS-1$
+							appendedTX += valueTX + StringTool.lf; //$NON-NLS-1$
 						} else if (HL7Constants.OBX_VALUE_TYPE_FT.equals(valueType)) {
 							String kuerzel =
 								obx.getObx3_ObservationIdentifier().getCe1_Identifier().getValue();
 							String name =
 								obx.getObx3_ObservationIdentifier().getCe2_Text().getValue();
 							
-							String valueST = ""; //$NON-NLS-1$
+							String valueST = StringTool.leer; //$NON-NLS-1$
 							Object value = obx.getObx5_ObservationValue().getData();
 							if (value instanceof ST) {
 								ST st = (ST) value;

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v26/HL7_OML_O21.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v26/HL7_OML_O21.java
@@ -17,6 +17,7 @@ import ch.elexis.hl7.data.HL7Mandant;
 import ch.elexis.hl7.data.HL7Patient;
 import ch.elexis.hl7.util.HL7Helper;
 
+import ch.rgw.tools.StringTool;
 public class HL7_OML_O21 extends HL7Writer {
 	
 	final String uniqueMessageControlID;
@@ -85,7 +86,7 @@ public class HL7_OML_O21 extends HL7Writer {
 		addKontaktToXPN(nk1.getNk12_Name(0), rechnungsempfaenger);
 		
 		CWE cwe = nk1.getNk13_Relationship();
-		cwe.getCwe1_Identifier().setValue(""); //$NON-NLS-1$
+		cwe.getCwe1_Identifier().setValue(StringTool.leer); //$NON-NLS-1$
 		cwe.getCwe2_Text().setValue("INVOICERECEIPT"); //$NON-NLS-1$
 		
 		addAddressToXAD(nk1.getNk14_Address(0), rechnungsempfaenger);
@@ -108,14 +109,14 @@ public class HL7_OML_O21 extends HL7Writer {
 		
 		// PLV-13: Aktueller Aufenthaltsort des Patienten, optional
 		// Empfehlung: Wenn vorhanden, dann ausfüllen -> In unserem Fall leer lassen
-		pv1.getPv14_AdmissionType().setValue(""); //$NON-NLS-1$
-		pv1.getPv15_PreadmitNumber().getCx1_IDNumber().setValue(""); //$NON-NLS-1$
-		pv1.getPv16_PriorPatientLocation().getPl1_PointOfCare().setValue(""); //$NON-NLS-1$
+		pv1.getPv14_AdmissionType().setValue(StringTool.leer); //$NON-NLS-1$
+		pv1.getPv15_PreadmitNumber().getCx1_IDNumber().setValue(StringTool.leer); //$NON-NLS-1$
+		pv1.getPv16_PriorPatientLocation().getPl1_PointOfCare().setValue(StringTool.leer); //$NON-NLS-1$
 		
 		// Fallnummer, optional (Beschreibung gemäss HL7 Standard)
 		// Empfehlung: Wenn vorhanden, dann ausfüllen -> In unserem Fall leer lassen oder den Key
 		// des Falles nehmen
-		pv1.getPv119_VisitNumber().getIDNumber().setValue(""); //$NON-NLS-1$
+		pv1.getPv119_VisitNumber().getIDNumber().setValue(StringTool.leer); //$NON-NLS-1$
 		// ...
 		pv1.getPv144_AdmitDateTime().setValue(HL7Helper.dateToString(beginDate));
 	}

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v26/HL7_ORU_R01.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v26/HL7_ORU_R01.java
@@ -57,6 +57,7 @@ import ch.elexis.hl7.model.ObservationMessage;
 import ch.elexis.hl7.model.StringData;
 import ch.elexis.hl7.model.TextData;
 
+import ch.rgw.tools.StringTool;
 public class HL7_ORU_R01 extends HL7Writer {
 	
 	// constants for OBR-47
@@ -134,13 +135,13 @@ public class HL7_ORU_R01 extends HL7Writer {
 			String pid2_patientId = pid.getPid2_PatientID().getCx1_IDNumber().getValue();
 			String pid4_alternatePatientId =
 				pid.getPid4_AlternatePatientIDPID(0).getCx1_IDNumber().getValue();
-			String tmp1 = "";
-			String tmp2 = "";
+			String tmp1 = StringTool.leer;
+			String tmp2 = StringTool.leer;
 			if (pid.getPid5_PatientName(0).getName() != null)
 				tmp1 = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getFamilyName() != null)
 				tmp2 = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String pid5_patientName = tmp1 + " " + tmp2;
+			String pid5_patientName = tmp1 + StringTool.space + tmp2;
 			String nteAfterPid_patientNotesAndComments = readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			String orc2_placerOrderNumber =
 				oru.getPATIENT_RESULT().getORDER_OBSERVATION().getORC().getOrc2_PlacerOrderNumber()
@@ -152,7 +153,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 			
 			int obscount = oru.getPATIENT_RESULT().getORDER_OBSERVATIONReps();
 			for (int j = 0; j < obscount; j++) {
-				String appendedTX = ""; //$NON-NLS-1$
+				String appendedTX = StringTool.leer; //$NON-NLS-1$
 				OBR obr = oru.getPATIENT_RESULT().getORDER_OBSERVATION(j).getOBR();
 				String obrDateOfObservation = obr.getObr7_ObservationDateTime().getValue();
 				
@@ -163,9 +164,9 @@ public class HL7_ORU_R01 extends HL7Writer {
 					AbstractPrimitive comment = nte.getNte3_Comment(0);
 					if (comment != null) {
 						if (orderCommentNTE != null) {
-							orderCommentNTE += "\n";
+							orderCommentNTE += StringTool.lf;
 						} else {
-							orderCommentNTE = "";
+							orderCommentNTE = StringTool.leer;
 						}
 						orderCommentNTE += comment.getValue();
 					}
@@ -187,9 +188,9 @@ public class HL7_ORU_R01 extends HL7Writer {
 						AbstractPrimitive comment = nte.getNte3_Comment(0);
 						if (comment != null) {
 							if (commentNTE != null) {
-								commentNTE += "\n";
+								commentNTE += StringTool.lf;
 							} else {
-								commentNTE = "";
+								commentNTE = StringTool.leer;
 							}
 							commentNTE += comment.getValue();
 						}
@@ -202,7 +203,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 					for (int k = 0; k < 2; k++) {
 						CWE cwe = obr.getObr47_FillerSupplementalServiceInformation(k);
 						if (cwe != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (cwe.getCwe3_NameOfCodingSystem() != null)
 								code = cwe.getCwe3_NameOfCodingSystem().getValue();
 							if (CODINGSYSTEM_DORNER_GROUP_CODE.equalsIgnoreCase(code)) {
@@ -241,7 +242,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 					} else if (HL7Constants.OBX_VALUE_TYPE_ST.equals(valueType)) {
 						String name = obx.getObx4_ObservationSubID().getValue();
 						
-						String valueST = ""; //$NON-NLS-1$
+						String valueST = StringTool.leer; //$NON-NLS-1$
 						Object value = obx.getObx5_ObservationValue(0).getData();
 						if (value instanceof ST) {
 							valueST = ((ST) obx.getObx5_ObservationValue(0).getData()).getValue();
@@ -253,19 +254,19 @@ public class HL7_ORU_R01 extends HL7Writer {
 						observation.add(new StringData(name, unit, valueST, range,
 							dateOfObservation, commentNTE, group, sequence));
 					} else if (HL7Constants.OBX_VALUE_TYPE_TX.equals(valueType)) {
-						String valueTX = ""; //$NON-NLS-1$
+						String valueTX = StringTool.leer; //$NON-NLS-1$
 						Object value = obx.getObx5_ObservationValue(0).getData();
 						if (value instanceof TX) {
 							valueTX = ((TX) obx.getObx5_ObservationValue(0).getData()).getValue();
 						}
-						appendedTX += valueTX + "\n"; //$NON-NLS-1$
+						appendedTX += valueTX + StringTool.lf; //$NON-NLS-1$
 					} else if (HL7Constants.OBX_VALUE_TYPE_FT.equals(valueType)) {
-						String valueFT = ""; //$NON-NLS-1$
+						String valueFT = StringTool.leer; //$NON-NLS-1$
 						Object value = obx.getObx5_ObservationValue(0).getData();
 						if (value instanceof FT) {
 							valueFT = ((FT) obx.getObx5_ObservationValue(0).getData()).getValue();
 						}
-						appendedTX += parseTextValue(valueFT) + "\n"; //$NON-NLS-1$
+						appendedTX += parseTextValue(valueFT) + StringTool.lf; //$NON-NLS-1$
 					} else {
 						addError(MessageFormat.format("Value type {0} is not implemented!", //$NON-NLS-1$
 							valueType));
@@ -294,8 +295,8 @@ public class HL7_ORU_R01 extends HL7Writer {
 	
 	public String parseTextValue(String value){
 		String text = value;
-		text = text.replaceAll("\\\\.br\\\\", "\n");
-		text = text.replaceAll("\\\\.BR\\\\", "\n");
+		text = text.replaceAll("\\\\.br\\\\", StringTool.lf);
+		text = text.replaceAll("\\\\.BR\\\\", StringTool.lf);
 		
 		// only return parsed value if it contains reasonable input
 		if (text != null && !text.isEmpty()) {
@@ -310,7 +311,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -478,9 +479,9 @@ public class HL7_ORU_R01 extends HL7Writer {
 		}
 		
 		if (refValue == null)
-			return "";
-		if (refValue == "")
-			return "";
+			return StringTool.leer;
+		if (refValue == StringTool.leer)
+			return StringTool.leer;
 		
 		if (resultat != null) {
 			Double doubleObj = null;
@@ -644,7 +645,7 @@ public class HL7_ORU_R01 extends HL7Writer {
 		// OBX-6: Units <LabItems.EINHEIT>
 		obx.getObx6_Units().getCwe1_Identifier().setValue(laborItem.getEinheit());
 		// OBX-7: References Range <LabItems.REFMANN>, bzw <LabItems.REFFRAU> je nach Geschlecht
-		String refRange = "";
+		String refRange = StringTool.leer;
 		if (patient.isMale()) {
 			refRange = laborItem.getRefMann();
 		} else {
@@ -672,6 +673,6 @@ public class HL7_ORU_R01 extends HL7Writer {
 	private void fillNTE(final NTE nte, final HL7LaborWert laborWert) throws DataTypeException,
 		HL7Exception{
 		nte.getNte1_SetIDNTE().setValue("1"); //$NON-NLS-1$
-		nte.getNte3_Comment(0).setValue(laborWert.getKommentar().replace("\n", ";"));
+		nte.getNte3_Comment(0).setValue(laborWert.getKommentar().replace(StringTool.lf, ";"));
 	}
 }

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV21.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV21.java
@@ -59,7 +59,7 @@ public class HL7ReaderV21 extends HL7Reader {
 			msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SENDINGFACILITY().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -91,12 +91,12 @@ public class HL7ReaderV21 extends HL7Reader {
 					String commentNTE = getComments(obs, i);
 					
 					// groupe and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getObr4_UNIVERSALSERVICEIDENT(); // .getObr47_FillerSupplementalServiceInformation(k);
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 								
@@ -124,7 +124,7 @@ public class HL7ReaderV21 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -133,15 +133,15 @@ public class HL7ReaderV21 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -159,7 +159,7 @@ public class HL7ReaderV21 extends HL7Reader {
 				if (StringTool.isNothing(patid)) {
 					patid = patid_alternative;
 					if (patid == null) {
-						patid = "";
+						patid = StringTool.leer;
 					}
 				}
 			}
@@ -169,7 +169,7 @@ public class HL7ReaderV21 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -181,7 +181,7 @@ public class HL7ReaderV21 extends HL7Reader {
 				lastName = pid.getPid5_PATIENTNAME().getPn1_FamilyName().getValue();
 			if (pid.getPid5_PATIENTNAME().getPn2_GivenName().getValue() != null)
 				firstName = pid.getPid5_PATIENTNAME().getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments = readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			
 			observation = new ObservationMessage(sendingApplication, sendingFacility,
@@ -242,7 +242,7 @@ public class HL7ReaderV21 extends HL7Reader {
 			TX comment = oru_R01_PATIENT.getNTE(i).getCOMMENT(0);
 			sb.append(comment.toString());
 			if (oru_R01_PATIENT.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -271,9 +271,9 @@ public class HL7ReaderV21 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_COMMENT(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if(comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -287,12 +287,12 @@ public class HL7ReaderV21 extends HL7Reader {
 		String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = obs.getOBX();
 		String valueType = obx.getObx2_VALUETYPE().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlag;
 		
@@ -304,7 +304,7 @@ public class HL7ReaderV21 extends HL7Reader {
 					name = obx.getObx3_OBSERVATIONIDENTIFIER().getCe1_Identifier().getValue();
 				}
 			}
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_OBSERVATIONRESULTS().getData();
 			
 			if (tmp instanceof ST) {

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV22.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV22.java
@@ -53,12 +53,12 @@ public class HL7ReaderV22 extends HL7Reader {
 	
 	@Override
 	public String getSender() throws ElexisException{
-		String sender = "";
+		String sender = StringTool.leer;
 		try {
 			MSH msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SendingFacility().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -91,13 +91,13 @@ public class HL7ReaderV22 extends HL7Reader {
 					String commentNTE = getComments(obs, i);
 					
 					// groupe and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getUniversalServiceID();
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -124,7 +124,7 @@ public class HL7ReaderV22 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -133,15 +133,15 @@ public class HL7ReaderV22 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -160,7 +160,7 @@ public class HL7ReaderV22 extends HL7Reader {
 				if (StringTool.isNothing(patid)) {
 					patid = patid_alternative;
 					if (patid == null) {
-						patid = "";
+						patid = StringTool.leer;
 					}
 				}
 			}
@@ -170,7 +170,7 @@ public class HL7ReaderV22 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -182,7 +182,7 @@ public class HL7ReaderV22 extends HL7Reader {
 				lastName = pid.getPatientName().getPn1_FamilyName().getValue();
 			if (pid.getPatientName().getGivenName().getValue() != null)
 				firstName = pid.getPatientName().getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			
@@ -265,9 +265,9 @@ public class HL7ReaderV22 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -281,12 +281,12 @@ public class HL7ReaderV22 extends HL7Reader {
 		String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = obs.getOBX();
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -295,7 +295,7 @@ public class HL7ReaderV22 extends HL7Reader {
 			if (name == null) {
 				name = obx.getObx3_ObservationIdentifier().getCe1_Identifier().getValue();
 			}
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue().getData();
 			if (tmp instanceof ST) {
 				value = ((ST) tmp).getValue();
@@ -345,7 +345,7 @@ public class HL7ReaderV22 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV23.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV23.java
@@ -63,7 +63,7 @@ public class HL7ReaderV23 extends HL7Reader {
 			MSH msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SendingFacility().getNamespaceID().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -100,12 +100,12 @@ public class HL7ReaderV23 extends HL7Reader {
 					String commentNTE = getComments(obs, i);
 					
 					// groupe and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getObr4_UniversalServiceIdentifier();
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -132,7 +132,7 @@ public class HL7ReaderV23 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -141,15 +141,15 @@ public class HL7ReaderV23 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -170,7 +170,7 @@ public class HL7ReaderV23 extends HL7Reader {
 				if (StringTool.isNothing(patid)) {
 					patid = patid_alternative;
 					if (patid == null) {
-						patid = "";
+						patid = StringTool.leer;
 					}
 				}
 			}
@@ -180,7 +180,7 @@ public class HL7ReaderV23 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -192,7 +192,7 @@ public class HL7ReaderV23 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oru.getRESPONSE().getPATIENT());
 			
@@ -276,9 +276,9 @@ public class HL7ReaderV23 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null && comment.getValue() != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -292,12 +292,12 @@ public class HL7ReaderV23 extends HL7Reader {
 		String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = obs.getOBX();
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -324,7 +324,7 @@ public class HL7ReaderV23 extends HL7Reader {
 			if (name == null) {
 				name = obx.getObx3_ObservationIdentifier().getCe3_NameOfCodingSystem().getValue();
 			}
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {
@@ -381,7 +381,7 @@ public class HL7ReaderV23 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV231.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV231.java
@@ -62,7 +62,7 @@ public class HL7ReaderV231 extends HL7Reader {
 			MSH msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SendingFacility().getNamespaceID().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -98,12 +98,12 @@ public class HL7ReaderV231 extends HL7Reader {
 					String commentNTE = getComments(obs, i);
 					
 					// groupe and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getObr4_UniversalServiceID();
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -130,7 +130,7 @@ public class HL7ReaderV231 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -139,15 +139,15 @@ public class HL7ReaderV231 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -169,7 +169,7 @@ public class HL7ReaderV231 extends HL7Reader {
 				if (StringTool.isNothing(patid)) {
 					patid = patid_alternative;
 					if (patid == null) {
-						patid = "";
+						patid = StringTool.leer;
 					}
 				}
 			}
@@ -179,7 +179,7 @@ public class HL7ReaderV231 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -192,12 +192,12 @@ public class HL7ReaderV231 extends HL7Reader {
 			if (familyLastName.getFn1_FamilyName().getValue() != null
 				|| familyLastName.getFn2_LastNamePrefix().getValue() != null)
 				lastName = pid.getPid5_PatientName(0).getFamilyLastName().getFn2_LastNamePrefix()
-					.getValue() + " "
+					.getValue() + StringTool.space
 					+ pid.getPid5_PatientName(0).getFamilyLastName().getFn1_FamilyName().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
-			String patientNotesAndComments = "";
+			String patientName = firstName + StringTool.space + lastName;
+			String patientNotesAndComments = StringTool.leer;
 			
 			observation =
 				new ObservationMessage(sendingApplication, sendingFacility, dateTimeOfMessage,
@@ -280,9 +280,9 @@ public class HL7ReaderV231 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -296,12 +296,12 @@ public class HL7ReaderV231 extends HL7Reader {
 		String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = obs.getOBX();
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -331,7 +331,7 @@ public class HL7ReaderV231 extends HL7Reader {
 					name = obx.getObx3_ObservationIdentifier().getCe2_Text().getValue();
 				}
 			}
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV24.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV24.java
@@ -63,7 +63,7 @@ public class HL7ReaderV24 extends HL7Reader {
 			MSH msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SendingFacility().getNamespaceID().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -97,12 +97,12 @@ public class HL7ReaderV24 extends HL7Reader {
 					String commentNTE = getComments(obs, i);
 					
 					// groupe and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getObr47_FillerSupplementalServiceInformation(k);
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -129,7 +129,7 @@ public class HL7ReaderV24 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -138,15 +138,15 @@ public class HL7ReaderV24 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -177,7 +177,7 @@ public class HL7ReaderV24 extends HL7Reader {
 						if (StringTool.isNothing(patid)) {
 							patid = patid_alternative;
 							if (patid == null) {
-								patid = "";
+								patid = StringTool.leer;
 							}
 						}
 					}
@@ -189,7 +189,7 @@ public class HL7ReaderV24 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -201,7 +201,7 @@ public class HL7ReaderV24 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			
@@ -272,7 +272,7 @@ public class HL7ReaderV24 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -301,9 +301,9 @@ public class HL7ReaderV24 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -318,12 +318,12 @@ public class HL7ReaderV24 extends HL7Reader {
 		String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = obs.getOBX();
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -354,7 +354,7 @@ public class HL7ReaderV24 extends HL7Reader {
 			if (name == null) {
 				name = obx.getObx3_ObservationIdentifier().getCe1_Identifier().getValue();
 			}
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV25.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV25.java
@@ -65,7 +65,7 @@ public class HL7ReaderV25 extends HL7Reader {
 			MSH msh = (MSH) message.get("MSH");
 			sender = msh.getMsh4_SendingFacility().getNamespaceID().getValue();
 			if (sender == null) {
-				sender = "";
+				sender = StringTool.leer;
 			}
 		} catch (HL7Exception e) {
 			throw new ElexisException(e.getMessage(), e);
@@ -101,12 +101,12 @@ public class HL7ReaderV25 extends HL7Reader {
 					String commentNTE = getComments(orderObservationGroup, i);
 					
 					// group and sequence
-					String group = "";
-					String sequence = "";
+					String group = StringTool.leer;
+					String sequence = StringTool.leer;
 					for (int k = 0; k < 2; k++) {
 						CE ce = obr.getObr47_FillerSupplementalServiceInformation(k);
 						if (ce != null) {
-							String code = "";
+							String code = StringTool.leer;
 							if (ce.getCe3_NameOfCodingSystem() != null)
 								code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -133,7 +133,7 @@ public class HL7ReaderV25 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -142,15 +142,15 @@ public class HL7ReaderV25 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -176,7 +176,7 @@ public class HL7ReaderV25 extends HL7Reader {
 						if (StringTool.isNothing(patid)) {
 							patid = patid_alternative;
 							if (patid == null) {
-								patid = "";
+								patid = StringTool.leer;
 							}
 						}
 					}
@@ -188,7 +188,7 @@ public class HL7ReaderV25 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -200,7 +200,7 @@ public class HL7ReaderV25 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			
@@ -275,7 +275,7 @@ public class HL7ReaderV25 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -296,9 +296,9 @@ public class HL7ReaderV25 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -312,12 +312,12 @@ public class HL7ReaderV25 extends HL7Reader {
 		String group, String sequence, String defaultDateTime) throws ParseException{
 		OBX obx = observationGroup.getOBX();
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -341,7 +341,7 @@ public class HL7ReaderV25 extends HL7Reader {
 				commentNTE, group, sequence));
 		} else if (valueType != null && isTextOrNumeric(valueType)) {
 			name = determineName(obx, obr);
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {
@@ -389,7 +389,7 @@ public class HL7ReaderV25 extends HL7Reader {
 	}
 	
 	private String determineName(OBX obx, OBR obr){
-		String prefix = "";
+		String prefix = StringTool.leer;
 		ST ce2_Text = obr.getUniversalServiceIdentifier().getCe2_Text();
 		if (ce2_Text != null && StringUtils.isNotBlank(ce2_Text.toString())) {
 			prefix = ce2_Text.toString() + " - ";

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV251.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV251.java
@@ -70,7 +70,7 @@ public class HL7ReaderV251 extends HL7Reader {
 			if (sender == null) {
 				sender = msh.getMsh3_SendingApplication().getNamespaceID().getValue();
 				if (sender == null) {
-					sender = "";
+					sender = StringTool.leer;
 				}
 			}
 		} catch (HL7Exception e) {
@@ -124,12 +124,12 @@ public class HL7ReaderV251 extends HL7Reader {
 				String commentNTE = getComments(obs, i);
 				
 				// groupe and sequence
-				String group = "";
-				String sequence = "";
+				String group = StringTool.leer;
+				String sequence = StringTool.leer;
 				for (int k = 0; k < 2; k++) {
 					CE ce = obr.getObr47_FillerSupplementalServiceInformation(k);
 					if (ce != null) {
-						String code = "";
+						String code = StringTool.leer;
 						if (ce.getCe3_NameOfCodingSystem() != null)
 							code = ce.getCe3_NameOfCodingSystem().getValue();
 							
@@ -184,9 +184,9 @@ public class HL7ReaderV251 extends HL7Reader {
 						oul.getSPECIMEN().getORDER(idx).getNTE(j).getNte3_Comment(0);
 					if (comment != null) {
 						if (commentNTE != null) {
-							commentNTE += "\n";
+							commentNTE += StringTool.lf;
 						} else {
-							commentNTE = "";
+							commentNTE = StringTool.leer;
 						}
 						if(comment.getValue() != null) {
 							commentNTE += comment.getValue();
@@ -195,8 +195,8 @@ public class HL7ReaderV251 extends HL7Reader {
 				}
 			}
 			// groupe and sequence
-			String group = "";
-			String sequence = "";
+			String group = StringTool.leer;
+			String sequence = StringTool.leer;
 			
 			// result
 			readOBXResults(order.getRESULT(idx).getOBX(), commentNTE, group, sequence,
@@ -210,7 +210,7 @@ public class HL7ReaderV251 extends HL7Reader {
 				return ce.getCe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CE ce){
@@ -220,15 +220,15 @@ public class HL7ReaderV251 extends HL7Reader {
 				return ce.getCe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(PID pid, String orderNumber, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -245,7 +245,7 @@ public class HL7ReaderV251 extends HL7Reader {
 						if (StringTool.isNothing(patid)) {
 							patid = patid_alternative;
 							if (patid == null) {
-								patid = "";
+								patid = StringTool.leer;
 							}
 						}
 					}
@@ -257,7 +257,7 @@ public class HL7ReaderV251 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -265,13 +265,13 @@ public class HL7ReaderV251 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			
 			String sendingApplication =
 				msh.getMsh3_SendingApplication().getHd1_NamespaceID().getValue();
 			String sendingFacility = msh.getMsh4_SendingFacility().getHd1_NamespaceID().getValue();
 			String dateTimeOfMessage = msh.getMsh7_DateTimeOfMessage().getTs1_Time().getValue();
-			String patientNotesAndComments  = ""; 
+			String patientNotesAndComments  = StringTool.leer; 
 			
 			observation = new ObservationMessage(sendingApplication, sendingFacility,
 				dateTimeOfMessage, patid, patientName, patientNotesAndComments, patid_alternative, orderNumber);
@@ -356,9 +356,9 @@ public class HL7ReaderV251 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				commentNTE += comment.getValue();
 			}
@@ -370,12 +370,12 @@ public class HL7ReaderV251 extends HL7Reader {
 	private void readOBXResults(OBX obx, String commentNTE, String group, String sequence,
 		String defaultDateTime) throws ParseException{
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
 		String observationTime = obx.getObx14_DateTimeOfTheObservation().getTs1_Time().getValue();
-		String status = "";
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -402,7 +402,7 @@ public class HL7ReaderV251 extends HL7Reader {
 		} else if (isTextOrNumeric(valueType)) {
 			name = determineName(obx);
 			
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {

--- a/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV26.java
+++ b/bundles/ch.elexis.core.hl7.v2x/src/ch/elexis/hl7/v2x/HL7ReaderV26.java
@@ -71,7 +71,7 @@ public class HL7ReaderV26 extends HL7Reader {
 			if (sender == null) {
 				sender = msh.getMsh3_SendingApplication().getNamespaceID().getValue();
 				if (sender == null) {
-					sender = "";
+					sender = StringTool.leer;
 				}
 			}
 		} catch (HL7Exception e) {
@@ -115,12 +115,12 @@ public class HL7ReaderV26 extends HL7Reader {
 				OUL_R24_SPECIMEN specimen = oul.getORDER(idx).getSPECIMEN(i);
 				
 				// groupe and sequence
-				String group = "";
-				String sequence = "";
+				String group = StringTool.leer;
+				String sequence = StringTool.leer;
 				for (int k = 0; k < 2; k++) {
 					CWE cwe = obr.getObr47_FillerSupplementalServiceInformation(k);
 					if (cwe != null) {
-						String code = "";
+						String code = StringTool.leer;
 						if (cwe.getCwe3_NameOfCodingSystem() != null)
 							code = cwe.getCwe3_NameOfCodingSystem().getValue();
 						
@@ -131,7 +131,7 @@ public class HL7ReaderV26 extends HL7Reader {
 				
 				for (int obxIdx = 0; obxIdx < specimen.getOBXReps(); obxIdx++) {
 					// result
-					readOBXResults(specimen.getOBX(obxIdx), "", group, sequence,
+					readOBXResults(specimen.getOBX(obxIdx), StringTool.leer, group, sequence,
 						obrObservationDateTime);
 				}
 			}
@@ -158,12 +158,12 @@ public class HL7ReaderV26 extends HL7Reader {
 				String commentNTE = getComments(obs, i);
 				
 				// groupe and sequence
-				String group = "";
-				String sequence = "";
+				String group = StringTool.leer;
+				String sequence = StringTool.leer;
 				for (int k = 0; k < 2; k++) {
 					CWE cwe = obr.getObr47_FillerSupplementalServiceInformation(k);
 					if (cwe != null) {
-						String code = "";
+						String code = StringTool.leer;
 						if (cwe.getCwe3_NameOfCodingSystem() != null)
 							code = cwe.getCwe3_NameOfCodingSystem().getValue();
 						
@@ -184,7 +184,7 @@ public class HL7ReaderV26 extends HL7Reader {
 				return cwe.getCwe2_Text().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private String getSequence(String code, CWE cwe){
@@ -193,15 +193,15 @@ public class HL7ReaderV26 extends HL7Reader {
 				return cwe.getCwe1_Identifier().getValue();
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void setPatient(OUL_R24 oul, boolean createIfNotFound)
 		throws ParseException, DataTypeException{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -226,7 +226,7 @@ public class HL7ReaderV26 extends HL7Reader {
 						if (StringTool.isNothing(patid)) {
 							patid = patid_alternative;
 							if (patid == null) {
-								patid = "";
+								patid = StringTool.leer;
 							}
 						}
 					}
@@ -238,7 +238,7 @@ public class HL7ReaderV26 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -250,7 +250,7 @@ public class HL7ReaderV26 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oul.getPATIENT());
 			
@@ -318,9 +318,9 @@ public class HL7ReaderV26 extends HL7Reader {
 	private void setPatient(ORU_R01 oru, final boolean createIfNotFound)
 		throws ParseException, HL7Exception{
 		List<? extends IPatient> list = new ArrayList<IPatient>();
-		String lastName = ""; //$NON-NLS-1$
-		String firstName = ""; //$NON-NLS-1$
-		String birthDate = ""; //$NON-NLS-1$
+		String lastName = StringTool.leer; //$NON-NLS-1$
+		String firstName = StringTool.leer; //$NON-NLS-1$
+		String birthDate = StringTool.leer; //$NON-NLS-1$
 		String sex = Gender.FEMALE.value();
 		pat = null;
 		
@@ -345,7 +345,7 @@ public class HL7ReaderV26 extends HL7Reader {
 						if (StringTool.isNothing(patid)) {
 							patid = patid_alternative;
 							if (patid == null) {
-								patid = "";
+								patid = StringTool.leer;
 							}
 						}
 					}
@@ -357,7 +357,7 @@ public class HL7ReaderV26 extends HL7Reader {
 			}
 			
 			// String[] pidflds = patid.split("[\\^ ]+"); //$NON-NLS-1$
-			// String pid = "";
+			// String pid = StringTool.leer;
 			// if (pidflds.length > 0)
 			// pid = pidflds[pidflds.length - 1];
 			
@@ -369,7 +369,7 @@ public class HL7ReaderV26 extends HL7Reader {
 				lastName = pid.getPid5_PatientName(0).getFamilyName().getFn1_Surname().getValue();
 			if (pid.getPid5_PatientName(0).getGivenName().getValue() != null)
 				firstName = pid.getPid5_PatientName(0).getGivenName().getValue();
-			String patientName = firstName + " " + lastName;
+			String patientName = firstName + StringTool.space + lastName;
 			String patientNotesAndComments =
 				readPatientNotesAndComments(oru.getPATIENT_RESULT().getPATIENT());
 			
@@ -440,7 +440,7 @@ public class HL7ReaderV26 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -452,7 +452,7 @@ public class HL7ReaderV26 extends HL7Reader {
 			FT comment = patient.getNTE(i).getComment(0);
 			sb.append(comment.toString());
 			if (patient.getNTEReps() > i) {
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 		}
 		return sb.toString();
@@ -489,9 +489,9 @@ public class HL7ReaderV26 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -510,9 +510,9 @@ public class HL7ReaderV26 extends HL7Reader {
 			AbstractPrimitive comment = nte.getNte3_Comment(0);
 			if (comment != null) {
 				if (commentNTE != null) {
-					commentNTE += "\n";
+					commentNTE += StringTool.lf;
 				} else {
-					commentNTE = "";
+					commentNTE = StringTool.leer;
 				}
 				if (comment.getValue() != null) {
 					commentNTE += comment.getValue();
@@ -525,12 +525,12 @@ public class HL7ReaderV26 extends HL7Reader {
 	private void readOBXResults(OBX obx, String commentNTE, String group,
 		String sequence, String defaultDateTime) throws ParseException{
 		String valueType = obx.getObx2_ValueType().getValue();
-		String name = "";
-		String itemCode = "";
-		String unit = "";
-		String range = "";
-		String observationTime = "";
-		String status = "";
+		String name = StringTool.leer;
+		String itemCode = StringTool.leer;
+		String unit = StringTool.leer;
+		String range = StringTool.leer;
+		String observationTime = StringTool.leer;
+		String status = StringTool.leer;
 		Boolean flag;
 		String rawAbnormalFlags;
 		
@@ -553,7 +553,7 @@ public class HL7ReaderV26 extends HL7Reader {
 				commentNTE, group, sequence));
 		} else if (isTextOrNumeric(valueType)) {
 			name = determineName(obx);
-			String value = "";
+			String value = StringTool.leer;
 			Object tmp = obx.getObx5_ObservationValue(0).getData();
 			
 			if (tmp instanceof ST) {

--- a/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/AccessWrapper.java
+++ b/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/AccessWrapper.java
@@ -32,9 +32,10 @@ import ch.rgw.tools.JdbcLink;
  * @author Gerry Weirich
  *
  */
+import ch.rgw.tools.StringTool;
 public class AccessWrapper {
 	private Database db;
-	private static String ImportPrefix = "";
+	private static String ImportPrefix = StringTool.leer;
 	
 	/*
 	 * Open the mdbFile using sensible default
@@ -55,7 +56,7 @@ public class AccessWrapper {
 	/*
 	 * Set a prefix for the imported tablesnames
 	 * 
-	 * @param prefix prefix to be used. Default to ""
+	 * @param prefix prefix to be used. Default to StringTool.leer
 	 */
 	public void setPrefixForImportedTableNames(String prefix){
 		ImportPrefix = prefix;
@@ -85,7 +86,7 @@ public class AccessWrapper {
 		StringBuilder sb = new StringBuilder();
 		sb.append("CREATE TABLE ").append(insertName).append("(");//$NON-NLS-1$ //$NON-NLS-2$
 		for (Column c : cols) {
-			sb.append(c.getName()).append(" ");
+			sb.append(c.getName()).append(StringTool.space);
 			switch (c.getType()) {
 			case MEMO:
 				sb.append("TEXT");//$NON-NLS-1$

--- a/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/ExcelWrapper.java
+++ b/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/ExcelWrapper.java
@@ -35,6 +35,7 @@ import ch.rgw.tools.TimeTool;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class ExcelWrapper {
 	private Class<?>[] types;
 	private Sheet sheet;
@@ -116,7 +117,7 @@ public class ExcelWrapper {
 			if (cell != null) {
 				switch (cell.getCellType()) {
 				case Cell.CELL_TYPE_BLANK:
-					ret.add(""); //$NON-NLS-1$
+					ret.add(StringTool.leer); //$NON-NLS-1$
 					break;
 				case Cell.CELL_TYPE_BOOLEAN:
 					ret.add(Boolean.toString(cell.getBooleanCellValue()));
@@ -131,7 +132,7 @@ public class ExcelWrapper {
 								TimeTool tt = new TimeTool(date.getTime());
 								ret.add(tt.toString(TimeTool.FULL_MYSQL));
 							} else {
-								ret.add(""); //$NON-NLS-1$
+								ret.add(StringTool.leer); //$NON-NLS-1$
 							}
 						} else if (types[i].equals(Double.class)) {
 							ret.add(Double.toString(cell.getNumericCellValue()));
@@ -163,7 +164,7 @@ public class ExcelWrapper {
 				
 			} else {
 				// empty cell
-				ret.add(""); //$NON-NLS-1$
+				ret.add(StringTool.leer); //$NON-NLS-1$
 			}
 		}
 		return ret;
@@ -201,6 +202,6 @@ public class ExcelWrapper {
 		if (row.size() > col) {
 			return row.get(col);
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 }

--- a/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/HL7Parser.java
+++ b/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/HL7Parser.java
@@ -97,7 +97,7 @@ public class HL7Parser {
 	public Result<Object> parse(final HL7Reader hl7Reader, ILabItemResolver labItemResolver,
 		ILabContactResolver labContactResolver, boolean createPatientIfNotFound){
 		final TimeTool transmissionTime = new TimeTool();
-		String orderId = "";
+		String orderId = StringTool.leer;
 		
 		ILabContactResolver labResolver = labContactResolver != null ? labContactResolver : this.labContactResolver;
 
@@ -171,8 +171,8 @@ public class HL7Parser {
 						if (hl7LabResult.isNumeric() == false) {
 							typ = LabItemTyp.TEXT;
 						}
-						String refMale = "";
-						String refFemale = "";
+						String refMale = StringTool.leer;
+						String refFemale = StringTool.leer;
 						if (pat.getGender().equals(Gender.MALE)) {
 							refMale = hl7LabResult.getRange();
 						} else {
@@ -210,7 +210,7 @@ public class HL7Parser {
 						TransientLabResult importedResult =
 							new TransientLabResult.Builder(pat, labor, labItem, "text")
 								.date(obrDateTime)
-								.comment(StringTool.unNull(hl7LabResult.getValue()) + "\n"
+								.comment(StringTool.unNull(hl7LabResult.getValue()) + StringTool.lf
 									+ StringTool.unNull(hl7LabResult.getComment()))
 								.flags(flag).rawAbnormalFlags(hl7LabResult.getRawAbnormalFlag())
 								.unit(hl7LabResult.getUnit()).ref(hl7LabResult.getRange())
@@ -248,13 +248,13 @@ public class HL7Parser {
 							}
 						}
 						date = new TimeTool(hl7EncData.getDate());
-						String dateString = date.toString(TimeTool.DATETIME_XML).replace(":", "");
-						dateString = dateString.replace("-", "");
+						String dateString = date.toString(TimeTool.DATETIME_XML).replace(":", StringTool.leer);
+						dateString = dateString.replace("-", StringTool.leer);
 						String title = "Lab-" + dateString + "-" + hl7EncData.getSequence();
 						
-						String fileType = "";
-						if (hl7EncData.getName().contains("/")) {
-							String[] split = hl7EncData.getName().split("/");
+						String fileType = StringTool.leer;
+						if (hl7EncData.getName().contains(StringTool.slash)) {
+							String[] split = hl7EncData.getName().split(StringTool.slash);
 							if (split.length == 2) {
 								fileType = split[1];
 								title = title + "." + fileType;
@@ -268,8 +268,8 @@ public class HL7Parser {
 						ILabItem labItem =
 							labImportUtil.getDocumentLabItem(liShort, liName, labor).orElse(null);
 						if (labItem == null) {
-							labItem = labImportUtil.createLabItem(liShort, liName, labor, "", "",
-								fileType, LabItemTyp.DOCUMENT, hl7EncData.getGroup(), "");
+							labItem = labImportUtil.createLabItem(liShort, liName, labor, StringTool.leer, StringTool.leer,
+								fileType, LabItemTyp.DOCUMENT, hl7EncData.getGroup(), StringTool.leer);
 						}
 						
 						TransientLabResult importedResult =
@@ -299,7 +299,7 @@ public class HL7Parser {
 							.orElse(null);
 						if (labItem == null) {
 							labItem = labImportUtil.createLabItem(HL7Constants.COMMENT_CODE,
-								HL7Constants.COMMENT_NAME, labor, "", "", "", LabItemTyp.TEXT,
+								HL7Constants.COMMENT_NAME, labor, StringTool.leer, StringTool.leer, StringTool.leer, LabItemTyp.TEXT,
 								HL7Constants.COMMENT_GROUP, Integer.toString(number));
 						}
 						
@@ -330,7 +330,7 @@ public class HL7Parser {
 				if (labItem == null) {
 					labItem =
 						labImportUtil.createLabItem("NOTE", Messages.HL7Parser_LabItem_Note_Name,
-							labor, "", "", "", LabItemTyp.TEXT, "AA", "1");
+							labor, StringTool.leer, StringTool.leer, StringTool.leer, LabItemTyp.TEXT, "AA", "1");
 					logger.debug("LabItem created [{}]", labItem);
 				}
 				
@@ -484,7 +484,7 @@ public class HL7Parser {
 				if (res == null) {
 					res = r;
 				} else {
-					res.add(r.getSeverity(), 1, "", null, true); //$NON-NLS-1$
+					res.add(r.getSeverity(), 1, StringTool.leer, null, true); //$NON-NLS-1$
 				}
 			}
 		}

--- a/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/internal/LabImportUtil.java
+++ b/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/internal/LabImportUtil.java
@@ -56,6 +56,7 @@ import ch.rgw.tools.TimeTool;
  * @author thomashu
  * 
  */
+import ch.rgw.tools.StringTool;
 @Component
 public class LabImportUtil implements ILabImportUtil {
 	
@@ -301,7 +302,7 @@ public class LabImportUtil implements ILabImportUtil {
 			// case 1 try to find mandant via orc message
 			if (orcMessage != null && !orcMessage.getNames().isEmpty()) {
 				for (String name : orcMessage.getNames()) {
-					String[] splitNames = name.split(" ");
+					String[] splitNames = name.split(StringTool.space);
 					int size = splitNames.length;
 					if (size > 1) {
 						IQuery<IMandator> query = modelService.getQuery(IMandator.class);

--- a/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/multifile/strategy/DefaultPDFImportStrategy.java
+++ b/bundles/ch.elexis.core.importer.div/src/ch/elexis/core/importer/div/importers/multifile/strategy/DefaultPDFImportStrategy.java
@@ -43,6 +43,7 @@ import ch.rgw.tools.TimeTool;
  * @author lucia
  * 
  */
+import ch.rgw.tools.StringTool;
 public class DefaultPDFImportStrategy implements IFileImportStrategy {
 	private static final Logger log = LoggerFactory.getLogger(DefaultPDFImportStrategy.class);
 
@@ -101,7 +102,7 @@ public class DefaultPDFImportStrategy implements IFileImportStrategy {
 				}
 			}
 			return new Result<>(SEVERITY.ERROR, 2,
-					Messages.DefaultPDFImportStrategy_InitContextFailed + "\n" + ise.getMessage(), context, true);
+					Messages.DefaultPDFImportStrategy_InitContextFailed + StringTool.lf + ise.getMessage(), context, true);
 		}
 
 		// get or create LabItem and create labresult
@@ -109,7 +110,7 @@ public class DefaultPDFImportStrategy implements IFileImportStrategy {
 		String shortname = "doc";
 		ILabItem labItem = LabImportUtilHolder.get().getLabItem(shortname, name, LabItemTyp.DOCUMENT).orElse(null);
 		if (labItem == null) {
-			labItem = LabImportUtilHolder.get().createLabItem(shortname, name, myLab, "", "", PDF, LabItemTyp.DOCUMENT,
+			labItem = LabImportUtilHolder.get().createLabItem(shortname, name, myLab, StringTool.leer, StringTool.leer, PDF, LabItemTyp.DOCUMENT,
 					group, prio);
 			log.debug("LabItem created [{}]", labItem);
 		}
@@ -198,7 +199,7 @@ public class DefaultPDFImportStrategy implements IFileImportStrategy {
 		SimpleDateFormat sdfTitle = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"); //$NON-NLS-1$
 		String title = "Laborbefund" + sdfTitle.format(dateTime.getTime()) + "." //$NON-NLS-2$
 				+ FileTool.getExtension(filename);
-		log.debug("generated labresult pdf title '" + title + "");
+		log.debug("generated labresult pdf title '" + title + StringTool.leer);
 		return title;
 	}
 

--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBInitializer.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBInitializer.java
@@ -21,6 +21,7 @@ import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 
+import ch.rgw.tools.StringTool;
 public class LiquibaseDBInitializer {
 
 	private static Logger logger = LoggerFactory.getLogger(LiquibaseDBInitializer.class);
@@ -48,10 +49,10 @@ public class LiquibaseDBInitializer {
 			// else sync the changelog as the db already exists
 			if (isFirstStart(connection)) {
 				logger.info("Initialize database [" + connection + "] with liquibase");
-				liquibase.update("");
+				liquibase.update(StringTool.leer);
 			} else {
 				logger.info("Synchronize liquibase log of database [" + connection + "]");
-				liquibase.changeLogSync("");
+				liquibase.changeLogSync(StringTool.leer);
 			}
 		} catch (LiquibaseException | SQLException e) {
 			// log and try to carry on

--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBScriptExecutor.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBScriptExecutor.java
@@ -22,6 +22,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ResourceAccessor;
 
+import ch.rgw.tools.StringTool;
 public class LiquibaseDBScriptExecutor {
 
 	private static Logger logger = LoggerFactory.getLogger(LiquibaseDBScriptExecutor.class);
@@ -44,7 +45,7 @@ public class LiquibaseDBScriptExecutor {
 				DatabaseFactory.getInstance().findCorrectDatabaseImplementation(database);
 			
 			Liquibase liquibase = new Liquibase(changeId, resourceAccessor, targetDb);
-			liquibase.update("");
+			liquibase.update(StringTool.leer);
 			return true;
 		} catch (LiquibaseException | SQLException e) {
 			// log and try to carry on

--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBUpdater.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/liquibase/LiquibaseDBUpdater.java
@@ -17,6 +17,7 @@ import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 
+import ch.rgw.tools.StringTool;
 public class LiquibaseDBUpdater {
 
 	private static Logger logger = LoggerFactory.getLogger(LiquibaseDBUpdater.class);
@@ -41,7 +42,7 @@ public class LiquibaseDBUpdater {
 
 			Liquibase liquibase = new Liquibase(changelogXmlUrl, resourceAccessor, targetDb);
 			logger.info("Updating database [" + connection + "] with liquibase");
-			liquibase.update("");
+			liquibase.update(StringTool.leer);
 		} catch (LiquibaseException | SQLException e) {
 			// log and try to carry on
 			logger.warn("Exception on DB init.", e);

--- a/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/event/EntityChangeEventListener.java
+++ b/bundles/ch.elexis.core.jpa/src/ch/elexis/core/jpa/model/adapter/event/EntityChangeEventListener.java
@@ -17,9 +17,10 @@ import ch.elexis.core.common.ElexisEventTopics;
 import ch.elexis.core.jpa.entities.EntityWithId;
 import ch.elexis.core.jpa.model.adapter.AbstractIdModelAdapter;
 
+import ch.rgw.tools.StringTool;
 @Component(service = {
 	EventHandler.class, EntityChangeEventListener.class
-}, property = EventConstants.EVENT_TOPIC + "=" + ElexisEventTopics.PERSISTENCE_EVENT_ENTITYCHANGED)
+}, property = EventConstants.EVENT_TOPIC + StringTool.equals + ElexisEventTopics.PERSISTENCE_EVENT_ENTITYCHANGED)
 public class EntityChangeEventListener implements EventHandler {
 	
 	private static Logger logger = LoggerFactory.getLogger(EntityChangeEventListener.class);

--- a/bundles/ch.elexis.core.mail.ui/src/ch/elexis/core/mail/ui/dialogs/SendMailDialog.java
+++ b/bundles/ch.elexis.core.mail.ui/src/ch/elexis/core/mail/ui/dialogs/SendMailDialog.java
@@ -37,18 +37,19 @@ import ch.elexis.core.ui.dialogs.KontaktSelektor;
 import ch.elexis.data.Kontakt;
 import ch.elexis.data.Mandant;
 
+import ch.rgw.tools.StringTool;
 public class SendMailDialog extends TitleAreaDialog {
 	
 	private ComboViewer accountsViewer;
 	private MailAccount account;
 	private Text toText;
-	private String toString = "";
+	private String toString = StringTool.leer;
 	private Text subjectText;
-	private String subjectString = "";
+	private String subjectString = StringTool.leer;
 	private Text textText;
-	private String textString = "";
+	private String textString = StringTool.leer;
 	private Label attachmentsLabel;
-	private String attachmentsString = "";
+	private String attachmentsString = StringTool.leer;
 	
 	public SendMailDialog(Shell parentShell){
 		super(parentShell);

--- a/bundles/ch.elexis.core.mail.ui/src/ch/elexis/core/mail/ui/preference/MailAccountComposite.java
+++ b/bundles/ch.elexis.core.mail.ui/src/ch/elexis/core/mail/ui/preference/MailAccountComposite.java
@@ -42,6 +42,7 @@ import ch.elexis.core.ui.dialogs.KontaktSelektor;
 import ch.elexis.data.Kontakt;
 import ch.elexis.data.Mandant;
 
+import ch.rgw.tools.StringTool;
 public class MailAccountComposite extends Composite {
 
 	private WritableValue value;
@@ -76,7 +77,7 @@ public class MailAccountComposite extends Composite {
 			if (s != null && !s.isEmpty()) {
 				return ValidationStatus.ok();
 			}
-			return ValidationStatus.error("");
+			return ValidationStatus.error(StringTool.leer);
 		});
 		Binding binding = context.bindValue(target, model, targetToModel, null);
 		ControlDecorationSupport.create(binding, SWT.TOP | SWT.LEFT);
@@ -147,7 +148,7 @@ public class MailAccountComposite extends Composite {
 			if (s != null && !s.isEmpty()) {
 				return ValidationStatus.ok();
 			}
-			return ValidationStatus.error("");
+			return ValidationStatus.error(StringTool.leer);
 		});
 		binding = context.bindValue(target, model, targetToModel, null);
 		ControlDecorationSupport.create(binding, SWT.TOP | SWT.LEFT);
@@ -164,7 +165,7 @@ public class MailAccountComposite extends Composite {
 			if (s != null && !s.isEmpty()) {
 				return ValidationStatus.ok();
 			}
-			return ValidationStatus.error("");
+			return ValidationStatus.error(StringTool.leer);
 		});
 		binding = context.bindValue(target, model, targetToModel, null);
 		ControlDecorationSupport.create(binding, SWT.TOP | SWT.LEFT);

--- a/bundles/ch.elexis.core.mail/src/ch/elexis/core/mail/MailAccount.java
+++ b/bundles/ch.elexis.core.mail/src/ch/elexis/core/mail/MailAccount.java
@@ -14,6 +14,7 @@ import ch.elexis.data.Mandant;
  * @author thomas
  *
  */
+import ch.rgw.tools.StringTool;
 public class MailAccount {
 	
 	private static final String SEPARATOR = ",";
@@ -128,7 +129,7 @@ public class MailAccount {
 		if (parts != null && parts.length > 2) {
 			ret = new MailAccount();
 			for (String string : parts) {
-				String[] subParts = string.split("=");
+				String[] subParts = string.split(StringTool.equals);
 				if (subParts != null && subParts.length == 2) {
 					setField(subParts[0], subParts[1], ret);
 				}

--- a/bundles/ch.elexis.core.mail/src/ch/elexis/core/mail/internal/MailClient.java
+++ b/bundles/ch.elexis.core.mail/src/ch/elexis/core/mail/internal/MailClient.java
@@ -36,6 +36,7 @@ import ch.elexis.core.mail.MailAccount;
 import ch.elexis.core.mail.MailAccount.TYPE;
 import ch.elexis.core.mail.MailMessage;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class MailClient implements IMailClient {
 	
@@ -69,7 +70,7 @@ public class MailClient implements IMailClient {
 	@Override
 	public Optional<MailAccount> getAccount(String id){
 		MailAccount ret = null;
-		String accountString = CoreHub.globalCfg.get(CONFIG_ACCOUNT + "/" + id, null);
+		String accountString = CoreHub.globalCfg.get(CONFIG_ACCOUNT + StringTool.slash + id, null);
 		if (accountString != null) {
 			ret = MailAccount.from(accountString);
 		}
@@ -91,7 +92,7 @@ public class MailClient implements IMailClient {
 	public void saveAccount(MailAccount account){
 		if (account != null && account.getId() != null) {
 			addAccountId(account.getId());
-			CoreHub.globalCfg.set(CONFIG_ACCOUNT + "/" + account.getId(), account.toString());
+			CoreHub.globalCfg.set(CONFIG_ACCOUNT + StringTool.slash + account.getId(), account.toString());
 			CoreHub.globalCfg.flush();
 		}
 	}
@@ -121,7 +122,7 @@ public class MailClient implements IMailClient {
 	public void removeAccount(MailAccount account){
 		if (account != null && account.getId() != null) {
 			removeAccountId(account.getId());
-			CoreHub.globalCfg.remove(CONFIG_ACCOUNT + "/" + account.getId());
+			CoreHub.globalCfg.remove(CONFIG_ACCOUNT + StringTool.slash + account.getId());
 			CoreHub.globalCfg.flush();
 		}
 	}

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/ArticleDefaultSignature.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/ArticleDefaultSignature.java
@@ -9,6 +9,7 @@ import ch.elexis.core.model.article.defaultsignature.Constants;
 import ch.elexis.core.model.prescription.EntryType;
 import ch.elexis.core.services.holder.StoreToStringServiceHolder;
 
+import ch.rgw.tools.StringTool;
 public class ArticleDefaultSignature
 		extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.DefaultSignature>
 		implements IdentifiableWithXid, IArticleDefaultSignature {
@@ -109,7 +110,7 @@ public class ArticleDefaultSignature
 	@Override
 	public void setFreeText(String value){
 		if (value == null) {
-			value = "";
+			value = StringTool.leer;
 		}
 		setExtInfo(Constants.EXT_FLD_FREETEXT, value);
 	}

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Blob.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Blob.java
@@ -8,6 +8,7 @@ import ch.elexis.core.jpa.entities.Heap;
 import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.jpa.model.util.JpaModelUtil;
 
+import ch.rgw.tools.StringTool;
 public class Blob extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Heap>
 		implements IdentifiableWithXid, Deleteable, IBlob {
 	
@@ -29,7 +30,7 @@ public class Blob extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entiti
 	public String getStringContent(){
 		byte[] comp = getContent();
 		if ((comp == null) || (comp.length == 0)) {
-			return "";
+			return StringTool.leer;
 		}
 		byte[] exp = JpaModelUtil.getExpanded(comp);
 		try {

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/BlobSecondary.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/BlobSecondary.java
@@ -8,6 +8,7 @@ import ch.elexis.core.jpa.entities.Heap2;
 import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.jpa.model.util.JpaModelUtil;
 
+import ch.rgw.tools.StringTool;
 public class BlobSecondary extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Heap2>
 		implements IdentifiableWithXid, IBlobSecondary {
 	
@@ -29,7 +30,7 @@ public class BlobSecondary extends AbstractIdDeleteModelAdapter<ch.elexis.core.j
 	public String getStringContent(){
 		byte[] comp = getContent();
 		if ((comp == null) || (comp.length == 0)) {
-			return "";
+			return StringTool.leer;
 		}
 		byte[] exp = JpaModelUtil.getExpanded(comp);
 		try {

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Contact.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Contact.java
@@ -17,6 +17,7 @@ import ch.elexis.core.model.service.holder.CoreModelServiceHolder;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.elexis.core.types.Country;
 
+import ch.rgw.tools.StringTool;
 public class Contact extends AbstractIdDeleteModelAdapter<Kontakt> implements IdentifiableWithXid, IContact {
 
 	public Contact(Kontakt entity) {
@@ -246,12 +247,12 @@ public class Contact extends AbstractIdDeleteModelAdapter<Kontakt> implements Id
 	@Override
 	public String getLabel() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getDescription1()).append(" ").append(StringUtils.defaultString(getDescription2()));
+		sb.append(getDescription1()).append(StringTool.space).append(StringUtils.defaultString(getDescription2()));
 		if (!StringUtils.isBlank(getDescription3())) {
 			sb.append("(").append(getDescription3()).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		sb.append(", ").append(StringUtils.defaultString(getStreet())).append(", ") //$NON-NLS-1$ //$NON-NLS-2$
-				.append(StringUtils.defaultString(getZip())).append(" ").append(StringUtils.defaultString(getCity()));
+				.append(StringUtils.defaultString(getZip())).append(StringTool.space).append(StringUtils.defaultString(getCity()));
 		return sb.toString();
 	}
 

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/DiagnosisReference.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/DiagnosisReference.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 
+import ch.rgw.tools.StringTool;
 public class DiagnosisReference
 		extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Diagnosis>
 		implements IdentifiableWithXid, IDiagnosisReference {
@@ -40,7 +41,7 @@ public class DiagnosisReference
 	
 	@Override
 	public String getDescription(){
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/DocumentLetter.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/DocumentLetter.java
@@ -21,12 +21,13 @@ import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.elexis.core.types.DocumentStatus;
 
+import ch.rgw.tools.StringTool;
 public class DocumentLetter extends AbstractIdDeleteModelAdapter<Brief>
 		implements IdentifiableWithXid, IDocumentLetter {
 	
 	private ICategory category;
 	private DocumentStatus status;
-	private String storeId = "";
+	private String storeId = StringTool.leer;
 	private List<IHistory> history;
 	private String keywords;
 	

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Encounter.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Encounter.java
@@ -19,6 +19,7 @@ import ch.elexis.core.model.service.holder.CoreModelServiceHolder;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.rgw.tools.VersionedResource;
 
+import ch.rgw.tools.StringTool;
 public class Encounter extends AbstractIdDeleteModelAdapter<Behandlung>
 		implements IdentifiableWithXid, IEncounter {
 
@@ -205,7 +206,7 @@ public class Encounter extends AbstractIdDeleteModelAdapter<Behandlung>
 	}
 	
 	private String getInvoiceStateText(){
-		String statusText = "";
+		String statusText = StringTool.leer;
 		
 		IInvoice rechnung = getInvoice();
 		if (rechnung != null) {

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/LabItem.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/LabItem.java
@@ -11,6 +11,7 @@ import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.elexis.core.types.LabItemTyp;
 
+import ch.rgw.tools.StringTool;
 public class LabItem extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.LabItem>
 		implements IdentifiableWithXid, ILabItem {
 	
@@ -125,7 +126,7 @@ public class LabItem extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.ent
 		if (formula == null || formula.isEmpty()) {
 			String[] refWEntry =
 				StringUtils.defaultString(getEntity().getReferenceFemale()).split("##");
-			formula = refWEntry.length > 1 ? refWEntry[1] : "";
+			formula = refWEntry.length > 1 ? refWEntry[1] : StringTool.leer;
 			
 			if (formula != null && !formula.isEmpty()) {
 				setFormula(formula);
@@ -205,8 +206,8 @@ public class LabItem extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.ent
 	@Override
 	public String getVariableName(){
 		String group = getGroup();
-		if (group != null && group.contains(" ")) {
-			String[] group_tokens = group.split(" ", 2);
+		if (group != null && group.contains(StringTool.space)) {
+			String[] group_tokens = group.split(StringTool.space, 2);
 			String prio = getPriority();
 			String num = (prio != null) ? prio.trim() : "9999";
 			return group_tokens[0] + "_" + num;
@@ -221,7 +222,7 @@ public class LabItem extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.ent
 		sb.append(getCode() + ", " + getName());
 		if (LabItemTyp.NUMERIC == getTyp()) {
 			sb.append(
-				" (" + getReferenceMale() + "/" + getReferenceFemale() + " " + getUnit() + ")");
+				" (" + getReferenceMale() + StringTool.slash + getReferenceFemale() + StringTool.space + getUnit() + ")");
 		} else {
 			sb.append(" (" + getReferenceFemale() + ")");
 		}

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Order.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Order.java
@@ -11,6 +11,7 @@ import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.elexis.core.services.INamedQuery;
 
+import ch.rgw.tools.StringTool;
 public class Order extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Bestellung>
 		implements IdentifiableWithXid, IOrder {
 	
@@ -103,7 +104,7 @@ public class Order extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entit
 				return parts[0];
 			}
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override
@@ -119,9 +120,9 @@ public class Order extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entit
 			throw new IllegalStateException("Can not update id without timestamp");
 		}
 		Optional<IContact> activeUser = ModelUtil.getActiveUserContact();
-		String id = (name != null ? name : "") + ":"
-			+ (timestamp != null ? timestamp.format(timestampFormatter) : "") + ":"
-			+ (activeUser.isPresent() ? activeUser.get().getId() : "");
+		String id = (name != null ? name : StringTool.leer) + ":"
+			+ (timestamp != null ? timestamp.format(timestampFormatter) : StringTool.leer) + ":"
+			+ (activeUser.isPresent() ? activeUser.get().getId() : StringTool.leer);
 		getEntityMarkDirty().setId(id);
 	}
 	

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Prescription.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/Prescription.java
@@ -14,6 +14,7 @@ import ch.elexis.core.model.prescription.EntryType;
 import ch.elexis.core.model.util.internal.ModelUtil;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
 
+import ch.rgw.tools.StringTool;
 public class Prescription
 		extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Prescription>
 		implements IdentifiableWithXid, IPrescription {
@@ -222,7 +223,7 @@ public class Prescription
 	
 	@Override
 	public String getLabel(){
-		return getSimpleLabel() + " " + getDosageInstruction();
+		return getSimpleLabel() + StringTool.space + getDosageInstruction();
 	}
 	
 	private String getSimpleLabel(){

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/TypedArticle.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/TypedArticle.java
@@ -20,6 +20,7 @@ import ch.elexis.core.types.ArticleTyp;
 import ch.elexis.core.types.VatInfo;
 import ch.rgw.tools.Money;
 
+import ch.rgw.tools.StringTool;
 public class TypedArticle extends AbstractIdDeleteModelAdapter<ch.elexis.core.jpa.entities.Artikel>
 		implements IdentifiableWithXid, IArticle {
 	
@@ -142,7 +143,7 @@ public class TypedArticle extends AbstractIdDeleteModelAdapter<ch.elexis.core.jp
 		} else if (isTyp(ArticleTyp.MIGEL)) {
 			return (String) getExtInfo("unit");
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/UserConfig.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/UserConfig.java
@@ -6,6 +6,7 @@ import ch.elexis.core.jpa.model.adapter.AbstractIdDeleteModelAdapter;
 import ch.elexis.core.jpa.model.adapter.AbstractIdModelAdapter;
 import ch.elexis.core.model.service.holder.CoreModelServiceHolder;
 
+import ch.rgw.tools.StringTool;
 public class UserConfig extends AbstractIdModelAdapter<ch.elexis.core.jpa.entities.Userconfig>
 		implements IdentifiableWithXid, IUserConfig {
 	
@@ -20,7 +21,7 @@ public class UserConfig extends AbstractIdModelAdapter<ch.elexis.core.jpa.entiti
 	
 	@Override
 	public String getLabel(){
-		return getEntity().getOwnerId() + " " + getEntity().getParam() + " -> "
+		return getEntity().getOwnerId() + StringTool.space + getEntity().getParam() + " -> "
 			+ getEntity().getValue();
 	}
 	

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/util/internal/LabPathologicEvaluator.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/util/internal/LabPathologicEvaluator.java
@@ -16,6 +16,7 @@ import ch.elexis.core.types.LabItemTyp;
 import ch.elexis.core.types.PathologicDescription;
 import ch.elexis.core.types.PathologicDescription.Description;
 
+import ch.rgw.tools.StringTool;
 public class LabPathologicEvaluator {
 	
 	private static Pattern refValuesPattern = Pattern.compile("\\((.*?)\\)"); //$NON-NLS-1$
@@ -159,8 +160,8 @@ public class LabPathologicEvaluator {
 	private boolean isUsingItemRef(ILabResult labResult, Gender gender){
 		boolean useLocalRefs = ModelUtil.isUserConfig(ModelUtil.getActiveUserContact().orElse(null),
 			Preferences.LABSETTINGS_CFG_LOCAL_REFVALUES, true);
-		String localRef = "";
-		String ref = "";
+		String localRef = StringTool.leer;
+		String ref = StringTool.leer;
 		if (gender == Gender.MALE) {
 			localRef = labResult.getItem().getReferenceMale();
 			ref = labResult.getReferenceMale();
@@ -188,7 +189,7 @@ public class LabPathologicEvaluator {
 		Gender gender = labResult.getPatient().getGender();
 		
 		Description description = Description.PATHO_REF;
-		String refValue = "";
+		String refValue = StringTool.leer;
 		if (Gender.MALE == gender) {
 			refValue = labResult.getReferenceMale();
 			if (StringUtils.isEmpty(refValue)) {

--- a/bundles/ch.elexis.core.model/src/ch/elexis/core/model/util/internal/ModelUtil.java
+++ b/bundles/ch.elexis.core.model/src/ch/elexis/core/model/util/internal/ModelUtil.java
@@ -46,6 +46,7 @@ import ch.rgw.tools.MimeTool;
  * @author thomas
  *
  */
+import ch.rgw.tools.StringTool;
 public class ModelUtil {
 	
 	private static Logger logger = LoggerFactory.getLogger(ModelUtil.class);
@@ -390,14 +391,14 @@ public class ModelUtil {
 				sb.append(kontakt.getDescription1());
 			}
 			if (StringUtils.isNotBlank(sb.toString())) {
-				sb.append(" ");
+				sb.append(StringTool.space);
 			}
 			if (StringUtils.isNoneEmpty(kontakt.getDescription2())) {
 				sb.append(kontakt.getDescription2());
 			}
 			
 			if (kontakt.getDob() != null) {
-				sb.append(" ").append(defaultDateFormatter.format(kontakt.getDob()));
+				sb.append(StringTool.space).append(defaultDateFormatter.format(kontakt.getDob()));
 			}
 			
 			if (StringUtils.isNoneEmpty(kontakt.getTitel())) {

--- a/bundles/ch.elexis.core.scripting.beanshell/src/ch/elexis/scripting/beanshell/Interpreter.java
+++ b/bundles/ch.elexis.core.scripting.beanshell/src/ch/elexis/scripting/beanshell/Interpreter.java
@@ -13,6 +13,7 @@ import ch.elexis.data.Script;
 import ch.elexis.scripting.beanshell.internal.MultiClassLoader;
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class Interpreter implements ch.elexis.core.data.interfaces.scripting.Interpreter,
 		IExecutableExtension {
 	private bsh.Interpreter scripter = new bsh.Interpreter();
@@ -51,13 +52,13 @@ public class Interpreter implements ch.elexis.core.data.interfaces.scripting.Int
 			throw (new ElexisException(Script.class, e.getMessage(),
 				ElexisException.EE_UNEXPECTED_RESPONSE));
 		} catch (ParseException e) {
-			String msg = "";
+			String msg = StringTool.leer;
 			if (e != null) {
 				try {
 					msg = e.getMessage();
 					// msg = e.getErrorText();
 					if (msg == null) {
-						msg = "";
+						msg = StringTool.leer;
 					}
 				} catch (Exception ex) {
 					ExHandler.handle(ex);

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/AccountService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/AccountService.java
@@ -11,12 +11,13 @@ import org.osgi.service.component.annotations.Reference;
 import ch.elexis.core.model.IAccount;
 import ch.elexis.core.services.internal.Account;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class AccountService implements IAccountService {
 	private static final String ACCOUNTS_CONFIG = "ch.elexis.core.data/accounttransaction/accounts"; //$NON-NLS-1$
 	private static final String ACCOUNTS_SEPARATOR = "||"; //$NON-NLS-1$
 	
-	public Account UNKNOWN = new Account(-1, "");
+	public Account UNKNOWN = new Account(-1, StringTool.leer);
 	private HashMap<Integer, IAccount> localCache;
 
 	@Reference
@@ -25,7 +26,7 @@ public class AccountService implements IAccountService {
 	private List<IAccount> loadAccounts(){
 		List<IAccount> ret = new ArrayList<>();
 		ret.add(UNKNOWN);
-		String accountsString = configService.get(ACCOUNTS_CONFIG, ""); //$NON-NLS-1$
+		String accountsString = configService.get(ACCOUNTS_CONFIG, StringTool.leer); //$NON-NLS-1$
 		if (accountsString != null && !accountsString.isEmpty()) {
 			String[] accounts = accountsString.split("\\|\\|"); //$NON-NLS-1$
 			for (String string : accounts) {
@@ -74,7 +75,7 @@ public class AccountService implements IAccountService {
 	
 	@Override
 	public void addAccount(IAccount newAccount){
-		String existingString = configService.get(ACCOUNTS_CONFIG, "");
+		String existingString = configService.get(ACCOUNTS_CONFIG, StringTool.leer);
 		StringBuilder sb = new StringBuilder();
 		sb.append(existingString);
 		if (sb.length() > 0) {

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/AppointmentService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/AppointmentService.java
@@ -174,7 +174,7 @@ public class AppointmentService implements IAppointmentService {
 		}
 		
 		Hashtable<String, String> map = StringTool.foldStrings(
-			ConfigServiceHolder.get().get("agenda/tagesvorgaben" + "/" + schedule, null));
+			ConfigServiceHolder.get().get("agenda/tagesvorgaben" + StringTool.slash + schedule, null));
 		if (map == null) {
 			map = new Hashtable<String, String>();
 		}
@@ -188,7 +188,7 @@ public class AppointmentService implements IAppointmentService {
 		String[] flds = ds.split("\r*\n\r*"); //$NON-NLS-1$
 		for (String fld : flds) {
 			String from = fld.substring(0, 4);
-			String until = fld.replaceAll("-", "").substring(4); //$NON-NLS-1$ //$NON-NLS-2$
+			String until = fld.replaceAll("-", StringTool.leer).substring(4); //$NON-NLS-1$ //$NON-NLS-2$
 			// Lege Termine für die Tagesgrenzen an
 			IAppointment iAppointment = CoreModelServiceHolder.get().create(IAppointment.class);
 			LocalDateTime startTime =

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/BillingService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/BillingService.java
@@ -34,6 +34,7 @@ import ch.elexis.core.services.holder.ContextServiceHolder;
 import ch.rgw.tools.Result;
 import ch.rgw.tools.Result.SEVERITY;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class BillingService implements IBillingService {
 	
@@ -123,7 +124,7 @@ public class BillingService implements IBillingService {
 		if (ok) {
 			return new Result<>(encounter);
 		} else {
-			String msg = "";
+			String msg = StringTool.leer;
 			if (!mandatorLoggedIn) {
 				msg = "Es ist kein Mandant eingeloggt";
 			} else {

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/BillingSystemService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/BillingSystemService.java
@@ -14,6 +14,7 @@ import ch.elexis.core.model.BillingSystem;
 import ch.elexis.core.model.IBillingSystem;
 import ch.elexis.core.model.ch.BillingLaw;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class BillingSystemService implements IBillingSystemService {
 	
@@ -24,21 +25,21 @@ public class BillingSystemService implements IBillingSystemService {
 	
 	@Override
 	public String getRequirements(IBillingSystem system){
-		String value = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String value = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ system.getName() + "/bedingungen", null);
 		return value;
 	}
 	
 	@Override
 	public String getDefaultPrintSystem(IBillingSystem system){
-		String value = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String value = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ system.getName() + "/standardausgabe", null);
 		return value;
 	}
 	
 	@Override
 	public List<String> getBillingSystemConstants(IBillingSystem billingSystem){
-		String bc = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
+		String bc = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
 			+ billingSystem + "/constants", null); //$NON-NLS-1$
 		if (bc == null) {
 			return Collections.emptyList();
@@ -51,12 +52,12 @@ public class BillingSystemService implements IBillingSystemService {
 	public String getBillingSystemConstant(IBillingSystem billingSystem, String name){
 		List<String> constants = getBillingSystemConstants(billingSystem);
 		for (String bc : constants) {
-			String[] val = bc.split("="); //$NON-NLS-1$
+			String[] val = bc.split(StringTool.equals); //$NON-NLS-1$
 			if (val[0].equalsIgnoreCase(name)) {
 				return val[1];
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	@Override
@@ -111,15 +112,15 @@ public class BillingSystemService implements IBillingSystemService {
 	
 	private String getConfigurationValue(String billingSystemName, String attributeName,
 		String defaultIfNotDefined){
-		String ret = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + "/" //$NON-NLS-1$
-			+ billingSystemName + "/" + attributeName, defaultIfNotDefined); //$NON-NLS-1$
+		String ret = configService.get(Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash //$NON-NLS-1$
+			+ billingSystemName + StringTool.slash + attributeName, defaultIfNotDefined); //$NON-NLS-1$
 		return ret;
 	}
 	
 	private void setConfigurationValue(String billingSystemName, String attributeName,
 		String attributeValue){
-		String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + billingSystemName; //$NON-NLS-1$
-		configService.set(key + "/" + attributeName, attributeValue);
+		String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + billingSystemName; //$NON-NLS-1$
+		configService.set(key + StringTool.slash + attributeName, attributeValue);
 	}
 	
 }

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/ConfigService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/ConfigService.java
@@ -34,6 +34,7 @@ import ch.elexis.core.utils.CoreUtil;
 import ch.rgw.io.Settings;
 import ch.rgw.io.SysSettings;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class ConfigService implements IConfigService {
 	
@@ -72,7 +73,7 @@ public class ConfigService implements IConfigService {
 		String config = "default"; //$NON-NLS-1$
 		for (String s : args) {
 			if (s.startsWith("--use-config=")) { //$NON-NLS-1$
-				String[] c = s.split("="); //$NON-NLS-1$
+				String[] c = s.split(StringTool.equals); //$NON-NLS-1$
 				config = c[1];
 			}
 		}

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/CoverageService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/CoverageService.java
@@ -30,7 +30,7 @@ public class CoverageService implements ICoverageService {
 		String reqs = BillingSystemServiceHolder.get().getRequirements(coverage.getBillingSystem());
 		if (reqs != null) {
 			for (String req : reqs.split(";")) { //$NON-NLS-1$
-				String localReq = ""; //$NON-NLS-1$
+				String localReq = StringTool.leer; //$NON-NLS-1$
 				String[] r = req.split(":"); //$NON-NLS-1$
 				if ((r[1].equalsIgnoreCase("X")) && (r.length > 2)) { //$NON-NLS-1$
 					// *** support for additional field types (checkboxes with

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/InvoiceService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/InvoiceService.java
@@ -35,6 +35,7 @@ import ch.rgw.tools.Money;
 import ch.rgw.tools.Result;
 import ch.rgw.tools.Result.SEVERITY;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class InvoiceService implements IInvoiceService {
 	
@@ -76,7 +77,7 @@ public class InvoiceService implements IInvoiceService {
 							+ " für\nPatient Nr. " + pat.getPatientNr() + ", " + pat.getLastName()
 							+ ", " + pat.getFirstName() + ", "
 							+ pat.getDateOfBirth().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-							+ "\n" + "enthält mindestens eine Leistung zum Preis 0.00.\n"
+							+ StringTool.lf + "enthält mindestens eine Leistung zum Preis 0.00.\n"
 							+ "\nDie Ärztekasse würde so eine Rechnung zurückgeben.\n\n";
 						return result.add(Result.SEVERITY.WARNING, 1, msg
 							+ "Diese Rechnung wird jetzt nicht erstellt."

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/LabService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/LabService.java
@@ -68,7 +68,7 @@ public class LabService implements ILabService {
 				evaluate(labResult.getItem(), labResult.getPatient(), new TimeTool(time));
 		}
 		
-		if (evaluationResult == null || "".equals(evaluationResult) //$NON-NLS-1$
+		if (evaluationResult == null || StringTool.leer.equals(evaluationResult) //$NON-NLS-1$
 			|| "?formel?".equals(evaluationResult)) { //$NON-NLS-1$
 			return Result.ERROR(evaluationResult);
 		}
@@ -123,7 +123,7 @@ public class LabService implements ILabService {
 		if (formula.startsWith("SCRIPT:")) {
 			log.warn("Script elements currently not supported, returning empty String. LabItem ["
 				+ labItem.getId() + "]");
-			return "";
+			return StringTool.leer;
 		}
 		boolean bMatched = false;
 		labresults = sortResultsDescending(labresults);
@@ -147,7 +147,7 @@ public class LabService implements ILabService {
 			if (fields.length > 1) {
 				String val = getPersistentObjectAttributeMapping(patient,
 					fields[1].replaceFirst("\\]", StringTool.leer));
-				String repl = "\"" + val + "\"";
+				String repl = StringTool.backslash + val + StringTool.backslash;
 				matcher.appendReplacement(sb, repl);
 				bMatched = true;
 			}

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/MedicationService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/MedicationService.java
@@ -25,6 +25,7 @@ import ch.elexis.core.services.holder.ContextServiceHolder;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
 import ch.elexis.core.services.holder.StoreToStringServiceHolder;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class MedicationService implements IMedicationService {
 	
@@ -48,7 +49,7 @@ public class MedicationService implements IMedicationService {
 			// Match stuff like '1/2', '7/8', '~1,2'
 			// System.out.println(dosis.matches(special_num_at_start));
 			if (dosis.matches(special_num_at_start)) {
-				list.add(getNum(dosis.replace("~", "")));
+				list.add(getNum(dosis.replace("~", StringTool.leer)));
 			} else if (dosis.matches("[0-9½¼]+([xX][0-9]+(/[0-9]+)?|)")) { //$NON-NLS-1$
 				String[] dose = dosis.split("[xX]"); //$NON-NLS-1$
 				float count = getNum(dose[0]);
@@ -62,8 +63,8 @@ public class MedicationService implements IMedicationService {
 				if (StringUtils.countMatches(dosis, "-") > 1 && sub_list.size() > 0) {
 					return sub_list;
 				}
-				sub_list = getDosageAsFloats(dosis, "/");
-				if (StringUtils.countMatches(dosis, "/") > 1 && sub_list.size() > 0) {
+				sub_list = getDosageAsFloats(dosis, StringTool.slash);
+				if (StringUtils.countMatches(dosis, StringTool.slash) > 1 && sub_list.size() > 0) {
 					return sub_list;
 				}
 				if (dosis.indexOf('-') != -1 || dosis.indexOf('/') != -1) {
@@ -146,7 +147,7 @@ public class MedicationService implements IMedicationService {
 			}
 			// matching for values like 2x1, 2,5x1 or 20x1
 			else if (n.toLowerCase().matches("^[0-9][,.]*[0-9]*x[0-9][,.]*[0-9]*$")) {
-				n = n.replace("\\s", "");
+				n = n.replace("\\s", StringTool.leer);
 				String[] nums = n.toLowerCase().split("x");
 				float num1 = Float.parseFloat(nums[0].replace(",", "."));
 				float num2 = Float.parseFloat(nums[1].replace(",", "."));
@@ -160,7 +161,7 @@ public class MedicationService implements IMedicationService {
 			// any other digit-letter combination. replaces comma with dot and removes all non-digit chars. i.e. 1,5 p. Day becomes 1.5
 			else {
 				n = n.replace(",", ".");
-				n = n.replaceAll("[^\\d.]", "");
+				n = n.replaceAll("[^\\d.]", StringTool.leer);
 				if (n.endsWith(".")) {
 					n = n.substring(0, n.length() - 1);
 				}

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/VirtualFilesystemService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/VirtualFilesystemService.java
@@ -11,6 +11,7 @@ import org.osgi.service.component.annotations.Component;
 
 import ch.elexis.core.services.internal.VirtualFilesystemHandle;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class VirtualFilesystemService implements IVirtualFilesystemService {
 	
@@ -47,7 +48,7 @@ public class VirtualFilesystemService implements IVirtualFilesystemService {
 			}
 			
 			if (StringUtils.startsWith(urlString, "\\\\")) {
-				String replaced = urlString.replace("\\", "/");
+				String replaced = urlString.replace("\\", StringTool.slash);
 				return isValidURL("smb:" + replaced);
 			}
 		}

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/XidService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/XidService.java
@@ -27,6 +27,7 @@ import ch.elexis.core.model.XidQuality;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
 import ch.elexis.core.services.internal.TransientXid;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class XidService implements IXidService {
 	
@@ -80,7 +81,7 @@ public class XidService implements IXidService {
 				if (spl.length < 2) {
 					logger.error("Fehler in XID-Domain " + domainString);
 				}
-				String simpleName = "";
+				String simpleName = StringTool.leer;
 				if (spl.length >= 3) {
 					simpleName = spl[2];
 				}
@@ -113,7 +114,7 @@ public class XidService implements IXidService {
 			if (domainName.matches(".*[;#].*")) {
 				logger.error("XID Domain " + domainName + " ungültig");
 			} else {
-				XidDomain created = new XidDomain(domainName, simpleName == null ? "" : simpleName,
+				XidDomain created = new XidDomain(domainName, simpleName == null ? StringTool.leer : simpleName,
 						quality, "Kontakt");
 				domains.put(domainName, created);
 				if (simpleName != null) {

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/eenv/RocketchatMessageTransporter.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/eenv/RocketchatMessageTransporter.java
@@ -23,6 +23,7 @@ import ch.elexis.core.services.IContextService;
 import ch.elexis.core.services.IMessageTransporter;
 import ch.elexis.core.services.internal.Bundle;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class RocketchatMessageTransporter implements IMessageTransporter {
 	
@@ -87,7 +88,7 @@ public class RocketchatMessageTransporter implements IMessageTransporter {
 		if (!entrySet.isEmpty()) {
 			header.append(" | ");
 			message.getMessageCodes().entrySet()
-				.forEach(c -> header.append(c.getKey() + ":" + c.getValue() + " "));
+				.forEach(c -> header.append(c.getKey() + ":" + c.getValue() + StringTool.space));
 		}
 		
 		json.put("text", header.toString());

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/internal/VirtualFilesystemHandle.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/internal/VirtualFilesystemHandle.java
@@ -26,6 +26,7 @@ import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 import jcifs.smb.SmbFileFilter;
 
+import ch.rgw.tools.StringTool;
 public class VirtualFilesystemHandle implements IVirtualFilesystemHandle {
 
 	private static final String ERROR_MESSAGE_CAN_NOT_HANDLE = "Can not handle type";
@@ -223,7 +224,7 @@ public class VirtualFilesystemHandle implements IVirtualFilesystemHandle {
 			}
 		} catch (URISyntaxException e) {
 		}
-		return "";
+		return StringTool.leer;
 	}
 
 	@Override
@@ -293,13 +294,13 @@ public class VirtualFilesystemHandle implements IVirtualFilesystemHandle {
 
 	@Override
 	public IVirtualFilesystemHandle subDir(String subdir) throws IOException {
-		return subFile(subdir + "/");
+		return subFile(subdir + StringTool.slash);
 	}
 
 	@Override
 	public IVirtualFilesystemHandle subFile(String subFile) throws IOException {
 
-		if(StringUtils.isBlank(subFile) || subFile.startsWith("/")) {
+		if(StringUtils.isBlank(subFile) || subFile.startsWith(StringTool.slash)) {
 			throw new IllegalArgumentException();
 		}
 		

--- a/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/LogProgressMonitor.java
+++ b/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/LogProgressMonitor.java
@@ -3,6 +3,7 @@ package ch.elexis.core.tasks.internal.service;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.slf4j.Logger;
 
+import ch.rgw.tools.StringTool;
 public class LogProgressMonitor implements IProgressMonitor {
 	
 	private Logger logger;
@@ -28,7 +29,7 @@ public class LogProgressMonitor implements IProgressMonitor {
 	
 	private void log(){
 		if (logger.isDebugEnabled()) {
-			String msg = name + " [" + worked + "/" + totalWork + "]";
+			String msg = name + " [" + worked + StringTool.slash + totalWork + "]";
 			if (cancelled) {
 				msg = "-CNCLD- " + msg;
 			}
@@ -68,7 +69,7 @@ public class LogProgressMonitor implements IProgressMonitor {
 	
 	@Override
 	public void subTask(String name){
-		this.name = this.name + "/" + name;
+		this.name = this.name + StringTool.slash + name;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/TaskServiceImpl.java
+++ b/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/TaskServiceImpl.java
@@ -50,6 +50,7 @@ import ch.elexis.core.tasks.model.OwnerTaskNotification;
 import ch.elexis.core.tasks.model.TaskState;
 import ch.elexis.core.tasks.model.TaskTriggerType;
 
+import ch.rgw.tools.StringTool;
 @Component(immediate = true)
 public class TaskServiceImpl implements ITaskService {
 	
@@ -306,7 +307,7 @@ public class TaskServiceImpl implements ITaskService {
 		StringBuilder sb = new StringBuilder();
 		sb.append(task.getLabel());
 		if (StringUtils.isNotBlank(resultText)) {
-			sb.append("\n" + resultText);
+			sb.append(StringTool.lf + resultText);
 		}
 		message.setMessageText(sb.toString());
 		

--- a/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/sysevents/SysEventWatcher.java
+++ b/bundles/ch.elexis.core.tasks/src/ch/elexis/core/tasks/internal/service/sysevents/SysEventWatcher.java
@@ -20,7 +20,8 @@ import ch.elexis.core.tasks.model.ITaskDescriptor;
 import ch.elexis.core.tasks.model.ITaskService;
 import ch.elexis.core.tasks.model.TaskTriggerType;
 
-@Component(property = EventConstants.EVENT_TOPIC + "=" + ElexisEventTopics.BASE + "*")
+import ch.rgw.tools.StringTool;
+@Component(property = EventConstants.EVENT_TOPIC + StringTool.equals + ElexisEventTopics.BASE + "*")
 public class SysEventWatcher implements EventHandler {
 	
 	private static Map<String, Set<ITaskDescriptor>> incurred;

--- a/bundles/ch.elexis.core.test/src/ch/elexis/core/test/util/TestUtil.java
+++ b/bundles/ch.elexis.core.test/src/ch/elexis/core/test/util/TestUtil.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import ch.rgw.tools.StringTool;
 public class TestUtil {
 
 	public static String loadFile(Class<?> classLoader, String resourceName) throws IOException{
@@ -16,7 +17,7 @@ public class TestUtil {
 		}
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
 			while ((line = reader.readLine()) != null) {
-				sb.append(line + "\n");
+				sb.append(line + StringTool.lf);
 			}
 		}
 		return sb.toString();

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/controls/StammDatenComposite.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/controls/StammDatenComposite.java
@@ -66,6 +66,7 @@ import ch.elexis.core.ui.contacts.views.provider.TableDecoratingLabelProvider;
 import ch.elexis.core.ui.icons.Images;
 
 // TODO Use icons from elexis?
+import ch.rgw.tools.StringTool;
 public class StammDatenComposite extends AbstractComposite {
 	
 	private static Logger log = LoggerFactory.getLogger(StammDatenComposite.class);
@@ -418,7 +419,7 @@ public class StammDatenComposite extends AbstractComposite {
 			if (kontakt.getCode() != null) {
 				lblCode.setText("#" + kontakt.getCode());
 			} else {
-				lblCode.setText("");
+				lblCode.setText(StringTool.leer);
 			}
 			break;
 		case ORGANIZATION:
@@ -434,7 +435,7 @@ public class StammDatenComposite extends AbstractComposite {
 			txtFirstName.setMessage("Bezeichnung 1");
 			txtFamilyName.setMessage("Bezeichnung 2");
 			lblHeadline.setText(ORGANIZATION_LABEL);
-			lblCode.setText("");
+			lblCode.setText(StringTool.leer);
 			break;
 		default:
 			break;
@@ -496,7 +497,7 @@ public class StammDatenComposite extends AbstractComposite {
 		public void focusLost(FocusEvent e){
 			Text text = ((Text) e.widget);
 			if (text.getText().equalsIgnoreCase(ContactGeonames.getDialPrefix()))
-				text.setText("");
+				text.setText(StringTool.leer);
 		}
 		
 		@Override

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/dialogs/BezugsKontaktAuswahl.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/dialogs/BezugsKontaktAuswahl.java
@@ -87,10 +87,10 @@ public class BezugsKontaktAuswahl extends Dialog {
 		new Label(ret, SWT.NONE)
 			.setText(Messages.Patientenblatt2_pleaseEnterKindOfRelationship); //$NON-NLS-1$
 		
-		new Label(ret, SWT.NONE).setText(srcLabel + " " + Messages.Bezugskontakt_Is); //$NON-NLS-1$
+		new Label(ret, SWT.NONE).setText(srcLabel + StringTool.space + Messages.Bezugskontakt_Is); //$NON-NLS-1$
 		cbBezugSrc = new Combo(ret, SWT.NONE);
 		cbBezugSrc.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
-		String bez = CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, ""); //$NON-NLS-1$
+		String bez = CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, StringTool.leer); //$NON-NLS-1$
 		
 		String[] items = getBezugKonkaktTypes(bez);
 		
@@ -139,13 +139,13 @@ public class BezugsKontaktAuswahl extends Dialog {
 
 		String[] bezugKontaktTypes = getBezugKontaktTypes();
 		
-		new Label(dynComposite, SWT.NONE).setText(Messages.Bezugskontakt_RelationFrom + " "); //$NON-NLS-1$
+		new Label(dynComposite, SWT.NONE).setText(Messages.Bezugskontakt_RelationFrom + StringTool.space); //$NON-NLS-1$
 		cbTypeDest = new Combo(dynComposite, SWT.READ_ONLY);
 		cbTypeDest.setEnabled(!locked);
 		cbTypeDest.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		cbTypeDest.setItems(bezugKontaktTypes);
 		
-		new Label(dynComposite, SWT.NONE).setText(Messages.Bezugskontakt_RelationTo + " "); //$NON-NLS-1$
+		new Label(dynComposite, SWT.NONE).setText(Messages.Bezugskontakt_RelationTo + StringTool.space); //$NON-NLS-1$
 		cbTypeSrc = new Combo(dynComposite, SWT.READ_ONLY);
 		cbTypeSrc.setEnabled(!locked);
 		cbTypeSrc.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
@@ -214,7 +214,7 @@ public class BezugsKontaktAuswahl extends Dialog {
 		String[] items = cbBezugSrc.getItems();
 		String nitem = selectedBezugKontaktRelation.getName();
 		if (StringTool.getIndex(items, nitem) == -1) {
-			String res = CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, "")
+			String res = CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, StringTool.leer)
 				+ Patientenblatt2.SPLITTER + selectedBezugKontaktRelation.getCfgString();
 			CoreHub.globalCfg.set(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, res);
 		}

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/BezugsKontaktSettings.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/BezugsKontaktSettings.java
@@ -59,6 +59,7 @@ import ch.elexis.core.ui.preferences.SettingsPreferenceStore;
 import ch.elexis.core.ui.views.Messages;
 import ch.elexis.data.BezugsKontaktRelation;
 
+import ch.rgw.tools.StringTool;
 public class BezugsKontaktSettings extends PreferencePage implements IWorkbenchPreferencePage {
 
 	private TableViewer tableViewer;
@@ -110,7 +111,7 @@ public class BezugsKontaktSettings extends PreferencePage implements IWorkbenchP
 			mntmAddBezugsKontaktRelation.addSelectionListener(new SelectionAdapter() {
 				@Override
 				public void widgetSelected(SelectionEvent e){
-					BezugsKontaktRelation bezugsKontaktRelation = new BezugsKontaktRelation("",
+					BezugsKontaktRelation bezugsKontaktRelation = new BezugsKontaktRelation(StringTool.leer,
 						RelationshipType.AGENERIC, RelationshipType.AGENERIC);
 					tableViewer.add(bezugsKontaktRelation);
 					tableViewer.setSelection(new StructuredSelection(bezugsKontaktRelation));
@@ -162,7 +163,7 @@ public class BezugsKontaktSettings extends PreferencePage implements IWorkbenchP
 						if (tableData != null && !tableData.equals(element)
 							&& !tableData.getName().isEmpty()
 							&& newName.equalsIgnoreCase(tableData.getName())) {
-							MessageDialog.openError(UiDesk.getTopShell(), "",
+							MessageDialog.openError(UiDesk.getTopShell(), StringTool.leer,
 								Messages.Bezugskontakt_NameMustBeUnique);
 							return;
 						}
@@ -311,7 +312,7 @@ public class BezugsKontaktSettings extends PreferencePage implements IWorkbenchP
 		});
 		;
 		tableViewer.setInput(loadBezugKonkaktTypes(
-			CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, "")));
+			CoreHub.globalCfg.get(Patientenblatt2.CFG_BEZUGSKONTAKTTYPEN, StringTool.leer)));
 		return container;
 	}
 	
@@ -388,7 +389,7 @@ public class BezugsKontaktSettings extends PreferencePage implements IWorkbenchP
 			BezugsKontaktRelation initalBezugKonktaktRelation =
 				getInitalBezugKontakt(bezugsKontaktRelation.getId());
 			if (initalBezugKonktaktRelation != null) {
-				boolean ret = MessageDialog.openQuestion(UiDesk.getTopShell(), "",
+				boolean ret = MessageDialog.openQuestion(UiDesk.getTopShell(), StringTool.leer,
 					Messages.Bezugskontakt_ConfirmUpdateExisting);
 				if (ret) {
 					updateExistingEntriesIds.add(bezugsKontaktRelation.getId());

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/CityInformationProposalProvider.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/CityInformationProposalProvider.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.fieldassist.ContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposalProvider;
 
+import ch.rgw.tools.StringTool;
 public class CityInformationProposalProvider implements IContentProposalProvider {
 	
 	public IContentProposal[] getProposals(String contents, int position){
@@ -41,6 +42,6 @@ public class CityInformationProposalProvider implements IContentProposalProvider
 		List<String> result = ContactGeonames.getZipByCity(content);
 		if (result.size() >= 1)
 			return result.get(0);
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/ContactGeonames.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/ContactGeonames.java
@@ -7,6 +7,7 @@ import ch.elexis.core.types.Country;
 import ch.elexis.core.ui.contacts.extension.ContactGeonamesExtensionPoint;
 import ch.elexis.core.ui.contacts.interfaces.IContactGenoameService;
 
+import ch.rgw.tools.StringTool;
 public class ContactGeonames {
 	
 	private static Country currentCountryCode;
@@ -50,7 +51,7 @@ public class ContactGeonames {
 	public static String getDialPrefix(){
 		if (currentService != null)
 			return currentService.getDialPrefix();
-		return "";
+		return StringTool.leer;
 	}
 	
 	public static Country getCurrentCountryCode(){

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/ZipInformationProposalProvider.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/proposalProvider/ZipInformationProposalProvider.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.fieldassist.ContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposalProvider;
 
+import ch.rgw.tools.StringTool;
 public class ZipInformationProposalProvider implements IContentProposalProvider {
 	
 	public IContentProposal[] getProposals(String contents, int position){
@@ -37,7 +38,7 @@ public class ZipInformationProposalProvider implements IContentProposalProvider 
 		List<String> result = ContactGeonames.getCityByZip(content);
 		if (result.size() >= 1)
 			return result.get(0);
-		return "";
+		return StringTool.leer;
 	}
 	
 }

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/ContactSelectorView.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/ContactSelectorView.java
@@ -73,6 +73,7 @@ import ch.elexis.data.Query;
 /**
  * @since 3.0.0
  */
+import ch.rgw.tools.StringTool;
 public class ContactSelectorView extends ViewPart implements ITabbedPropertySheetPageContributor {
 	
 	public static final String ID = "ch.elexis.core.ui.contacts.views.ContactSelectorView";
@@ -226,14 +227,14 @@ public class ContactSelectorView extends ViewPart implements ITabbedPropertyShee
 		
 		@Override
 		public void keyPressed(KeyEvent e){
-			text.setMessage("");
+			text.setMessage(StringTool.leer);
 		}
 		
 		public void keyReleased(KeyEvent ke){
 			String txt = text.getText();
 			
-			// We have a formula, if the string starts with "="
-			if (txt.startsWith("=")) {
+			// We have a formula, if the string starts with StringTool.equals
+			if (txt.startsWith(StringTool.equals)) {
 				String formula;
 				if (txt.contains(";")) {
 					formula = txt.substring(1, txt.indexOf(";"));
@@ -247,11 +248,11 @@ public class ContactSelectorView extends ViewPart implements ITabbedPropertyShee
 					try {
 						Expression expr = jexl.createExpression(formula);
 						Object result = expr.evaluate(new MapContext());
-						text.setText("");
-						text.setMessage(formula + "=" + result + "");
+						text.setText(StringTool.leer);
+						text.setMessage(formula + StringTool.equals + result + StringTool.leer);
 						result = null;
 					} catch (JexlException e) {
-						text.setText("");
+						text.setText(StringTool.leer);
 						text.setMessage("Invalid expression: " + formula);
 					}
 				}

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/KontaktBlatt.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/KontaktBlatt.java
@@ -60,6 +60,7 @@ import ch.elexis.data.Person;
 import ch.elexis.data.Xid;
 import ch.elexis.data.Xid.XIDDomain;
 
+import ch.rgw.tools.StringTool;
 public class KontaktBlatt extends Composite implements IActivationListener, IUnlockable {
 	
 	private static final String IS_USER = "istAnwender";
@@ -126,9 +127,9 @@ public class KontaktBlatt extends Composite implements IActivationListener, IUnl
 						XIDDomain xd = Xid.getDomain(dom);
 						if ((k.istPerson() && xd.isDisplayedFor(Person.class))
 							|| (k.istOrganisation() && xd.isDisplayedFor(Organisation.class))) {
-							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + "=" + dom); //$NON-NLS-1$
+							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + StringTool.equals + dom); //$NON-NLS-1$
 						} else if (k.istOrganisation() && xd.isDisplayedFor(Labor.class)) {
-							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + "=" + dom);
+							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + StringTool.equals + dom);
 						}
 					}
 					KontaktExtDialog dlg = new KontaktExtDialog(UiDesk.getTopShell(), (Kontakt) po,
@@ -246,7 +247,7 @@ public class KontaktBlatt extends Composite implements IActivationListener, IUnl
 					def[0].setLabel(BEZEICHNUNG);
 					def[1].setLabel(ZUSATZ);
 					def[2].setLabel(ANSPRECHPERSON);
-					def[3].setText(""); //$NON-NLS-1$
+					def[3].setText(StringTool.leer); //$NON-NLS-1$
 					def[10].setLabel(TEL_DIREKT);
 					setOrganisationFieldsVisible(true);
 				} else if (type.equals("istLabor")) { //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatListFilterBox.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatListFilterBox.java
@@ -57,6 +57,7 @@ import ch.rgw.tools.IFilter;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class PatListFilterBox extends ListDisplay<PersistentObject> implements IFilter {
 	PersistentObjectDropTarget dropTarget;
 	private static final String ETIKETTE = Messages.PatListFilterBox_Sticker; //$NON-NLS-1$
@@ -258,13 +259,13 @@ public class PatListFilterBox extends ListDisplay<PersistentObject> implements I
 			ret.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 			ret.setLayout(new GridLayout(3, false));
 			new Label(ret, SWT.NONE).setText(Messages.PatListFilterBox_Field3); //$NON-NLS-1$
-			new Label(ret, SWT.NONE).setText(" "); //$NON-NLS-1$
+			new Label(ret, SWT.NONE).setText(StringTool.space); //$NON-NLS-1$
 			new Label(ret, SWT.NONE).setText(Messages.PatListFilterBox_VValue); //$NON-NLS-1$
 			tFeld = new Text(ret, SWT.BORDER);
 			tFeld.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			cbOp = new Combo(ret, SWT.SINGLE | SWT.READ_ONLY);
 			cbOp.setItems(new String[] {
-				"=", "LIKE", "Regexp" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				StringTool.equals, "LIKE", "Regexp" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			});
 			cbOp.select(0);
 			tValue = new Text(ret, SWT.BORDER);

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatientDetailView.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatientDetailView.java
@@ -351,7 +351,7 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectDiagnosen.setText("Diagnosen");
 			sectDiagnosen.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectDiagnosen.getText(), false));
 
-			txtDiagnosen = toolkit.createText(sectDiagnosen, "", SWT.WRAP | SWT.MULTI);
+			txtDiagnosen = toolkit.createText(sectDiagnosen, StringTool.leer, SWT.WRAP | SWT.MULTI);
 			txtDiagnosen.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtDiagnosen));
 
 			sectDiagnosen.setClient(txtDiagnosen);
@@ -368,7 +368,7 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectAnamnese.setText("Persönliche Anamnese");
 			sectAnamnese.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectAnamnese.getText(), false));
 
-			txtAnamnese = toolkit.createText(sectAnamnese, "", SWT.WRAP | SWT.MULTI);
+			txtAnamnese = toolkit.createText(sectAnamnese, StringTool.leer, SWT.WRAP | SWT.MULTI);
 			txtAnamnese.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtAnamnese));
 			sectAnamnese.setClient(txtAnamnese);
 			sectAnamnese.addExpansionListener(new SectionExpansionHandler());
@@ -384,8 +384,8 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectFamAnamnese.setText("Familien-Anamnese");
 			sectFamAnamnese.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectFamAnamnese.getText(), false));
 
-			txtFamAnamnese = toolkit.createText(sectFamAnamnese, "", SWT.WRAP | SWT.MULTI);
-			txtFamAnamnese.setText("");
+			txtFamAnamnese = toolkit.createText(sectFamAnamnese, StringTool.leer, SWT.WRAP | SWT.MULTI);
+			txtFamAnamnese.setText(StringTool.leer);
 			txtFamAnamnese.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtFamAnamnese));
 			sectFamAnamnese.setClient(txtFamAnamnese);
 			sectFamAnamnese.addExpansionListener(new SectionExpansionHandler());
@@ -401,8 +401,8 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectAllergien.setText("Allergien");
 			sectAllergien.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectAllergien.getText(), false));
 
-			txtAllergien = toolkit.createText(sectAllergien, "", SWT.WRAP | SWT.MULTI);
-			txtAllergien.setText("");
+			txtAllergien = toolkit.createText(sectAllergien, StringTool.leer, SWT.WRAP | SWT.MULTI);
+			txtAllergien.setText(StringTool.leer);
 			txtAllergien.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtAllergien));
 			sectAllergien.setClient(txtAllergien);
 			sectAllergien.addExpansionListener(new SectionExpansionHandler());
@@ -418,8 +418,8 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectRisiken.setText("Risiken");
 			sectRisiken.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectRisiken.getText(), false));
 
-			txtRisiken = toolkit.createText(sectRisiken, "", SWT.WRAP | SWT.MULTI);
-			txtRisiken.setText("");
+			txtRisiken = toolkit.createText(sectRisiken, StringTool.leer, SWT.WRAP | SWT.MULTI);
+			txtRisiken.setText(StringTool.leer);
 			txtRisiken.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtRisiken));
 			sectRisiken.setClient(txtRisiken);
 			sectRisiken.addExpansionListener(new SectionExpansionHandler());
@@ -435,8 +435,8 @@ public class PatientDetailView extends ViewPart implements IUnlockable, IActivat
 			sectBemerkungen.setText("Bemerkungen");
 			sectBemerkungen.setExpanded(CoreHub.localCfg.get(KEY_PATIENTENBLATT + sectBemerkungen.getText(), false));
 
-			txtBemerkungen = toolkit.createText(sectBemerkungen, "", SWT.WRAP | SWT.MULTI);
-			txtBemerkungen.setText("");
+			txtBemerkungen = toolkit.createText(sectBemerkungen, StringTool.leer, SWT.WRAP | SWT.MULTI);
+			txtBemerkungen.setText(StringTool.leer);
 			txtBemerkungen.addListener(SWT.Modify, new MultiLineAutoGrowListener(txtBemerkungen));
 			sectBemerkungen.setClient(txtBemerkungen);
 			sectBemerkungen.addExpansionListener(new SectionExpansionHandler());

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatientenListeView.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/PatientenListeView.java
@@ -85,6 +85,7 @@ import ch.elexis.data.Query;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class PatientenListeView extends ViewPart implements IActivationListener, ISaveablePart2, HeartListener {
 	private CommonViewer cv;
 	private ViewerConfigurer vc;
@@ -217,7 +218,7 @@ public class PatientenListeView extends ViewPart implements IActivationListener,
 
 	private void collectUserFields() {
 		ArrayList<String> fields = new ArrayList<String>();
-		initiated = !("".equals(CoreHub.userCfg.get(Preferences.USR_PATLIST_SHOWPATNR, "")));
+		initiated = !(StringTool.leer.equals(CoreHub.userCfg.get(Preferences.USR_PATLIST_SHOWPATNR, StringTool.leer)));
 		if (CoreHub.userCfg.get(Preferences.USR_PATLIST_SHOWPATNR, false)) {
 			fields.add("code" + Query.EQUALS + Messages.PatientenListeView_PatientNr); // $NON-NLS-1$
 		}

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
@@ -337,7 +337,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 				
 				public void displayContent(Object po, InputData ltf){
 					Patient p = (Patient) po;
-					String result = "";
+					String result = StringTool.leer;
 					if (p.getStammarzt() != null && p.getStammarzt().exists()) {
 						Kontakt stammarzt = p.getStammarzt();
 						if (stammarzt.istPerson()) {
@@ -351,7 +351,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						
 						String telephoneLabel = stammarzt.getTelephoneLabel();
 						String label = stammarzt.getLabel()
-							+ ((telephoneLabel.length() > 0) ? " (" + telephoneLabel + ")" : "");
+							+ ((telephoneLabel.length() > 0) ? " (" + telephoneLabel + ")" : StringTool.leer);
 						ltf.setTooltipText(label);
 					} else {
 						ltf.setTooltipText(null);
@@ -397,9 +397,9 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						XIDDomain xd = Xid.getDomain(dom);
 						if ((k.istPerson() && xd.isDisplayedFor(Person.class))
 							|| (k.istOrganisation() && xd.isDisplayedFor(Organisation.class))) {
-							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + "=" + dom); //$NON-NLS-1$
+							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + StringTool.equals + dom); //$NON-NLS-1$
 						} else if (k.istOrganisation() && xd.isDisplayedFor(Labor.class)) {
-							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + "=" + dom);
+							extFlds.add(Xid.getSimpleNameForXIDDomain(dom) + StringTool.equals + dom);
 						}
 					}
 					
@@ -416,10 +416,10 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 				@Override
 				public void displayContent(Object po, InputData ltf){
 					Patient p = (Patient) po;
-					String guardianLabel = "";
+					String guardianLabel = StringTool.leer;
 					Kontakt legalGuardian = p.getLegalGuardian();
 					if (legalGuardian != null && legalGuardian.exists()) {
-						guardianLabel = legalGuardian.get(Kontakt.FLD_NAME1) + " "
+						guardianLabel = legalGuardian.get(Kontakt.FLD_NAME1) + StringTool.space
 							+ legalGuardian.get(Kontakt.FLD_NAME2);
 					}
 					ltf.setText(guardianLabel);
@@ -435,14 +435,14 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						Messages.Patientenblatt2_selectLegalGuardianMessage, null);
 					ks.enableEmptyFieldButton();
 					if (ks.open() == Dialog.OK) {
-						String guardianLabel = "";
+						String guardianLabel = StringTool.leer;
 						Object contactSel = ks.getSelection();
 						Kontakt legalGuardian = null;
 						
 						// get legal guardian if one is defined
 						if (contactSel != null) {
 							legalGuardian = (Kontakt) contactSel;
-							guardianLabel = legalGuardian.get(Kontakt.FLD_NAME1) + " "
+							guardianLabel = legalGuardian.get(Kontakt.FLD_NAME1) + StringTool.space
 								+ legalGuardian.get(Kontakt.FLD_NAME2);
 						}
 						((Patient) po).setLegalGuardian(legalGuardian);
@@ -682,7 +682,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 		for (int i = 0; i < lbExpandable.size(); i++) {
 			ec.add(WidgetFactory.createExpandableComposite(tk, form, lbExpandable.get(i)));
 			UserSettings.setExpandedState(ec.get(i), KEY_PATIENTENBLATT + lbExpandable.get(i));
-			txExpandable.add(tk.createText(ec.get(i), "", SWT.MULTI)); //$NON-NLS-1$
+			txExpandable.add(tk.createText(ec.get(i), StringTool.leer, SWT.MULTI)); //$NON-NLS-1$
 			ec.get(i).setData(KEY_DBFIELD, dfExpandable.get(i));
 			ec.get(i).addExpansionListener(new ExpansionAdapter() {
 				@Override
@@ -694,7 +694,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 							tx.setText(StringTool
 								.unNull(actPatient.get((String) src.getData(KEY_DBFIELD))));
 						} else {
-							tx.setText(""); //$NON-NLS-1$
+							tx.setText(StringTool.leer); //$NON-NLS-1$
 						}
 					} else {
 						if (actPatient != null) {
@@ -1001,7 +1001,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						
 						// System.out.print("jsdebug:
 						// SelectedContactInfos.k.toString():
-						// \n"+k.toString()+"\n");
+						// \n"+k.toString()+StringTool.lf);
 						
 						// The following code is adopted from
 						// Kontakt.createStdAnschrift for a
@@ -1059,7 +1059,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 							if (p.getGeschlecht().equals(Person.FEMALE)) {
 								salutation = Messages.KontakteView_SalutationF; // $NON-NLS-1$
 							} else {
-								salutation = ""; //$NON-NLS-1$
+								salutation = StringTool.leer; //$NON-NLS-1$
 							}
 							
 							if (!StringTool.isNothing(salutation)) { // salutation
@@ -1251,7 +1251,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						 */
 						
 						// System.out.print("jsdebug: SelectedContactInfosText:
-						// \n"+SelectedContactInfosText+"\n");
+						// \n"+SelectedContactInfosText+StringTool.lf);
 						
 						// Adopted from BestellView.exportClipboardAction:
 						// Copy some generated object.toString() to the clipoard
@@ -1402,7 +1402,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						 */
 						
 						// System.out.print("jsdebug: selectedAddressesText:
-						// \n"+selectedAddressesText+"\n");
+						// \n"+selectedAddressesText+StringTool.lf);
 						
 						// Adopted from BestellView.exportClipboardAction:
 						// Copy some generated object.toString() to the clipoard

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/filter/KontaktAnzeigeTextFieldViewerFilter.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/filter/KontaktAnzeigeTextFieldViewerFilter.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.viewers.ViewerFilter;
 
 import ch.elexis.core.model.IContact;
 
+import ch.rgw.tools.StringTool;
 public class KontaktAnzeigeTextFieldViewerFilter extends ViewerFilter {
 	
 	private String searchString;
@@ -36,14 +37,14 @@ public class KontaktAnzeigeTextFieldViewerFilter extends ViewerFilter {
 					return true;
 			}
 		} else {
-			String desc1 = (k.getDescription1() != null) ? k.getDescription1().toLowerCase() : "";
-			String desc2 = (k.getDescription2() != null) ? k.getDescription2().toLowerCase() : "";
+			String desc1 = (k.getDescription1() != null) ? k.getDescription1().toLowerCase() : StringTool.leer;
+			String desc2 = (k.getDescription2() != null) ? k.getDescription2().toLowerCase() : StringTool.leer;
 			
 			String[] searchListComma = searchString.split(",");
 			for (String string : searchListComma) {
-				if (string.contains(" ")) {
-					String searchA = desc1 + " " + desc2;
-					String searchB = desc2 + " " + desc1;
+				if (string.contains(StringTool.space)) {
+					String searchA = desc1 + StringTool.space + desc2;
+					String searchB = desc2 + StringTool.space + desc1;
 					if (searchA.matches(".*" + string + ".*")
 						|| searchB.matches(".*" + string + ".*"))
 						return true;
@@ -64,7 +65,7 @@ public class KontaktAnzeigeTextFieldViewerFilter extends ViewerFilter {
 			searchString = s.toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
 		// filter "dirty" characters
 		if (searchString != null)
-			searchString = searchString.replaceAll("[^#$, a-zA-Z0-9]", "");
+			searchString = searchString.replaceAll("[^#$, a-zA-Z0-9]", StringTool.leer);
 	}
 	
 }

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/provider/ContactSelectorObservableMapLabelProvider.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/provider/ContactSelectorObservableMapLabelProvider.java
@@ -23,6 +23,7 @@ import ch.elexis.core.data.interfaces.IPerson;
 import ch.elexis.core.types.Gender;
 import ch.elexis.core.ui.icons.Images;
 
+import ch.rgw.tools.StringTool;
 public class ContactSelectorObservableMapLabelProvider extends ObservableMapLabelProvider
 		implements ITableLabelProvider {
 		
@@ -66,7 +67,7 @@ public class ContactSelectorObservableMapLabelProvider extends ObservableMapLabe
 		case ORGANIZATION:
 			sb = new StringBuilder();
 			if (contact.getDescription1() != null) {
-				sb.append(contact.getDescription1() + " ");
+				sb.append(contact.getDescription1() + StringTool.space);
 			}
 			if (contact.getDescription2() != null)
 				sb.append(contact.getDescription2());
@@ -75,7 +76,7 @@ public class ContactSelectorObservableMapLabelProvider extends ObservableMapLabe
 			IPerson person = (IPerson) contact;
 			sb = new StringBuilder();
 			if (person.getTitel() != null)
-				sb.append(person.getTitel() + " ");
+				sb.append(person.getTitel() + StringTool.space);
 			sb.append(contact.getDescription1() + ", ");
 			sb.append(contact.getDescription2());
 			if (person.getTitelSuffix() != null)
@@ -100,7 +101,7 @@ public class ContactSelectorObservableMapLabelProvider extends ObservableMapLabe
 		case UNKNOWN:
 			return "?";
 		default:
-			return "";
+			return StringTool.leer;
 		}
 	}
 }

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CheckExec.java
@@ -10,6 +10,7 @@ import ch.elexis.core.data.activator.CoreHub;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLinkSyntaxException;
 
+import ch.rgw.tools.StringTool;
 public abstract class CheckExec {
 	public static String MYSQL_DB = JdbcLink.MYSQL_DRIVER_CLASS_NAME;
 	public static String POSTG_DB = JdbcLink.POSTGRESQL_DRIVER_CLASS_NAME;
@@ -33,7 +34,7 @@ public abstract class CheckExec {
 	}
 	
 	public static String getDBVersion(){
-		String version = "";
+		String version = StringTool.leer;
 		if (sqlDriver.equalsIgnoreCase(MYSQL_DB)) {
 			try {
 				version = j.queryString("SELECT wert FROM config WHERE param=\"dbversion\"");

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CleaningCheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/CleaningCheckExec.java
@@ -7,6 +7,7 @@ package ch.elexis.core.ui.dbcheck;
 import ch.elexis.core.ui.dbcheck.cleaning.CleaningCheck;
 import ch.elexis.core.ui.dbcheck.cleaning.CleaningCheckPGSQL;
 
+import ch.rgw.tools.StringTool;
 public class CleaningCheckExec extends CheckExec {
 	/**
 	 * Execute cleaning scripts
@@ -16,7 +17,7 @@ public class CleaningCheckExec extends CheckExec {
 	public static String doCleaning(){
 		
 		if (sqlDriver.equalsIgnoreCase(MYSQL_DB)) {
-			return "";
+			return StringTool.leer;
 			
 		}
 		if (sqlDriver.equalsIgnoreCase(POSTG_DB)) {

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/RefIntegrityCheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/RefIntegrityCheckExec.java
@@ -6,6 +6,7 @@ import ch.elexis.core.ui.dbcheck.refintegrity.RefIntegrityCheck;
 import ch.elexis.core.ui.dbcheck.refintegrity.RefIntegrityCheckMySQL;
 import ch.elexis.core.ui.dbcheck.refintegrity.RefIntegrityCheckPGSQL;
 
+import ch.rgw.tools.StringTool;
 public class RefIntegrityCheckExec extends CheckExec {
 	
 	public static RefIntegrityCheck ric = null;
@@ -37,12 +38,12 @@ public class RefIntegrityCheckExec extends CheckExec {
 	public static String getOutputLog(){
 		if (ric != null)
 			return ric.getOutputLog();
-		return "";
+		return StringTool.leer;
 	}
 	
 	public static String getErrorLog(){
 		if (ric != null)
 			return ric.getErrorLog();
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/SemanticCheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/SemanticCheckExec.java
@@ -11,6 +11,7 @@ import ch.elexis.core.ui.dbcheck.semantic.SemanticCheck;
 import ch.elexis.core.ui.dbcheck.semantic.SemanticCheckMySQL;
 import ch.elexis.core.ui.dbcheck.semantic.SemanticCheckPGSQL;
 
+import ch.rgw.tools.StringTool;
 public class SemanticCheckExec extends CheckExec {
 	
 	public static SemanticCheck sc = null;
@@ -40,12 +41,12 @@ public class SemanticCheckExec extends CheckExec {
 	public static String getOutputLog(){
 		if (sc != null)
 			return sc.getOutputLog();
-		return "";
+		return StringTool.leer;
 	}
 	
 	public static String getErrorLog(){
 		if (sc != null)
 			return sc.getErrorLog();
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/SyntacticCheckExec.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/SyntacticCheckExec.java
@@ -11,6 +11,7 @@ import ch.elexis.core.ui.dbcheck.syntactic.SyntacticCheck;
 import ch.elexis.core.ui.dbcheck.syntactic.SyntacticCheckMySQL;
 import ch.elexis.core.ui.dbcheck.syntactic.SyntacticCheckPGSQL;
 
+import ch.rgw.tools.StringTool;
 public class SyntacticCheckExec extends CheckExec {
 	
 	public static SyntacticCheck sc = null;
@@ -41,12 +42,12 @@ public class SyntacticCheckExec extends CheckExec {
 	public static String getOutputLog(){
 		if (sc != null)
 			return sc.getOutputLog();
-		return "";
+		return StringTool.leer;
 	}
 	
 	public static String getErrorLog(){
 		if (sc != null)
 			return sc.getErrorLog();
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/BillAllOpenCons.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/BillAllOpenCons.java
@@ -24,6 +24,7 @@ import ch.elexis.data.Rechnung;
 import ch.elexis.data.Rechnungssteller;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class BillAllOpenCons extends ExternalMaintenance {
 	
 	public enum BillStrategies implements IBillStrategy {
@@ -241,10 +242,10 @@ public class BillAllOpenCons extends ExternalMaintenance {
 		if (problems != null && !problems.isEmpty()) {
 			StringBuilder sb = new StringBuilder();
 			sb.append("\nProblems:\n");
-			problems.stream().forEach(problem -> sb.append(problem + "\n"));
+			problems.stream().forEach(problem -> sb.append(problem + StringTool.lf));
 			return sb.toString();
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/CheckKonsultationValidity.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/CheckKonsultationValidity.java
@@ -18,6 +18,7 @@ import ch.elexis.data.Verrechnet;
  * @author Lucia
  *
  */
+import ch.rgw.tools.StringTool;
 public class CheckKonsultationValidity extends ExternalMaintenance {
 	
 	@Override
@@ -33,7 +34,7 @@ public class CheckKonsultationValidity extends ExternalMaintenance {
 		for (Konsultation k : kons) {
 			if (k.getFall() == null || !k.getFall().exists()) {
 				output.append("Kons.ID: " + k.getLabel() + " (" + k.getId() + ") , Datum: "
-					+ k.getDatum() + "\n");
+					+ k.getDatum() + StringTool.lf);
 				counter++;
 			}
 		}
@@ -59,7 +60,7 @@ public class CheckKonsultationValidity extends ExternalMaintenance {
 					output.append("Kons.ID: " + v.getKons().getLabel() + " (" + v.getKons().getId()
 						+ "), Patient: " + v.getKons().getFall().getPatient().getLabel()
 						+ ", LeistungsCode: " + v.get(Verrechnet.LEISTG_CODE) + ", Klasse: "
-						+ v.get(Verrechnet.CLASS) + "\n");
+						+ v.get(Verrechnet.CLASS) + StringTool.lf);
 					counter++;
 				}
 			}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixBestellungen217.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixBestellungen217.java
@@ -14,6 +14,7 @@ import ch.elexis.data.PersistentObject;
 import ch.rgw.compress.CompEx;
 import ch.rgw.tools.JdbcLink.Stm;
 
+import ch.rgw.tools.StringTool;
 public class FixBestellungen217 extends ExternalMaintenance {
 	
 	@Override
@@ -56,7 +57,7 @@ public class FixBestellungen217 extends ExternalMaintenance {
 								existingBestellung.set("Liste", content);
 								updateCnt++;
 							} else {
-								existingBestellung.set("Liste", "");
+								existingBestellung.set("Liste", StringTool.leer);
 								updateCnt++;
 							}
 						}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixEmptyDiagnoseKonsultation.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixEmptyDiagnoseKonsultation.java
@@ -15,6 +15,7 @@ import ch.elexis.data.Konsultation;
 import ch.elexis.data.Mandant;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class FixEmptyDiagnoseKonsultation extends ExternalMaintenance {
 	private HashMap<Mandant, Integer> missingMap;
 	private HashMap<Mandant, String> mandantDiagnoseMap;
@@ -39,7 +40,7 @@ public class FixEmptyDiagnoseKonsultation extends ExternalMaintenance {
 				Mandant mandant = k.getMandant();
 				
 				String diagnoseId =
-					CoreHub.getUserSetting(mandant).get(Preferences.USR_DEFDIAGNOSE, "");
+					CoreHub.getUserSetting(mandant).get(Preferences.USR_DEFDIAGNOSE, StringTool.leer);
 				String diagnoseLabel = null;
 				
 				// add the diagnose if default diagnose is defined
@@ -75,11 +76,11 @@ public class FixEmptyDiagnoseKonsultation extends ExternalMaintenance {
 			
 			// no default diagnose set
 			if (diagnose == null) {
-				output.append(mandant.getVorname() + " " + mandant.getName() + " ("
+				output.append(mandant.getVorname() + StringTool.space + mandant.getName() + " ("
 					+ mandant.getLabel() + "): " + result
 					+ " Konsultationen ohne Diagnose (keine Standarddiagnose definiert)\n");
 			} else {
-				output.append(mandant.getVorname() + " " + mandant.getName() + " ("
+				output.append(mandant.getVorname() + StringTool.space + mandant.getName() + " ("
 					+ mandant.getLabel() + "): " + result
 					+ " Konsultationen mit Standarddiagnose (" + diagnose + ") vervollständigt\n");
 			}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixLeistungenKlasseReferenz.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixLeistungenKlasseReferenz.java
@@ -12,6 +12,7 @@ import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Query;
 import ch.elexis.data.Verrechnet;
 
+import ch.rgw.tools.StringTool;
 public class FixLeistungenKlasseReferenz extends ExternalMaintenance {
 	
 	public FixLeistungenKlasseReferenz(){}
@@ -77,7 +78,7 @@ public class FixLeistungenKlasseReferenz extends ExternalMaintenance {
 			if (art.exists()) {
 				ver.set(Verrechnet.CLASS, art.get(Artikel.FLD_KLASSE));
 				output.append("Fixing Klasse entry for " + ver.getLabel() + " to "
-					+ art.get(Artikel.FLD_KLASSE) + "\n");
+					+ art.get(Artikel.FLD_KLASSE) + StringTool.lf);
 			}
 		}
 		pm.worked(1);

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixMultipleDiagnosis.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixMultipleDiagnosis.java
@@ -65,7 +65,7 @@ public class FixMultipleDiagnosis extends ExternalMaintenance {
 						fw.write(diagnoseSts + ";");
 					}
 					diagMap.put(konsultation.getId(), diagnosen);
-					fw.write("\n");
+					fw.write(StringTool.lf);
 				} else {
 					sb.append("[" + konsultation.getId() + "] 0 diagnosis entries\n");
 				}
@@ -109,8 +109,8 @@ public class FixMultipleDiagnosis extends ExternalMaintenance {
 				ArrayList<IDiagnose> diagnosen = kons.getDiagnosen();
 				int should = diagnosisEntries.size();
 				if (diagnosen.size() != should) {
-					sb.append("[" + split[0] + "] # of diagnosis entries mismatch " + should + " "
-						+ diagnosen.size() + "\n");
+					sb.append("[" + split[0] + "] # of diagnosis entries mismatch " + should + StringTool.space
+						+ diagnosen.size() + StringTool.lf);
 					resultOk = false;
 				} else {
 					for (IDiagnose iDiagnose : diagnosen) {
@@ -118,7 +118,7 @@ public class FixMultipleDiagnosis extends ExternalMaintenance {
 							+ StringConstants.DOUBLECOLON + iDiagnose.getCode())) {
 							sb.append("[" + split[0] + "] missing " + iDiagnose.getClass().getName()
 								+ StringConstants.DOUBLECOLON + iDiagnose.getCode()
-								+ "\n");
+								+ StringTool.lf);
 							resultOk = false;
 						}
 					}
@@ -137,7 +137,7 @@ public class FixMultipleDiagnosis extends ExternalMaintenance {
 		
 		sb.append("--> No of unique diagnoses matches: "
 			+ Boolean.toString(parseLong == uniqueDiagnosen.size()));
-		sb.append("Result is equivalent " + resultOk + "\n");
+		sb.append("Result is equivalent " + resultOk + StringTool.lf);
 		return sb.toString();
 	}
 	

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixPharmacodeLessSeven.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/FixPharmacodeLessSeven.java
@@ -23,6 +23,7 @@ import ch.elexis.data.Query;
  * @author Marco Descher
  * 
  */
+import ch.rgw.tools.StringTool;
 public class FixPharmacodeLessSeven extends ExternalMaintenance {
 	
 	public static final String PHARMACODE_EXTINFO_ID = "Pharmacode";
@@ -70,7 +71,7 @@ public class FixPharmacodeLessSeven extends ExternalMaintenance {
 					}
 					sb.append(subId);
 					output.append("Korrigiere " + artikel.getName() + " von " + subId + " auf "
-						+ sb.toString() + "\n");
+						+ sb.toString() + StringTool.lf);
 					artikel.set(Artikel.FLD_SUB_ID, sb.toString());
 					articleExtInfo.put(PHARMACODE_EXTINFO_ID, sb.toString());
 					artikel.setMap(Artikel.FLD_EXTINFO, articleExtInfo);

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/LabResetPathologic.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/LabResetPathologic.java
@@ -14,6 +14,7 @@ import ch.elexis.data.LabResult;
 import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class LabResetPathologic extends ExternalMaintenance {
 	
 	private List<String> problems = new ArrayList<>();
@@ -29,7 +30,7 @@ public class LabResetPathologic extends ExternalMaintenance {
 		for (LabResult labResult : results) {
 			if (pm.isCanceled()) {
 				addProblem("Cancelled.", labResult);
-				return getProblemsString() + "\n" + changedCount + " Werte wurden geändert.\n "
+				return getProblemsString() + StringTool.lf + changedCount + " Werte wurden geändert.\n "
 					+ allCount + " Werte insgesamt.";
 			}
 			
@@ -86,9 +87,9 @@ public class LabResetPathologic extends ExternalMaintenance {
 		if (problems != null && !problems.isEmpty()) {
 			StringBuilder sb = new StringBuilder();
 			sb.append("\nProblems:\n");
-			problems.stream().forEach(problem -> sb.append(problem + "\n"));
+			problems.stream().forEach(problem -> sb.append(problem + StringTool.lf));
 			return sb.toString();
 		}
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/MoveFallAHVNrToContact.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/MoveFallAHVNrToContact.java
@@ -16,6 +16,7 @@ import ch.elexis.data.Xid;
  * As defined in bug 1439 - https://redmine.medelexis.ch/issues/1439 We have to move all definitions
  * of an AHV number allocated to a Fall to the respective contact.
  */
+import ch.rgw.tools.StringTool;
 public class MoveFallAHVNrToContact extends ExternalMaintenance {
 	
 	public static final String AHV_NUMMER = "AHV-Nummer";
@@ -40,7 +41,7 @@ public class MoveFallAHVNrToContact extends ExternalMaintenance {
 			
 			if (patAhvNummer.length() < 1 && ahvNummer.length() > 1) {
 				output
-					.append("Setze AHV Nummer für " + pat.getLabel() + " auf " + ahvNummer + "\n");
+					.append("Setze AHV Nummer für " + pat.getLabel() + " auf " + ahvNummer + StringTool.lf);
 				pat.addXid(XidConstants.DOMAIN_AHV, ahvNummer, true);
 			}
 			
@@ -48,7 +49,7 @@ public class MoveFallAHVNrToContact extends ExternalMaintenance {
 			if (extinfo.containsKey(AHV_NUMMER)) {
 				extinfo.remove(AHV_NUMMER);
 				fall.setMap(Fall.FLD_EXTINFO, extinfo);
-				output.append("Entferne AHV-Nummer Eintrag aus Fall " + fall.getLabel() + "\n");
+				output.append("Entferne AHV-Nummer Eintrag aus Fall " + fall.getLabel() + StringTool.lf);
 			}
 			
 			pm.worked(1);

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/ReChargeTarmedOpenCons.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/ReChargeTarmedOpenCons.java
@@ -27,6 +27,7 @@ import ch.elexis.data.Verrechnet;
 import ch.rgw.tools.Result;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ReChargeTarmedOpenCons extends ExternalMaintenance {
 	
 	private List<String> problems = new ArrayList<>();
@@ -203,10 +204,10 @@ public class ReChargeTarmedOpenCons extends ExternalMaintenance {
 		if (problems != null && !problems.isEmpty()) {
 			StringBuilder sb = new StringBuilder();
 			sb.append("\nProblems:\n");
-			problems.stream().forEach(problem -> sb.append(problem + "\n"));
+			problems.stream().forEach(problem -> sb.append(problem + StringTool.lf));
 			return sb.toString();
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	private void addProblem(String prefix, Konsultation cons){

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/RenameAccountingSystemField.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/RenameAccountingSystemField.java
@@ -16,6 +16,7 @@ import ch.elexis.core.ui.dbcheck.external.ExternalMaintenance;
 import ch.elexis.data.Fall;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class RenameAccountingSystemField extends ExternalMaintenance {
 	private static final String DESCRIPTION = "Feld aus Abrechnungssystem umbenennen [3341]";
 	private static final String REQUIRED = "/bedingungen";
@@ -80,7 +81,7 @@ public class RenameAccountingSystemField extends ExternalMaintenance {
 			
 			//update configuration of accounting system
 			pm.subTask("Globale Einstellungen werden aktualisiert... ");
-			String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + accountingSystem;
+			String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + accountingSystem;
 			String updatedConfig = updateFieldConfiguration(key, currFieldName, newFieldName);
 			pm.worked(1);
 			
@@ -114,9 +115,9 @@ public class RenameAccountingSystemField extends ExternalMaintenance {
 	}
 	
 	private boolean openRenameAccountingSysFieldDialog(){
-		accountingSystem = "";
-		currFieldName = "";
-		newFieldName = "";
+		accountingSystem = StringTool.leer;
+		currFieldName = StringTool.leer;
+		newFieldName = StringTool.leer;
 		
 		final Display display = Display.getDefault();
 		display.syncExec(new Runnable() {

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/dialogs/RenameAccountingSysFieldDialog.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/contributions/dialogs/RenameAccountingSysFieldDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Text;
 
 import ch.elexis.data.BillingSystem;
 
+import ch.rgw.tools.StringTool;
 public class RenameAccountingSysFieldDialog extends TitleAreaDialog {
 	private Text txtNewName;
 	private ComboViewer cViewerAccSys, cViewerField;
@@ -77,7 +78,7 @@ public class RenameAccountingSysFieldDialog extends TitleAreaDialog {
 		cmbField.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		cViewerField.setContentProvider(ArrayContentProvider.getInstance());
 		cViewerField.setLabelProvider(new LabelProvider());
-		cViewerField.setInput("");
+		cViewerField.setInput(StringTool.leer);
 		
 		Label lblNewName = new Label(area, SWT.NONE);
 		lblNewName.setText("Umbenennen zu");

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/refintegrity/RefIntegrityCheckMySQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/refintegrity/RefIntegrityCheckMySQL.java
@@ -15,6 +15,7 @@ import ch.elexis.core.ui.dbcheck.model.TableDescriptor;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLink.Stm;
 
+import ch.rgw.tools.StringTool;
 public class RefIntegrityCheckMySQL extends RefIntegrityCheck {
 	
 	public RefIntegrityCheckMySQL(){
@@ -39,13 +40,13 @@ public class RefIntegrityCheckMySQL extends RefIntegrityCheck {
 				if (!(refIntErrors == null) && refIntErrors.length > 0) {
 					for (int k = 0; k < refIntErrors.length; k = k + 2) {
 						String description = refIntErrors[k];
-						System.out.println(tables[i] + " " + description + " " + k);
+						System.out.println(tables[i] + StringTool.space + description + StringTool.space + k);
 						String query = refIntErrors[k + 1];
 						Stm stm = j.getStatement();
 						ResultSet rs = stm.query(query.toLowerCase());
 						while (rs.next()) {
-							errlog.append(tables[i] + ": " + rs.getString(1) + " " + description
-								+ "\n");
+							errlog.append(tables[i] + ": " + rs.getString(1) + StringTool.space + description
+								+ StringTool.lf);
 						}
 					}
 				}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/refintegrity/RefIntegrityCheckPGSQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/refintegrity/RefIntegrityCheckPGSQL.java
@@ -15,6 +15,7 @@ import ch.elexis.core.ui.dbcheck.model.TableDescriptor;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLink.Stm;
 
+import ch.rgw.tools.StringTool;
 public class RefIntegrityCheckPGSQL extends RefIntegrityCheck {
 	
 	public RefIntegrityCheckPGSQL(){
@@ -43,8 +44,8 @@ public class RefIntegrityCheckPGSQL extends RefIntegrityCheck {
 						Stm stm = j.getStatement();
 						ResultSet rs = stm.query(query);
 						while (rs.next()) {
-							errlog.append(tables[i] + ": " + rs.getString(1) + " " + description
-								+ "\n");
+							errlog.append(tables[i] + ": " + rs.getString(1) + StringTool.space + description
+								+ StringTool.lf);
 						}
 					}
 				}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/semantic/SemanticCheckMySQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/semantic/SemanticCheckMySQL.java
@@ -12,6 +12,7 @@ import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLinkSyntaxException;
 import ch.rgw.tools.JdbcLink.Stm;
 
+import ch.rgw.tools.StringTool;
 public class SemanticCheckMySQL extends SemanticCheck {
 	
 	public SemanticCheckMySQL(){
@@ -52,7 +53,7 @@ public class SemanticCheckMySQL extends SemanticCheck {
 							} catch (JdbcLinkSyntaxException je2) {
 								// We still did not find the table, assume its missing!
 								errlog.append(tables[i] + ": Semantischer Fehler bei Query <<"
-									+ query + ">> auf ID " + ((rs!=null) ? rs.getString(1) : rs) + "\n");
+									+ query + ">> auf ID " + ((rs!=null) ? rs.getString(1) : rs) + StringTool.lf);
 								continue;
 							}
 						}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/semantic/SemanticCheckPGSQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/semantic/SemanticCheckPGSQL.java
@@ -15,6 +15,7 @@ import ch.elexis.core.ui.dbcheck.model.TableDescriptor;
 import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLink.Stm;
 
+import ch.rgw.tools.StringTool;
 public class SemanticCheckPGSQL extends SemanticCheck {
 	
 	public SemanticCheckPGSQL(){
@@ -43,7 +44,7 @@ public class SemanticCheckPGSQL extends SemanticCheck {
 						ResultSet rs = stm.query("SELECT * FROM " + tables[i] + " WHERE " + query);
 						while (rs.next()) {
 							errlog.append(tables[i] + ": Semantischer Fehler bei Query <<" + query
-								+ ">> auf ID " + rs.getString(1) + "\n");
+								+ ">> auf ID " + rs.getString(1) + StringTool.lf);
 						}
 					}
 				}

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/syntactic/SyntacticCheckMySQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/syntactic/SyntacticCheckMySQL.java
@@ -17,6 +17,7 @@ import ch.rgw.tools.JdbcLink.Stm;
 import ch.rgw.tools.JdbcLinkSyntaxException;
 import ch.rgw.tools.Log;
 
+import ch.rgw.tools.StringTool;
 public class SyntacticCheckMySQL extends SyntacticCheck {
 	
 	private static Log logger = Log.get(SyntacticCheckMySQL.class.getName());
@@ -49,7 +50,7 @@ public class SyntacticCheckMySQL extends SyntacticCheck {
 					rsColl =
 						stmColl
 							.query("SELECT table_collation FROM information_schema.tables WHERE UPPER(table_name) = \""
-								+ tables[l].toUpperCase() + "\"");
+								+ tables[l].toUpperCase() + StringTool.backslash);
 				} catch (JdbcLinkSyntaxException je) {
 					errlog.append(tables[l] + ": SynErr: Tabelle nicht gefunden!\n");
 					continue;
@@ -60,7 +61,7 @@ public class SyntacticCheckMySQL extends SyntacticCheck {
 				}
 				String collation = rsColl.getString(1);
 				if (!collation.equalsIgnoreCase("utf8_general_ci")) {
-					oklog.append(" " + collation + " inkorrekt, erwarte utf8_general_ci\n");
+					oklog.append(StringTool.space + collation + " inkorrekt, erwarte utf8_general_ci\n");
 					errlog.append(tables[l] + ": Collation " + collation
 						+ " inkorrekt, erwarte utf8_general_ci\n");
 					fixScript.append("ALTER TABLE " + tables[l]
@@ -87,18 +88,18 @@ public class SyntacticCheckMySQL extends SyntacticCheck {
 				for (int k = 0; k < fields.length; k++) {
 					boolean ok = false;
 					
-					oklog.append(tables[i] + ": Erwarte " + fields[k] + " " + fieldType[k] + "...");
+					oklog.append(tables[i] + ": Erwarte " + fields[k] + StringTool.space + fieldType[k] + "...");
 					
 					Stm stm = j.getStatement();
 					ResultSet rs = null;
 					
 					try {
-						rs = stm.query("DESCRIBE " + tables[i].toLowerCase() + " " + fields[k]);
+						rs = stm.query("DESCRIBE " + tables[i].toLowerCase() + StringTool.space + fields[k]);
 						
 					} catch (JdbcLinkSyntaxException je) {
 						// We have no lowercase here, but uppercase!
 						try {
-							rs = stm.query("DESCRIBE " + tables[i] + " " + fields[k]);
+							rs = stm.query("DESCRIBE " + tables[i] + StringTool.space + fields[k]);
 						} catch (JdbcLinkSyntaxException je2) {
 							// We still did not find the table, assume its missing!
 							continue;
@@ -111,21 +112,21 @@ public class SyntacticCheckMySQL extends SyntacticCheck {
 							&& isCompatible(rs.getString(2), fieldType[k])) {
 							oklog.append(" OK\n");
 						} else {
-							oklog.append(" erhalte " + rs.getString(1) + " " + rs.getString(2)
-								+ "\n");
-							errlog.append(tables[i] + ": SynErr: FeldTyp " + rs.getString(1) + " "
-								+ rs.getString(2) + " inkorrekt, erwarte " + fields[k] + " "
-								+ fieldType[k] + "\n");
+							oklog.append(" erhalte " + rs.getString(1) + StringTool.space + rs.getString(2)
+								+ StringTool.lf);
+							errlog.append(tables[i] + ": SynErr: FeldTyp " + rs.getString(1) + StringTool.space
+								+ rs.getString(2) + " inkorrekt, erwarte " + fields[k] + StringTool.space
+								+ fieldType[k] + StringTool.lf);
 							fixScript.append("ALTER TABLE " + tables[i] + " MODIFY " + fields[k]
-								+ " " + fieldType[k] + ";\n");
+								+ StringTool.space + fieldType[k] + ";\n");
 						}
 						
 					}
 					if (!ok) {
 						oklog.append(" not found\n");
-						errlog.append(tables[i] + ": SynErr: Feld " + fields[k] + " "
+						errlog.append(tables[i] + ": SynErr: Feld " + fields[k] + StringTool.space
 							+ fieldType[k] + " nicht gefunden!\n");
-						fixScript.append("ALTER TABLE " + tables[i] + " ADD " + fields[k] + " "
+						fixScript.append("ALTER TABLE " + tables[i] + " ADD " + fields[k] + StringTool.space
 							+ fieldType[k]);
 					}
 					

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/syntactic/SyntacticCheckPGSQL.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/syntactic/SyntacticCheckPGSQL.java
@@ -15,6 +15,7 @@ import ch.elexis.core.ui.dbcheck.model.DBModel;
 import ch.elexis.core.ui.dbcheck.model.TableDescriptor;
 import ch.rgw.tools.JdbcLink;
 
+import ch.rgw.tools.StringTool;
 public class SyntacticCheckPGSQL extends SyntacticCheck {
 	public SyntacticCheckPGSQL(){
 		oklog = new StringBuilder();
@@ -45,7 +46,7 @@ public class SyntacticCheckPGSQL extends SyntacticCheck {
 				String[] fieldType = tableDetail.getFieldTypes(version);
 				for (int k = 0; k < fields.length; k++) {
 					boolean ok = false;
-					oklog.append(tables[i] + ": Erwarte " + fields[k] + " " + fieldType[k] + "...");
+					oklog.append(tables[i] + ": Erwarte " + fields[k] + StringTool.space + fieldType[k] + "...");
 					
 					ResultSet rs =
 						conn.getMetaData().getColumns(conn.getCatalog(), "%",
@@ -57,16 +58,16 @@ public class SyntacticCheckPGSQL extends SyntacticCheck {
 							&& isCompatible(dataType, fieldType[k])) {
 							oklog.append(" OK\n");
 						} else {
-							oklog.append(" erhalte " + rs.getString(4) + " " + dataType + "\n");
-							errlog.append(tables[i] + ": SynErr: FeldTyp " + rs.getString(4) + " "
-								+ dataType + " inkorrekt, erwarte " + fields[k] + " "
-								+ fieldType[k] + "\n");
+							oklog.append(" erhalte " + rs.getString(4) + StringTool.space + dataType + StringTool.lf);
+							errlog.append(tables[i] + ": SynErr: FeldTyp " + rs.getString(4) + StringTool.space
+								+ dataType + " inkorrekt, erwarte " + fields[k] + StringTool.space
+								+ fieldType[k] + StringTool.lf);
 						}
 						
 					}
 					if (!ok) {
 						oklog.append(" nicht gefunden\n");
-						errlog.append(tables[i] + ": SynErr: Feld " + fields[k] + " "
+						errlog.append(tables[i] + ": SynErr: Feld " + fields[k] + StringTool.space
 							+ fieldType[k] + " nicht gefunden!\n");
 					}
 					

--- a/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/ui/DBTestDialog.java
+++ b/bundles/ch.elexis.core.ui.dbcheck/src/ch/elexis/core/ui/dbcheck/ui/DBTestDialog.java
@@ -56,6 +56,7 @@ import ch.elexis.core.ui.dbcheck.external.ExternalMaintenance;
 import ch.elexis.core.ui.dbcheck.model.DBModel;
 import ch.elexis.data.PersistentObject;
 
+import ch.rgw.tools.StringTool;
 public class DBTestDialog extends TrayDialog {
 	
 	protected Object result;
@@ -125,7 +126,7 @@ public class DBTestDialog extends TrayDialog {
 							StringBuilder sb = new StringBuilder();
 							// TODO Call DB Check accordingly
 							SyntacticCheckExec.setJDBCLink(PersistentObject.getConnection());
-							sb.append(SyntacticCheckExec.getDBInformation() + "\n");
+							sb.append(SyntacticCheckExec.getDBInformation() + StringTool.lf);
 							StyleRange styleDBInfo = new StyleRange();
 							styleDBInfo.start = 0;
 							styleDBInfo.length = sb.length();
@@ -143,7 +144,7 @@ public class DBTestDialog extends TrayDialog {
 							
 							sb.append("--- Database Version Consistence ---\n");
 							monitor.subTask("Prüfe Datenbank Konsistenz");
-							sb.append(SyntacticCheckExec.checkDBVersionConsistence() + "\n");
+							sb.append(SyntacticCheckExec.checkDBVersionConsistence() + StringTool.lf);
 							monitor.worked(1);
 							
 							monitor.subTask("Checking Syntax");
@@ -180,11 +181,11 @@ public class DBTestDialog extends TrayDialog {
 								out.append("=== " + dateFormat.format(date) + " ===\n");
 								out.append(sb.toString());
 								out.append("--- OUTPUT LOG Syntactic Check ---\n");
-								out.append(SyntacticCheckExec.getOutputLog() + "\n");
+								out.append(SyntacticCheckExec.getOutputLog() + StringTool.lf);
 								out.append("--- OUTPUT LOG Semantic Check ---\n");
-								out.append(SemanticCheckExec.getOutputLog() + "\n");
+								out.append(SemanticCheckExec.getOutputLog() + StringTool.lf);
 								out.append("--- OUTPUT LOG Referential Integrity Check ---\n");
-								out.append(RefIntegrityCheckExec.getOutputLog() + "\n");
+								out.append(RefIntegrityCheckExec.getOutputLog() + StringTool.lf);
 								out.close();
 								fos.close();
 							}

--- a/bundles/ch.elexis.core.ui.documents/src/ch/elexis/core/ui/documents/views/DocumentsMetaDataDialog.java
+++ b/bundles/ch.elexis.core.ui.documents/src/ch/elexis/core/ui/documents/views/DocumentsMetaDataDialog.java
@@ -45,6 +45,7 @@ import ch.elexis.core.ui.documents.service.DocumentStoreServiceHolder;
 import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public class DocumentsMetaDataDialog extends TitleAreaDialog {
 	
 	private static Logger logger = LoggerFactory.getLogger(DocumentsMetaDataDialog.class);
@@ -160,7 +161,7 @@ public class DocumentsMetaDataDialog extends TitleAreaDialog {
 						MessageFormat.format(Messages.DocumentMetaDataDialog_deleteCategoryConfirm,
 						((ICategory) selection).getName()),
 						Messages.DocumentMetaDataDialog_deleteCategoryText,
-						"", null);
+						StringTool.leer, null);
 				if (id.open() == Dialog.OK) {
 					try {
 						document.setCategory((ICategory) selection);

--- a/bundles/ch.elexis.core.ui.documents/src/ch/elexis/core/ui/documents/views/DocumentsView.java
+++ b/bundles/ch.elexis.core.ui.documents/src/ch/elexis/core/ui/documents/views/DocumentsView.java
@@ -92,6 +92,7 @@ import ch.rgw.tools.TimeTool;
  * the selected patient. On double-click they are opened with their associated application.
  */
 
+import ch.rgw.tools.StringTool;
 public class DocumentsView extends ViewPart implements IActivationListener {
 	private static Logger logger = LoggerFactory.getLogger(DocumentsView.class);
 	
@@ -101,7 +102,7 @@ public class DocumentsView extends ViewPart implements IActivationListener {
 	public static String importAction_ID = "ch.elexis.omnivore.data.DocumentView.importAction";
 	private final String[] colLabels =
 		{
-			"", Messages.DocumentView_categoryColumn, Messages.DocumentView_stateColumn,
+			StringTool.leer, Messages.DocumentView_categoryColumn, Messages.DocumentView_stateColumn,
 			Messages.DocumentView_lastChangedColumn,
 			Messages.DocumentView_dateCreatedColumn,
 			Messages.DocumentView_titleColumn,
@@ -109,7 +110,7 @@ public class DocumentsView extends ViewPart implements IActivationListener {
 		};
 	private final String colWidth = "20,80,80,80,80,50,150,500";
 	private final String sortSettings = "0,1,-1,false";
-	private String searchTitle = "";
+	private String searchTitle = StringTool.leer;
 	
 	private DocumentsViewerComparator ovComparator;
 	private Action doubleClickAction;
@@ -334,9 +335,9 @@ public class DocumentsView extends ViewPart implements IActivationListener {
 			IDocument dh = (IDocument) obj;
 			switch (index) {
 			case 0:
-				return "";
+				return StringTool.leer;
 			case 1:
-				return "";
+				return StringTool.leer;
 			case 2:
 				return dh.getStatus().getName();
 			case 3:

--- a/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/EigenartikelComposite.java
+++ b/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/EigenartikelComposite.java
@@ -35,6 +35,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.locks.IUnlockable;
 import ch.elexis.core.ui.views.controls.StockDetailComposite;
 
+import ch.rgw.tools.StringTool;
 public class EigenartikelComposite extends Composite implements IUnlockable {
 	
 	private WritableValue<IArticle> drugPackageEigenartikel =
@@ -92,7 +93,7 @@ public class EigenartikelComposite extends Composite implements IUnlockable {
 		grpDrugPackages = new Group(this, SWT.NONE);
 		grpDrugPackages.setLayout(new GridLayout(1, false));
 		grpDrugPackages.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, true, 2, 1));
-		grpDrugPackages.setText("");
+		grpDrugPackages.setText(StringTool.leer);
 		
 		if (includeDeleteOption) {
 			Composite compDpSelector = new Composite(grpDrugPackages, SWT.NONE);

--- a/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/EigenartikelTreeLabelProvider.java
+++ b/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/EigenartikelTreeLabelProvider.java
@@ -6,6 +6,7 @@ import ch.elexis.core.data.service.StockServiceHolder;
 import ch.elexis.core.model.IArticle;
 import ch.elexis.core.services.IStockService.Availability;
 
+import ch.rgw.tools.StringTool;
 public class EigenartikelTreeLabelProvider extends LabelProvider {
 	
 	@Override
@@ -13,15 +14,15 @@ public class EigenartikelTreeLabelProvider extends LabelProvider {
 		IArticle ea = (IArticle) element;
 		String name = ea.getName();
 		if (!ea.isProduct()) {
-			String label = "";
-			label += ea.getPackageSize() + " "
-				+ (ea.getPackageUnit() != null ? ea.getPackageUnit() : "");
+			String label = StringTool.leer;
+			label += ea.getPackageSize() + StringTool.space
+				+ (ea.getPackageUnit() != null ? ea.getPackageUnit() : StringTool.leer);
 			Availability availability =
 				StockServiceHolder.get().getCumulatedAvailabilityForArticle(ea);
 			if (availability != null) {
 				label += " (" + availability.toString() + ")";
 			}
-			return name +" " +label;
+			return name +StringTool.space +label;
 		}
 		return name;
 	}

--- a/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/ShowEigenartikelProductsAction.java
+++ b/bundles/ch.elexis.core.ui.eigenartikel/src/ch/elexis/core/ui/eigenartikel/ShowEigenartikelProductsAction.java
@@ -5,6 +5,7 @@ import org.eclipse.jface.action.Action;
 import ch.elexis.core.data.activator.CoreHub;
 import ch.elexis.core.ui.icons.Images;
 
+import ch.rgw.tools.StringTool;
 public class ShowEigenartikelProductsAction extends Action {
 	
 	public static final String FILTER_CFG = "ShowEigenartikelProductsAction.showProducts";
@@ -18,7 +19,7 @@ public class ShowEigenartikelProductsAction extends Action {
 		this.eal = eal;
 		this.eigenartikelSelector = eigenartikelSelector;
 		setImageDescriptor(Images.IMG_CARDS.getImageDescriptor());
-		setToolTipText("");		
+		setToolTipText(StringTool.leer);		
 		setChecked(CoreHub.userCfg.get(ShowEigenartikelProductsAction.FILTER_CFG, false));
 		execute();
 	}

--- a/bundles/ch.elexis.core.ui.eigendiagnosen/src/ch/elexis/core/ui/eigendiagnosen/EigendiagnoseDetailDisplay.java
+++ b/bundles/ch.elexis.core.ui.eigendiagnosen/src/ch/elexis/core/ui/eigendiagnosen/EigendiagnoseDetailDisplay.java
@@ -67,9 +67,9 @@ public class EigendiagnoseDetailDisplay implements IDetailDisplay {
 			tblPls.reload(diag);
 			tComment.setText(diag.getDescription());
 		} else {
-			form.setText("");
+			form.setText(StringTool.leer);
 			tblPls.reload((Identifiable) null);
-			tComment.setText("");
+			tComment.setText(StringTool.leer);
 		}
 	}
 	

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/DefaultLabImportUiHandler.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/DefaultLabImportUiHandler.java
@@ -10,6 +10,7 @@ import ch.elexis.core.model.IPatient;
 import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.importer.div.importers.dialog.QueryOverwriteDialog;
 
+import ch.rgw.tools.StringTool;
 public class DefaultLabImportUiHandler extends ImportHandler {
 	
 	@Override
@@ -50,7 +51,7 @@ public class DefaultLabImportUiHandler extends ImportHandler {
 		public void run(){
 			StringBuilder message = new StringBuilder();
 			message.append("Alter Wert\n").append(oldResult.getLabel());
-			message.append("\n");
+			message.append(StringTool.lf);
 			message.append("Neuer Wert\n").append(newResult.getLabel());
 			message.append("\n\n");
 			message.append(Messages.HL7Parser_AskOverwrite);

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/GenericImporterBlatt.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/GenericImporterBlatt.java
@@ -297,7 +297,7 @@ public class GenericImporterBlatt extends Composite {
 			 */
 			private void loadAvailableFields(){
 				PersistentObject type = getSelectedType();
-				StringBuilder excelFieldsStrings = new StringBuilder("");
+				StringBuilder excelFieldsStrings = new StringBuilder(StringTool.leer);
 
 				inputAvailableFields = new ArrayList<Field>();
 				if (type != null) {
@@ -321,7 +321,7 @@ public class GenericImporterBlatt extends Composite {
 				if (type == null) {
 						return;
 				}
-				StringBuilder fields = new StringBuilder("");
+				StringBuilder fields = new StringBuilder(StringTool.leer);
 				for (int i = 0; i < dbAvailableFields.size(); i++) {
 					if (fields.toString().length() >= 1) fields.append(",");
 					fields.append(dbAvailableFields.get(i).name);
@@ -1065,7 +1065,7 @@ public class GenericImporterBlatt extends Composite {
 					}
 					
 					public String getColumnText(Object element, int columnIndex){
-						String text = ""; //$NON-NLS-1$
+						String text = StringTool.leer; //$NON-NLS-1$
 						
 						// commonly used variables
 						int fieldIndex;
@@ -1107,18 +1107,18 @@ public class GenericImporterBlatt extends Composite {
 									} else {
 										// values differ, show both values
 										if (dbValue != null) {
-											text = inputValue + "/" + dbValue; //$NON-NLS-1$
+											text = inputValue + StringTool.slash + dbValue; //$NON-NLS-1$
 										} else {
-											text = inputValue + "/"; //$NON-NLS-1$
+											text = inputValue + StringTool.slash; //$NON-NLS-1$
 										}
 									}
 								} else {
 									if (dbValue != null) {
 										// only dbValue available
-										text = "/" + dbValue; //$NON-NLS-1$
+										text = StringTool.slash + dbValue; //$NON-NLS-1$
 									} else {
 										// no value available
-										text = "/"; //$NON-NLS-1$
+										text = StringTool.slash; //$NON-NLS-1$
 									}
 								}
 								
@@ -1257,7 +1257,7 @@ public class GenericImporterBlatt extends Composite {
 				// first column: image
 				TableColumn imageColumn = new TableColumn(table, SWT.LEFT);
 				imageColumn.setWidth(IMAGE_COLUMN_WIDTH);
-				imageColumn.setText(""); //$NON-NLS-1$
+				imageColumn.setText(StringTool.leer); //$NON-NLS-1$
 				
 				if (mappingPage.isPageComplete()) {
 					int columnsCount = mappingPage.inputChosenFields.size();
@@ -1273,7 +1273,7 @@ public class GenericImporterBlatt extends Composite {
 						String dbName = mappingPage.dbChosenFields.get(i).name;
 						String name = dbName;
 						if (!inputName.equals(dbName)) {
-							name = inputName + "/" + name; //$NON-NLS-1$
+							name = inputName + StringTool.slash + name; //$NON-NLS-1$
 						}
 						columns[i].setText(name);
 					}
@@ -1321,7 +1321,7 @@ public class GenericImporterBlatt extends Composite {
 								// get value from excel, eliminate leading and trailing white space
 								value = row.get(index).trim();
 							} else {
-								value = ""; //$NON-NLS-1$
+								value = StringTool.leer; //$NON-NLS-1$
 							}
 							rowMap.put(key, value);
 						}
@@ -1367,7 +1367,7 @@ public class GenericImporterBlatt extends Composite {
 				for (KeyFields keyField : keyFields) {
 					String name = keyField.dbName;
 					String value = inputObject.get(keyField.inputName);
-					query.add(name, "=", value); //$NON-NLS-1$
+					query.add(name, StringTool.equals, value); //$NON-NLS-1$
 				}
 				List<PersistentObject> dbObjects = query.execute();
 				if (dbObjects != null && dbObjects.size() > 0) {
@@ -1598,7 +1598,7 @@ public class GenericImporterBlatt extends Composite {
 				}
 				
 				public String getColumnText(Object element, int columnIndex){
-					String text = ""; //$NON-NLS-1$
+					String text = StringTool.leer; //$NON-NLS-1$
 					
 					// commonly used variables
 					int fieldIndex;
@@ -1618,7 +1618,7 @@ public class GenericImporterBlatt extends Composite {
 								key = mappingPage.inputChosenFields.get(fieldIndex).name;
 								text = inputObject.get(key);
 							} else {
-								text = ""; //$NON-NLS-1$
+								text = StringTool.leer; //$NON-NLS-1$
 							}
 							break;
 						case SyncElement.DB_ONLY:
@@ -1627,7 +1627,7 @@ public class GenericImporterBlatt extends Composite {
 								key = mappingPage.dbChosenFields.get(fieldIndex).name;
 								text = dbObject.get(key);
 							} else {
-								text = ""; //$NON-NLS-1$
+								text = StringTool.leer; //$NON-NLS-1$
 							}
 							break;
 						case SyncElement.DIFF:

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/ImporterPatientResolver.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/ImporterPatientResolver.java
@@ -9,6 +9,7 @@ import ch.elexis.core.ui.exchange.KontaktMatcher.CreateMode;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ImporterPatientResolver extends AbstractHL7PatientResolver {
 	
 	private TimeTool convertTool = new TimeTool();
@@ -18,7 +19,7 @@ public class ImporterPatientResolver extends AbstractHL7PatientResolver {
 		String sender){
 		
 		// resolve with full data
-		Patient pat = KontaktMatcher.findPatient(lastname, firstname, birthDate, "", "", "", "", "", CreateMode.FAIL);
+		Patient pat = KontaktMatcher.findPatient(lastname, firstname, birthDate, StringTool.leer, StringTool.leer, StringTool.leer, StringTool.leer, StringTool.leer, CreateMode.FAIL);
 		// try to resolve with only the beginning of the name
 		if (pat == null) {
 			String shortLastname = lastname;
@@ -29,7 +30,7 @@ public class ImporterPatientResolver extends AbstractHL7PatientResolver {
 			if (firstname.length() > 3) {
 				shortFirstname = firstname.substring(0, 3);
 			}
-			pat = KontaktMatcher.findPatient(shortLastname, shortFirstname, birthDate, "", "", "", "", "",
+			pat = KontaktMatcher.findPatient(shortLastname, shortFirstname, birthDate, StringTool.leer, StringTool.leer, StringTool.leer, StringTool.leer, StringTool.leer,
 					CreateMode.FAIL);
 		}
 		// user decides
@@ -38,12 +39,12 @@ public class ImporterPatientResolver extends AbstractHL7PatientResolver {
 			String birthStr = convertTool.toString(TimeTool.DATE_GER);
 			if (sender != null) {
 				pat = (Patient) KontaktSelektor.showInSync(Patient.class,
-					Messages.HL7_SelectPatient, Messages.HL7_WhoIs + lastname + " " + firstname
-						+ " ," + birthStr + "?\n" + Messages.HL7_Lab + " " + sender);
+					Messages.HL7_SelectPatient, Messages.HL7_WhoIs + lastname + StringTool.space + firstname
+						+ " ," + birthStr + "?\n" + Messages.HL7_Lab + StringTool.space + sender);
 			} else {
 				pat =
 					(Patient) KontaktSelektor.showInSync(Patient.class, Messages.HL7_SelectPatient,
-						Messages.HL7_WhoIs + lastname + " " + firstname + " ," + birthStr + "?");
+						Messages.HL7_WhoIs + lastname + StringTool.space + firstname + " ," + birthStr + "?");
 			}
 		}
 		if (pat != null) {

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/KontaktImporter.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/KontaktImporter.java
@@ -23,6 +23,7 @@ import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.data.Kontakt;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class KontaktImporter extends ImporterPage {
 	KontaktImporterBlatt importer;
 	
@@ -69,11 +70,11 @@ public class KontaktImporter extends ImporterPage {
 			StringBuilder s1 = new StringBuilder();
 			StringBuilder s2 = new StringBuilder();
 			s1.append(found.get("Bezeichnung1")).append(", ").append(found.get("Bezeichnung2")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				.append(" - ").append(found.get("Strasse")).append(" ") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				.append(found.get("Plz")).append(" ").append(found.get("Ort")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				.append(" - ").append(found.get("Strasse")).append(StringTool.space) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				.append(found.get("Plz")).append(StringTool.space).append(found.get("Ort")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			
 			s2.append(name).append(", ").append(vorname).append(" - ") //$NON-NLS-1$ //$NON-NLS-2$
-				.append(strasse).append(" ").append(plz).append(" ").append(ort); //$NON-NLS-1$ //$NON-NLS-2$
+				.append(strasse).append(StringTool.space).append(plz).append(StringTool.space).append(ort); //$NON-NLS-1$ //$NON-NLS-2$
 			
 			if (SWTHelper.askYesNo(Messages.KontaktImporter_AskSameTitle,
 				Messages.KontaktImporter_AskSameText1 + s1.toString()

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/KontaktImporterBlatt.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/KontaktImporterBlatt.java
@@ -84,7 +84,7 @@ public class KontaktImporterBlatt extends Composite {
 			public void widgetSelected(final SelectionEvent e){
 				FileDialog fd = new FileDialog(getShell(), SWT.OPEN);
 				String file = fd.open();
-				lbFileName.setText(file == null ? "" : file); //$NON-NLS-1$
+				lbFileName.setText(file == null ? StringTool.leer : file); //$NON-NLS-1$
 				filename = lbFileName.getText();
 			}
 		});
@@ -149,7 +149,7 @@ public class KontaktImporterBlatt extends Composite {
 			if (row.length != 7) {
 				continue;
 			}
-			log.info(Messages.KontaktImporterBlatt_Importing + StringTool.join(row, " "));
+			log.info(Messages.KontaktImporterBlatt_Importing + StringTool.join(row, StringTool.space));
 			// Please keep in sync with doc/import.textile !!
 			String bagnr = StringTool.getSafe(row, 0);
 			String name = StringTool.getSafe(row, 1);
@@ -177,15 +177,15 @@ public class KontaktImporterBlatt extends Composite {
 	String[] splitAdress(final String adr){
 		String[] ret = new String[3];
 		String[] m1 = adr.split("\\s*,\\s*"); //$NON-NLS-1$
-		String[] plzOrt = m1[m1.length - 1].split(" ", 2); //$NON-NLS-1$
+		String[] plzOrt = m1[m1.length - 1].split(StringTool.space, 2); //$NON-NLS-1$
 		if (m1.length == 1) {
-			ret[0] = ""; //$NON-NLS-1$
+			ret[0] = StringTool.leer; //$NON-NLS-1$
 			
 		} else {
 			ret[0] = m1[0];
 		}
 		ret[1] = plzOrt[0];
-		ret[2] = plzOrt.length > 1 ? plzOrt[1] : ""; //$NON-NLS-1$
+		ret[2] = plzOrt.length > 1 ? plzOrt[1] : StringTool.leer; //$NON-NLS-1$
 		return ret;
 	}
 	
@@ -278,10 +278,10 @@ public class KontaktImporterBlatt extends Composite {
 			// Please keep in sync with doc/import.textile !!
 			VCard vcard = new VCard(new FileInputStream(file));
 			String name, vorname, tel, email, title;
-			String gebdat = ""; //$NON-NLS-1$
-			String strasse = ""; //$NON-NLS-1$
-			String plz = ""; //$NON-NLS-1$
-			String ort = ""; //$NON-NLS-1$
+			String gebdat = StringTool.leer; //$NON-NLS-1$
+			String strasse = StringTool.leer; //$NON-NLS-1$
+			String plz = StringTool.leer; //$NON-NLS-1$
+			String ort = StringTool.leer; //$NON-NLS-1$
 			String fqname = vcard.getElement("N"); //$NON-NLS-1$
 			if (fqname == null) {
 				return false;

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/MediportInsurerImporter.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/MediportInsurerImporter.java
@@ -14,6 +14,7 @@ import ch.elexis.data.Kontakt;
 import ch.elexis.data.Organisation;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class MediportInsurerImporter {
 	private static Logger log = LoggerFactory.getLogger(MediportInsurerImporter.class);
 	
@@ -41,7 +42,7 @@ public class MediportInsurerImporter {
 		List<Organisation> insurerList = new ArrayList<Organisation>();
 		try {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(csvInStream));
-			String line = "";
+			String line = StringTool.leer;
 			int lineNo = 0;
 			
 			while ((line = reader.readLine()) != null) {
@@ -76,7 +77,7 @@ public class MediportInsurerImporter {
 				contactQuery.add(Kontakt.FLD_PLACE, Query.EQUALS, city);
 				List<Kontakt> contactList = contactQuery.execute();
 				if (contactList != null && !contactList.isEmpty()) {
-					log.warn("Kontakt [" + org + " " + dept + ", " + street + ", " + city
+					log.warn("Kontakt [" + org + StringTool.space + dept + ", " + street + ", " + city
 						+ "] existiert bereits. Wird nicht imporiert.");
 					continue;
 				}

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/Presets.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/importers/Presets.java
@@ -267,14 +267,14 @@ public class Presets {
 			pat.set(new String[] {
 				"Strasse", "Plz", "Ort", "Land", "Telefon1", "Telefon2", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
 				"Natel", "E-Mail", "Titel", "Gruppe", "Zusatz"}, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-				strasse, plz, ort, land.equalsIgnoreCase(Messages.Presets_Switzerland) ? "CH" : "", //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+				strasse, plz, ort, land.equalsIgnoreCase(Messages.Presets_Switzerland) ? "CH" : StringTool.leer, //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
 				telp1, telp2, tel3, email, titel, arztn, zusatz);
 			if (!StringTool.isNothing(ahvnr)) {
 				pat.addXid(XidConstants.DOMAIN_AHV, ahvnr, true);
 			}
 			if (!StringTool.isNothing(kk)) {
 				Query<Kontakt> qbe = new Query<Kontakt>(Kontakt.class);
-				qbe.add("Bezeichnung1", "=", kk); //$NON-NLS-1$ //$NON-NLS-2$
+				qbe.add("Bezeichnung1", StringTool.equals, kk); //$NON-NLS-1$ //$NON-NLS-2$
 				List<Kontakt> res = qbe.execute();
 				Kontakt k = null;
 				if (res.size() > 0) {
@@ -292,7 +292,7 @@ public class Presets {
 			}
 			if (!StringTool.isNothing(unfallvers)) {
 				Query<Kontakt> qbe = new Query<Kontakt>(Kontakt.class);
-				qbe.add("Bezeichnung1", "=", unfallvers); //$NON-NLS-1$ //$NON-NLS-2$
+				qbe.add("Bezeichnung1", StringTool.equals, unfallvers); //$NON-NLS-1$ //$NON-NLS-2$
 				List<Kontakt> res = qbe.execute();
 				Kontakt k = null;
 				if (res.size() > 0) {
@@ -351,7 +351,7 @@ public class Presets {
 			pat.set("Telefon2", StringTool.getSafe(row, 8)); //$NON-NLS-1$
 			if (!StringTool.isNothing(StringTool.getSafe(row, 10))) {
 				Organisation org =
-					KontaktMatcher.findOrganisation(row[10], null, "", "", "", CreateMode.CREATE); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					KontaktMatcher.findOrganisation(row[10], null, StringTool.leer, StringTool.leer, StringTool.leer, CreateMode.CREATE); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				Fall fall =
 					pat.neuerFall(Fall.getDefaultCaseLabel(), Fall.getDefaultCaseReason(),
 						Messages.Presets_KVGAbkuerzung);
@@ -360,7 +360,7 @@ public class Presets {
 			}
 			if (!StringTool.isNothing(StringTool.getSafe(row, 11))) {
 				Organisation org =
-					KontaktMatcher.findOrganisation(row[11], null, "", "", "", CreateMode.CREATE); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					KontaktMatcher.findOrganisation(row[11], null, StringTool.leer, StringTool.leer, StringTool.leer, CreateMode.CREATE); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				Fall fall =
 					pat.neuerFall(Fall.getDefaultCaseLabel(), Fall.getDefaultCaseReason(),
 						Messages.Presets_UVGAbkuerzung);

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/matchers/Verifier.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/matchers/Verifier.java
@@ -29,6 +29,7 @@ import ch.elexis.core.ui.dialogs.KontaktSelektor;
 import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.data.Kontakt;
 
+import ch.rgw.tools.StringTool;
 public class Verifier {
 	
 	public static Kontakt verify(Kontakt k, String t, String m){
@@ -78,7 +79,7 @@ public class Verifier {
 			for (Kontakt k : list) {
 				TableItem it = new TableItem(table, SWT.NONE);
 				it.setText(0, k.getLabel(true));
-				it.setText(1, k.get("Strasse") + " " + k.get("Ort")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				it.setText(1, k.get("Strasse") + StringTool.space + k.get("Ort")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
 			return table;
 		}

--- a/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/rs232/SerialParameters.java
+++ b/bundles/ch.elexis.core.ui.importer.div/src/ch/elexis/core/ui/importer/div/rs232/SerialParameters.java
@@ -36,6 +36,7 @@ import gnu.io.SerialPort;
 /**
  * A class that stores parameters for serial ports.
  */
+import ch.rgw.tools.StringTool;
 public class SerialParameters {
 	
 	private String portName;
@@ -52,7 +53,7 @@ public class SerialParameters {
 	 */
 	public SerialParameters(){
 		this(
-			"", //$NON-NLS-1$
+			StringTool.leer, //$NON-NLS-1$
 			9600, SerialPort.FLOWCONTROL_NONE, SerialPort.FLOWCONTROL_NONE, SerialPort.DATABITS_8,
 			SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 		

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LabItemTreeSelectionComposite.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LabItemTreeSelectionComposite.java
@@ -33,6 +33,7 @@ import ch.elexis.data.LabGroup;
 import ch.elexis.data.LabItem;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class LabItemTreeSelectionComposite extends Composite {
 	// height of laborViewer
 	private static final int LINES_TO_SHOW = 20;
@@ -72,7 +73,7 @@ public class LabItemTreeSelectionComposite extends Composite {
 					filter.setSearchText(filterText.getText());
 					laborViewer.refresh();
 				} else {
-					filter.setSearchText(""); //$NON-NLS-1$
+					filter.setSearchText(StringTool.leer); //$NON-NLS-1$
 					laborViewer.refresh();
 				}
 				restoreLeafCheckState();

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborMappingComposite.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborMappingComposite.java
@@ -30,6 +30,7 @@ import ch.elexis.data.LabItem;
 import ch.elexis.data.LabMapping;
 import ch.elexis.data.Labor;
 
+import ch.rgw.tools.StringTool;
 public class LaborMappingComposite extends Composite {
 	
 	protected TableViewer viewer;
@@ -148,7 +149,7 @@ public class LaborMappingComposite extends Composite {
 				} else if (element instanceof TransientLabMapping) {
 					return ((TransientLabMapping) element).getOrigin().getLabel(true);
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -163,7 +164,7 @@ public class LaborMappingComposite extends Composite {
 				} else if (element instanceof TransientLabMapping) {
 					return ((TransientLabMapping) element).getItemName();
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		column.setEditingSupport(new ItemNameEditingSupport(viewer));
@@ -195,7 +196,7 @@ public class LaborMappingComposite extends Composite {
 			} else if (element instanceof TransientLabMapping) {
 				return ((TransientLabMapping) element).getItemName();
 			}
-			return ""; //$NON-NLS-1$
+			return StringTool.leer; //$NON-NLS-1$
 		}
 		
 		@Override

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrdersComposite.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrdersComposite.java
@@ -41,6 +41,7 @@ import ch.elexis.data.LabOrder.State;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LaborOrdersComposite extends Composite {
 	
 	private final FormToolkit tk = UiDesk.getToolkit();
@@ -78,7 +79,7 @@ public class LaborOrdersComposite extends Composite {
 		toolComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		
 		toolbar = new ToolBarManager();
-		toolbar.add(new Action("", Action.AS_CHECK_BOX) {
+		toolbar.add(new Action(StringTool.leer, Action.AS_CHECK_BOX) {
 			
 			@Override
 			public String getText(){
@@ -137,7 +138,7 @@ public class LaborOrdersComposite extends Composite {
 				if (element instanceof LaborOrderViewerItem) {
 					return LabOrder.getStateLabel(((LaborOrderViewerItem) element).getState());
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -157,7 +158,7 @@ public class LaborOrdersComposite extends Composite {
 						return "???";
 					}
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -170,9 +171,9 @@ public class LaborOrdersComposite extends Composite {
 			@Override
 			public String getText(Object element){
 				if (element instanceof LaborOrderViewerItem) {
-					return ((LaborOrderViewerItem) element).getOrderId().orElse("");
+					return ((LaborOrderViewerItem) element).getOrderId().orElse(StringTool.leer);
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -185,9 +186,9 @@ public class LaborOrdersComposite extends Composite {
 			@Override
 			public String getText(Object element){
 				if (element instanceof LaborOrderViewerItem) {
-					return ((LaborOrderViewerItem) element).getOrderGroupName().orElse("");
+					return ((LaborOrderViewerItem) element).getOrderGroupName().orElse(StringTool.leer);
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -200,9 +201,9 @@ public class LaborOrdersComposite extends Composite {
 			@Override
 			public String getText(Object element){
 				if (element instanceof LaborOrderViewerItem) {
-					return ((LaborOrderViewerItem) element).getLabItemLabel().orElse("");
+					return ((LaborOrderViewerItem) element).getLabItemLabel().orElse(StringTool.leer);
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -215,7 +216,7 @@ public class LaborOrdersComposite extends Composite {
 				if (element instanceof LaborOrderViewerItem) {
 					return ((LaborOrderViewerItem) element).getLabResultString().orElse("?");
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -289,8 +290,8 @@ public class LaborOrdersComposite extends Composite {
 					
 					@Override
 					public int compare(LaborOrderViewerItem lo1, LaborOrderViewerItem lo2){
-						String prio1 = lo1.getLabItemPrio().orElse("");
-						String prio2 = lo2.getLabItemPrio().orElse("");
+						String prio1 = lo1.getLabItemPrio().orElse(StringTool.leer);
+						String prio2 = lo2.getLabItemPrio().orElse(StringTool.leer);
 						return prio1.compareTo(prio2);
 					}
 				});
@@ -367,8 +368,8 @@ public class LaborOrdersComposite extends Composite {
 						return labOrder2.getTime().compareTo(labOrder1.getTime());
 					}
 				case 2:
-					String orderId1 = labOrder1.getOrderId().orElse("");
-					String orderId2 = labOrder2.getOrderId().orElse("");
+					String orderId1 = labOrder1.getOrderId().orElse(StringTool.leer);
+					String orderId2 = labOrder2.getOrderId().orElse(StringTool.leer);
 					
 					if (composite.isRevert()) {
 						try {
@@ -387,19 +388,19 @@ public class LaborOrdersComposite extends Composite {
 					}
 				case 3:
 					if (composite.isRevert()) {
-						return labOrder1.getOrderGroupName().orElse("")
-							.compareTo(labOrder2.getOrderGroupName().orElse(""));
+						return labOrder1.getOrderGroupName().orElse(StringTool.leer)
+							.compareTo(labOrder2.getOrderGroupName().orElse(StringTool.leer));
 					} else {
-						return labOrder2.getOrderGroupName().orElse("")
-							.compareTo(labOrder1.getOrderGroupName().orElse(""));
+						return labOrder2.getOrderGroupName().orElse(StringTool.leer)
+							.compareTo(labOrder1.getOrderGroupName().orElse(StringTool.leer));
 					}
 				case 4:
 					if (composite.isRevert()) {
-						return labOrder1.getLabItemLabel().orElse("")
-							.compareTo(labOrder2.getLabItemLabel().orElse(""));
+						return labOrder1.getLabItemLabel().orElse(StringTool.leer)
+							.compareTo(labOrder2.getLabItemLabel().orElse(StringTool.leer));
 					} else {
-						return labOrder2.getLabItemLabel().orElse("")
-							.compareTo(labOrder1.getLabItemLabel().orElse(""));
+						return labOrder2.getLabItemLabel().orElse(StringTool.leer)
+							.compareTo(labOrder1.getLabItemLabel().orElse(StringTool.leer));
 					}
 				default:
 					return 0;

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborResultsComposite.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborResultsComposite.java
@@ -43,6 +43,7 @@ import ch.elexis.data.Patient;
 import ch.elexis.data.Person;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LaborResultsComposite extends Composite {
 	
 	private final FormToolkit tk = UiDesk.getToolkit();
@@ -156,7 +157,7 @@ public class LaborResultsComposite extends Composite {
 						.append(item.getUnit()).append("]"); //$NON-NLS-1$
 					return sb.toString();
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -173,7 +174,7 @@ public class LaborResultsComposite extends Composite {
 						return ((LaborItemResults) element).getFirstResult().getRefFemale();
 					}
 				}
-				return ""; //$NON-NLS-1$
+				return StringTool.leer; //$NON-NLS-1$
 			}
 		});
 		
@@ -190,7 +191,7 @@ public class LaborResultsComposite extends Composite {
 		for (int i = 0; i < COLUMNS_PER_PAGE; i++) {
 			column = new TreeViewerColumn(viewer, SWT.NONE);
 			column.getColumn().setWidth(75);
-			column.getColumn().setText(""); //$NON-NLS-1$
+			column.getColumn().setText(StringTool.leer); //$NON-NLS-1$
 			column.setLabelProvider(new LaborResultsLabelProvider(column));
 			column.getColumn().addSelectionListener(new ChangeResultsDateSelection(column, this));
 			resultColumns.add(column);
@@ -254,7 +255,7 @@ public class LaborResultsComposite extends Composite {
 		
 		for (int i = 0; i < resultColumns.size(); i++) {
 			resultColumns.get(i).getColumn().setData(COLUMN_DATE_KEY, null);
-			resultColumns.get(i).getColumn().setText(""); //$NON-NLS-1$
+			resultColumns.get(i).getColumn().setText(StringTool.leer); //$NON-NLS-1$
 		}
 		
 		List<TimeTool> dates = contentProvider.getDates();
@@ -286,7 +287,7 @@ public class LaborResultsComposite extends Composite {
 		setInitialColumnOffset();
 		for (int i = 0; i < resultColumns.size(); i++) {
 			resultColumns.get(i).getColumn().setData(COLUMN_DATE_KEY, null);
-			resultColumns.get(i).getColumn().setText(""); //$NON-NLS-1$
+			resultColumns.get(i).getColumn().setText(StringTool.leer); //$NON-NLS-1$
 		}
 		
 		List<TimeTool> dates = contentProvider.getDates();

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/MultiLineTextCellEditor.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/MultiLineTextCellEditor.java
@@ -11,6 +11,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
+import ch.rgw.tools.StringTool;
 public class MultiLineTextCellEditor extends DialogCellEditor {
 	
 	public class MultiLineTextDialog extends StatusDialog {
@@ -64,7 +65,7 @@ public class MultiLineTextCellEditor extends DialogCellEditor {
 		if (getValue() != null) {
 			result = dialog.open(getValue().toString());
 		} else {
-			result = dialog.open(""); //$NON-NLS-1$
+			result = dialog.open(StringTool.leer); //$NON-NLS-1$
 		}
 		
 		if (result == Dialog.OK) {

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LabOrderEditingSupport.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LabOrderEditingSupport.java
@@ -31,6 +31,7 @@ import ch.elexis.data.LabOrder;
 import ch.elexis.data.LabResult;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LabOrderEditingSupport extends EditingSupport {
 	protected final String SMALLER = "<";
 	protected final String BIGGER = ">";
@@ -59,7 +60,7 @@ public class LabOrderEditingSupport extends EditingSupport {
 							String editedValue = (String) value;
 							if (editedValue.startsWith(SMALLER) || editedValue.startsWith(BIGGER)) {
 								String nrValue =
-									editedValue.replace(SMALLER, "").replace(BIGGER, "");
+									editedValue.replace(SMALLER, StringTool.leer).replace(BIGGER, StringTool.leer);
 								editedValue = nrValue.trim();
 							}
 							Float.parseFloat(editedValue);
@@ -162,7 +163,7 @@ public class LabOrderEditingSupport extends EditingSupport {
 				}
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LabResultEditingSupport.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LabResultEditingSupport.java
@@ -38,6 +38,7 @@ import ch.elexis.data.Mandant;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LabResultEditingSupport extends EditingSupport {
 	
 	protected final String SMALLER = "<";
@@ -124,7 +125,7 @@ public class LabResultEditingSupport extends EditingSupport {
 							String editedValue = (String) value;
 							if (editedValue.startsWith(SMALLER) || editedValue.startsWith(BIGGER)) {
 								String nrValue =
-									editedValue.replace(SMALLER, "").replace(BIGGER, "");
+									editedValue.replace(SMALLER, StringTool.leer).replace(BIGGER, StringTool.leer);
 								editedValue = nrValue.trim();
 							}
 							Float.parseFloat(editedValue);
@@ -159,7 +160,7 @@ public class LabResultEditingSupport extends EditingSupport {
 	
 	@Override
 	protected Object getValue(Object element){
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	private TimeTool getDate() {

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LaborResultsLabelProvider.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/util/LaborResultsLabelProvider.java
@@ -19,6 +19,7 @@ import ch.elexis.data.LabResult;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LaborResultsLabelProvider extends ColumnLabelProvider {
 	
 	private TreeViewerColumn column;
@@ -49,7 +50,7 @@ public class LaborResultsLabelProvider extends ColumnLabelProvider {
 				}
 			}
 		}
-		return ""; //$NON-NLS-1$
+		return StringTool.leer; //$NON-NLS-1$
 	}
 	
 	private String getResultString(LabResult labResult){
@@ -123,7 +124,7 @@ public class LaborResultsLabelProvider extends ColumnLabelProvider {
 		StringBuilder sb = new StringBuilder();
 		String comment = labResult.getComment();
 		if (!comment.isEmpty()) {
-			sb.append("\n").append(comment);
+			sb.append(StringTool.lf).append(comment);
 		}
 		return sb.toString();
 	}
@@ -148,7 +149,7 @@ public class LaborResultsLabelProvider extends ColumnLabelProvider {
 							sb.append(" - "); //$NON-NLS-1$
 							sb.append(getResultString(labResult));
 							sb.append(getUnitAndReferenceString(labResult));
-							sb.append("\n").append(getPathologicString(labResult));
+							sb.append(StringTool.lf).append(getPathologicString(labResult));
 							sb.append(getCommentString(labResult));
 						} else {
 							sb.append(",\n"); //$NON-NLS-1$
@@ -156,7 +157,7 @@ public class LaborResultsLabelProvider extends ColumnLabelProvider {
 							sb.append(" - "); //$NON-NLS-1$
 							sb.append(getResultString(labResult));
 							sb.append(getUnitAndReferenceString(labResult));
-							sb.append("\n").append(getPathologicString(labResult));
+							sb.append(StringTool.lf).append(getPathologicString(labResult));
 							sb.append(getCommentString(labResult));
 						}
 					}

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/EditLabItem.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/EditLabItem.java
@@ -191,7 +191,7 @@ public class EditLabItem extends TitleAreaDialog {
 		WidgetFactory.createLabel(ret, Messages.EditLabItem_OriginLaboratoryLabel);
 		originLaboratory = new Label(ret, SWT.None);
 		originLaboratory.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
-		originLaboratory.setText((actLabor != null) ? actLabor.getLabel() : "");
+		originLaboratory.setText((actLabor != null) ? actLabor.getLabel() : StringTool.leer);
 		originLaboratorySelection = new Button(ret, SWT.PUSH);
 		originLaboratorySelection.setText("..."); //$NON-NLS-1$
 		originLaboratorySelection.addSelectionListener(new SelectionAdapter() {
@@ -205,7 +205,7 @@ public class EditLabItem extends TitleAreaDialog {
 					originLaboratory.setText(actLabor.getLabel());
 				} else {
 					actLabor = null;
-					originLaboratory.setText("");
+					originLaboratory.setText(StringTool.leer);
 				}
 			}
 		});

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/LabItemLabelProvider.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/LabItemLabelProvider.java
@@ -16,6 +16,7 @@ import ch.elexis.data.LabItem;
 import ch.elexis.data.LabResult;
 import ch.elexis.data.PersistentObject;
 
+import ch.rgw.tools.StringTool;
 public class LabItemLabelProvider extends ColumnLabelProvider implements ILabelProvider {
 	public enum ItemLabelFields {
 			REFERENCES, KUERZEL, NAME, GROUP, UNIT
@@ -70,7 +71,7 @@ public class LabItemLabelProvider extends ColumnLabelProvider implements ILabelP
 	}
 	
 	private String getItemLabelField(ItemLabelFields itemLabelField, LabItem element){
-		String ret = "";
+		String ret = StringTool.leer;
 		String[] values = ((LabItem) element).get(true, LabItem.SHORTNAME, LabItem.TITLE,
 			LabItem.GROUP, LabItem.UNIT);
 			

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/LaborVerordnungDialog.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/LaborVerordnungDialog.java
@@ -49,6 +49,7 @@ import ch.elexis.data.Query;
 import ch.elexis.data.Reminder;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LaborVerordnungDialog extends TitleAreaDialog {
 	private static final String LAST_SELECTED_USER = LaborLink.PROVIDER_ID + "/last_selected_user"; //$NON-NLS-1$
 	private static final String PREV_PRINT_SETTING = LaborLink.PROVIDER_ID + "/prev_print_setting"; //$NON-NLS-1$
@@ -76,7 +77,7 @@ public class LaborVerordnungDialog extends TitleAreaDialog {
 	}
 	
 	private void selectLastSelectedUser(){
-		String id = CoreHub.userCfg.get(LAST_SELECTED_USER, ""); //$NON-NLS-1$
+		String id = CoreHub.userCfg.get(LAST_SELECTED_USER, StringTool.leer); //$NON-NLS-1$
 		Anwender user = Anwender.load(id);
 		if (user != null && user.exists()) {
 			StructuredSelection newSelection = new StructuredSelection(user);
@@ -86,7 +87,7 @@ public class LaborVerordnungDialog extends TitleAreaDialog {
 	
 	private void saveLastSelectedUser(){
 		Anwender user = getSelectedUser();
-		String id = ""; //$NON-NLS-1$
+		String id = StringTool.leer; //$NON-NLS-1$
 		if (user != null) {
 			id = user.getId();
 		}
@@ -248,11 +249,11 @@ public class LaborVerordnungDialog extends TitleAreaDialog {
 		StringBuilder message = new StringBuilder("Labor"); //$NON-NLS-1$
 		StringBuilder params = new StringBuilder();
 		if (orders != null && !orders.isEmpty()) {
-			message.append(" ")
+			message.append(StringTool.space)
 				.append(
 					ch.elexis.core.ui.laboratory.controls.Messages.LaborOrdersComposite_columnOrdernumber)
 				.append(": ").append(orders.get(0).get(LabOrder.FLD_ORDERID)); //$NON-NLS-1$
-			params.append(LabOrder.FLD_ORDERID + "=" + orders.get(0).get(LabOrder.FLD_ORDERID));
+			params.append(LabOrder.FLD_ORDERID + StringTool.equals + orders.get(0).get(LabOrder.FLD_ORDERID));
 		}
 		Reminder reminder = new Reminder(patient, date.toString(TimeTool.DATE_ISO),
 			Visibility.ALWAYS, params.toString(), message.toString()); //$NON-NLS-1$
@@ -350,12 +351,12 @@ public class LaborVerordnungDialog extends TitleAreaDialog {
 	private static class NoAnwender extends Anwender {
 		@Override
 		public String getId(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override
 		public String getLabel(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/MergeLabItemDialog.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/dialogs/MergeLabItemDialog.java
@@ -34,6 +34,7 @@ import ch.elexis.data.LabItem;
 import ch.elexis.data.LabMapping;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class MergeLabItemDialog extends TitleAreaDialog {
 	
 	private TableViewer destinationItems;
@@ -78,7 +79,7 @@ public class MergeLabItemDialog extends TitleAreaDialog {
 					destinationFilter.setSearchText(destinationFilterTxt.getText());
 					destinationItems.refresh();
 				} else {
-					destinationFilter.setSearchText(""); //$NON-NLS-1$
+					destinationFilter.setSearchText(StringTool.leer); //$NON-NLS-1$
 					destinationItems.refresh();
 				}
 			}
@@ -106,7 +107,7 @@ public class MergeLabItemDialog extends TitleAreaDialog {
 					sourceFilter.setSearchText(sourceFilterTxt.getText());
 					sourceItems.refresh();
 				} else {
-					sourceFilter.setSearchText(""); //$NON-NLS-1$
+					sourceFilter.setSearchText(StringTool.leer); //$NON-NLS-1$
 					sourceItems.refresh();
 				}
 			}
@@ -166,7 +167,7 @@ public class MergeLabItemDialog extends TitleAreaDialog {
 	
 	private void deleteMappings(LabItem li){
 		Query<LabMapping> qbe = new Query<LabMapping>(LabMapping.class);
-		qbe.add(LabMapping.FLD_LABITEMID, "=", li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		qbe.add(LabMapping.FLD_LABITEMID, StringTool.equals, li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
 		List<LabMapping> list = qbe.execute();
 		for (LabMapping po : list) {
 			po.delete();

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/laborlink/LaborLink.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/laborlink/LaborLink.java
@@ -32,6 +32,7 @@ import ch.elexis.data.LabItem;
 import ch.elexis.data.Patient;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LaborLink implements IKonsExtension {
 	public static final String PROVIDER_ID = "laborlink";
 	
@@ -80,7 +81,7 @@ public class LaborLink implements IKonsExtension {
 					new LaborVerordnungDialog(UiDesk.getTopShell(), patient, date);
 				if (dialog.open() == LaborVerordnungDialog.OK) {
 					// insert XRef
-					textField.insertXRef(-1, "Labor", PROVIDER_ID, "");
+					textField.insertXRef(-1, "Labor", PROVIDER_ID, StringTool.leer);
 				}
 			}
 		};

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/LabGroupPrefs.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/LabGroupPrefs.java
@@ -51,6 +51,7 @@ import ch.elexis.data.LabGroup;
 import ch.elexis.data.LabItem;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class LabGroupPrefs extends PreferencePage implements IWorkbenchPreferencePage {
 	public static final String SHOW_GROUPS_ONLY = "lab/showGroupsOnly"; //$NON-NLS-1$
 	
@@ -135,7 +136,7 @@ public class LabGroupPrefs extends PreferencePage implements IWorkbenchPreferenc
 					new InputDialog(
 						PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
 						Messages.LabGroupPrefs_newLabGroup,
-						Messages.LabGroupPrefs_selectNameForLabGroup, "", null); //$NON-NLS-1$
+						Messages.LabGroupPrefs_selectNameForLabGroup, StringTool.leer, null); //$NON-NLS-1$
 				int rc = dialog.open();
 				if (rc == Window.OK) {
 					String name = dialog.getValue();
@@ -361,7 +362,7 @@ public class LabGroupPrefs extends PreferencePage implements IWorkbenchPreferenc
 				sb.append(item.getGroup());
 				sb.append(" - "); //$NON-NLS-1$
 				sb.append(item.get("titel")); //$NON-NLS-1$
-				sb.append(" (").append(item.getRefM()).append("/").append(item.getRefW()) //$NON-NLS-1$ //$NON-NLS-2$
+				sb.append(" (").append(item.getRefM()).append(StringTool.slash).append(item.getRefW()) //$NON-NLS-1$ //$NON-NLS-2$
 					.append(")"); //$NON-NLS-1$
 				sb.append(" [").append(item.getEinheit()).append("]"); //$NON-NLS-1$ //$NON-NLS-2$
 				

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/LaborPrefs.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/LaborPrefs.java
@@ -70,6 +70,7 @@ import ch.elexis.data.LabMapping;
 import ch.elexis.data.LabResult;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class LaborPrefs extends PreferencePage implements IWorkbenchPreferencePage {
 	
 	// DynamicListDisplay params;
@@ -107,7 +108,7 @@ public class LaborPrefs extends PreferencePage implements IWorkbenchPreferencePa
 				viewerFilter.setSearchText(filterTxt.getText());
 				tableViewer.refresh();
 			} else {
-				viewerFilter.setSearchText(""); //$NON-NLS-1$
+				viewerFilter.setSearchText(StringTool.leer); //$NON-NLS-1$
 				tableViewer.refresh();
 			}
 		});
@@ -170,7 +171,7 @@ public class LaborPrefs extends PreferencePage implements IWorkbenchPreferencePa
 			public int compare(Viewer viewer, Object e1, Object e2){
 				LabItem li1 = (LabItem) e1;
 				LabItem li2 = (LabItem) e2;
-				String s1 = "", s2 = ""; //$NON-NLS-1$ //$NON-NLS-2$
+				String s1 = StringTool.leer, s2 = StringTool.leer; //$NON-NLS-1$ //$NON-NLS-2$
 				switch (sortC) {
 				case 1:
 					s1 = li1.getKuerzel();
@@ -429,7 +430,7 @@ public class LaborPrefs extends PreferencePage implements IWorkbenchPreferencePa
 	private boolean deleteResults(LabItem li){
 		boolean ret = true;
 		Query<LabResult> qbe = new Query<LabResult>(LabResult.class);
-		qbe.add(LabResult.ITEM_ID, "=", li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		qbe.add(LabResult.ITEM_ID, StringTool.equals, li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
 		List<LabResult> list = qbe.execute();
 		for (LabResult po : list) {
 			if (LocalLockServiceHolder.get().acquireLock(po).isOk()) {
@@ -444,7 +445,7 @@ public class LaborPrefs extends PreferencePage implements IWorkbenchPreferencePa
 	
 	private void deleteMappings(LabItem li){
 		Query<LabMapping> qbe = new Query<LabMapping>(LabMapping.class);
-		qbe.add(LabMapping.FLD_LABITEMID, "=", li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
+		qbe.add(LabMapping.FLD_LABITEMID, StringTool.equals, li.getId()); //$NON-NLS-1$ //$NON-NLS-2$
 		List<LabMapping> list = qbe.execute();
 		for (LabMapping po : list) {
 			po.delete();

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/views/LabNotSeenView.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/views/LabNotSeenView.java
@@ -58,6 +58,7 @@ import ch.rgw.tools.Log;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class LabNotSeenView extends ViewPart implements HeartListener {
 	public final static String ID = "ch.elexis.LabNotSeenView"; //$NON-NLS-1$
 	CheckboxTableViewer tv;
@@ -160,7 +161,7 @@ public class LabNotSeenView extends ViewPart implements HeartListener {
 		
 		public String getColumnText(final Object element, final int columnIndex){
 			if (element instanceof String) {
-				return columnIndex == 0 ? (String) element : ""; //$NON-NLS-1$
+				return columnIndex == 0 ? (String) element : StringTool.leer; //$NON-NLS-1$
 			}
 			LabResult lr = (LabResult) element;
 			switch (columnIndex) {

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/views/LabOrderView.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/views/LabOrderView.java
@@ -24,6 +24,7 @@ import ch.elexis.data.LabOrder;
 import ch.elexis.data.LabOrder.State;
 import ch.elexis.data.Patient;
 
+import ch.rgw.tools.StringTool;
 public class LabOrderView extends ViewPart implements ICallback {
 	public static final String ID = "ch.elexis.core.ui.laboratory.LabOrderView"; //$NON-NLS-1$
 	private static final String LABORDER_PLACEHOLDER = "[Verordnung]";
@@ -90,13 +91,13 @@ public class LabOrderView extends ViewPart implements ICallback {
 		for (String groupKey : keySet) {
 			List<LabOrder> gLabOrders = groupMap.get(groupKey);
 			// add group name
-			usedRows.add(createRow(groupKey, "", ""));
+			usedRows.add(createRow(groupKey, StringTool.leer, StringTool.leer));
 			
 			for (LabOrder labOrder : gLabOrders) {
 				// only interested in those with status ORDERED
 				if (labOrder.getState() == State.ORDERED) {
 					LabItem labItem = labOrder.getLabItem();
-					String ref = "";
+					String ref = StringTool.leer;
 					if (Patient.FEMALE.equals(patientGender)) {
 						ref = labItem.getRefW();
 					} else {
@@ -110,7 +111,7 @@ public class LabOrderView extends ViewPart implements ICallback {
 	}
 	
 	/**
-	 * Create a row with 4 places inserting the passed values. Not given fields are field with ""
+	 * Create a row with 4 places inserting the passed values. Not given fields are field with StringTool.leer
 	 * 
 	 * @param value
 	 *            name [idx 0]
@@ -118,17 +119,17 @@ public class LabOrderView extends ViewPart implements ICallback {
 	 *            reference (male or female) if given [idx 1]
 	 * @param unit
 	 *            will only be displayed if reference is present [idx 1]
-	 * @return Example: {@code new String[] "Kalium", "3.5-5.5 mmol/L", "", ""}
+	 * @return Example: {@code new String[] "Kalium", "3.5-5.5 mmol/L", StringTool.leer, StringTool.leer}
 	 */
 	private String[] createRow(String value, String ref, String unit){
 		// init array filled with empty strings
 		String[] row = new String[4];
-		Arrays.fill(row, "");
+		Arrays.fill(row, StringTool.leer);
 		
 		row[0] = value;
 		// add ref with unit if given
 		if (!ref.isEmpty()) {
-			row[1] = ref + " " + unit;
+			row[1] = ref + StringTool.space + unit;
 		}
 		return row;
 	}

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/billing/PrescriptionBilledAdjuster.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/billing/PrescriptionBilledAdjuster.java
@@ -27,6 +27,7 @@ import ch.elexis.core.services.holder.ContextServiceHolder;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
 import ch.elexis.core.services.holder.StoreToStringServiceHolder;
 
+import ch.rgw.tools.StringTool;
 @Component
 public class PrescriptionBilledAdjuster implements IBilledAdjuster {
 	
@@ -99,7 +100,7 @@ public class PrescriptionBilledAdjuster implements IBilledAdjuster {
 		IBilled billed){
 		IPrescription prescription =
 			new IPrescriptionBuilder(CoreModelServiceHolder.get(), ContextServiceHolder.get(),
-				article, patient, "").build();
+				article, patient, StringTool.leer).build();
 		prescription.setExtInfo(ch.elexis.core.model.prescription.Constants.FLD_EXT_VERRECHNET_ID,
 			billed.getId());
 		billed.setExtInfo(ch.elexis.core.model.verrechnet.Constants.FLD_EXT_PRESC_ID,

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/handlers/MentionInConsultationHandler.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/handlers/MentionInConsultationHandler.java
@@ -21,6 +21,7 @@ import ch.elexis.core.text.model.Samdas;
 import ch.elexis.core.text.model.Samdas.Record;
 import ch.elexis.core.ui.medication.views.MedicationTableViewerItem;
 
+import ch.rgw.tools.StringTool;
 public class MentionInConsultationHandler extends AbstractHandler {
 	@SuppressWarnings("unchecked")
 	@Override
@@ -44,13 +45,13 @@ public class MentionInConsultationHandler extends AbstractHandler {
 				encounter.ifPresent(enc -> {
 					StringBuilder sb = new StringBuilder();
 					for (IPrescription presc : prescriptions) {
-						String articleLabel = "";
+						String articleLabel = StringTool.leer;
 						if (presc.getArticle() != null) {
 							articleLabel = presc.getArticle().getLabel();
 						}
-						sb.append("\n");
+						sb.append(StringTool.lf);
 						sb.append("Medikation: " + articleLabel + ", "
-							+ presc.getDosageInstruction() + " " + getType(presc.getEntryType()));
+							+ presc.getDosageInstruction() + StringTool.space + getType(presc.getEntryType()));
 					}
 					
 					Samdas samdas = new Samdas(enc.getVersionedEntry().getHead());
@@ -78,7 +79,7 @@ public class MentionInConsultationHandler extends AbstractHandler {
 		case RECIPE:
 			return "(Rezeptiert)";
 		default:
-			return "";
+			return StringTool.leer;
 		}
 	}
 }

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/handlers/SwitchMedicationHandler.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/handlers/SwitchMedicationHandler.java
@@ -75,7 +75,7 @@ public class SwitchMedicationHandler extends AbstractHandler {
 		for (int i = 0; i < nameParts.length; i++) {
 			String s = nameParts[i];
 			if (i > 0) {
-				sbFilterName.append(" ");
+				sbFilterName.append(StringTool.space);
 			}
 			
 			// matches upper cases, dash an probably number but not only numbers

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationComposite.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationComposite.java
@@ -79,6 +79,7 @@ import ch.elexis.core.ui.util.CreatePrescriptionHelper;
 import ch.elexis.core.ui.util.GenericObjectDropTarget;
 import ch.elexis.core.ui.views.controls.InteractionLink;
 
+import ch.rgw.tools.StringTool;
 public class MedicationComposite extends Composite
 		implements ISelectionProvider, ISelectionChangedListener {
 	
@@ -185,8 +186,8 @@ public class MedicationComposite extends Composite
 	}
 	
 	private void clearSearchFilter(){
-		txtSearch.setText("");
-		medicationHistoryFilter.setSearchText("");
+		txtSearch.setText(StringTool.leer);
+		medicationHistoryFilter.setSearchText(StringTool.leer);
 	}
 	
 	private void medicationTableComposite(IWorkbenchPartSite partSite){
@@ -738,7 +739,7 @@ public class MedicationComposite extends Composite
 	}
 	
 	private void showSearchFilterComposite(boolean show){
-		medicationHistoryFilter.setSearchText("");
+		medicationHistoryFilter.setSearchText(StringTool.leer);
 		compositeSearchFilterLayoutData.exclude = !show;
 		compositeSearchFilter.setVisible(show);
 		this.layout(true);
@@ -772,7 +773,7 @@ public class MedicationComposite extends Composite
 		
 		contentProviderComp.refresh();
 		selectedMedication.setValue(null);
-		lblLastDisposalLink.setText("");
+		lblLastDisposalLink.setText(StringTool.leer);
 		showMedicationDetailComposite(null);
 		
 		if (medicationInput != null) {
@@ -781,7 +782,7 @@ public class MedicationComposite extends Composite
 			interactionLink.updateAtcs(MedicationViewHelper.getAllGtins(medicationInput));
 		
 		} else {
-			lblDailyTherapyCost.setText("");
+			lblDailyTherapyCost.setText(StringTool.leer);
 			interactionLink.updateAtcs(Collections.emptyList());
 		}
 	}
@@ -803,17 +804,17 @@ public class MedicationComposite extends Composite
 			&& signatureArray[2].isEmpty() && signatureArray[3].isEmpty();
 		if (isFreetext) {
 			txtFreeText.setText(signatureArray[0]);
-			txtMorning.setText("");
-			txtNoon.setText("");
-			txtEvening.setText("");
-			txtNight.setText("");
+			txtMorning.setText(StringTool.leer);
+			txtNoon.setText(StringTool.leer);
+			txtEvening.setText(StringTool.leer);
+			txtNight.setText(StringTool.leer);
 			
 			if (stackLayoutDosage.topControl == compositeDayTimeDosage) {
 				stackLayoutDosage.topControl = compositeFreeTextDosage;
 				stackCompositeDosage.layout();
 			}
 		} else {
-			txtFreeText.setText("");
+			txtFreeText.setText(StringTool.leer);
 			txtMorning.setText(signatureArray[0]);
 			txtNoon.setText(signatureArray[1]);
 			txtEvening.setText(signatureArray[2]);
@@ -907,7 +908,7 @@ public class MedicationComposite extends Composite
 	public void setLastDisposal(Identifiable identifiable){
 		lastDisposal.setValue(identifiable);
 		if (identifiable != null) {
-			String label = "";
+			String label = StringTool.leer;
 			if (identifiable instanceof IRecipe) {
 				IRecipe rp = (IRecipe) identifiable;
 				label = MessageFormat.format(Messages.MedicationComposite_recipeFrom,
@@ -923,7 +924,7 @@ public class MedicationComposite extends Composite
 			}
 			lblLastDisposalLink.setText(label);
 		} else {
-			lblLastDisposalLink.setText("");
+			lblLastDisposalLink.setText(StringTool.leer);
 		}
 	}
 	

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationTableViewerItem.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationTableViewerItem.java
@@ -27,6 +27,7 @@ import ch.elexis.core.ui.icons.Images;
  * Maps an element of type {@link IPrescription} for presentation within the MedicationTableViewer.
  * Used for performance reasons.
  */
+import ch.rgw.tools.StringTool;
 public class MedicationTableViewerItem {
 	
 	private static DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy");
@@ -90,11 +91,11 @@ public class MedicationTableViewerItem {
 	}
 	
 	public String getBeginDate(){
-		return dateFrom != null ? dateFormatter.format(dateFrom) : "";
+		return dateFrom != null ? dateFormatter.format(dateFrom) : StringTool.leer;
 	}
 	
 	public String getEndDate(){
-		return dateUntil != null ? dateFormatter.format(dateUntil) : "";
+		return dateUntil != null ? dateFormatter.format(dateUntil) : StringTool.leer;
 	}
 	
 	public Date getEndTime(){
@@ -106,7 +107,7 @@ public class MedicationTableViewerItem {
 	}
 	
 	public String getDosis(){
-		return dosis != null ? dosis : "";
+		return dosis != null ? dosis : StringTool.leer;
 	}
 	
 	public IPrescription getPrescription(){
@@ -302,12 +303,12 @@ public class MedicationTableViewerItem {
 			if (reason != null) {
 				item.stopReason = reason;
 			} else {
-				item.stopReason = "";
+				item.stopReason = StringTool.leer;
 			}
 		}
 		
 		private void resolvePrescriptorLabel(){
-			item.prescriptorLabel = "";
+			item.prescriptorLabel = StringTool.leer;
 			if (item.prescriptor != null) {
 				item.prescriptorLabel = item.prescriptor.getLabel();
 			}
@@ -318,7 +319,7 @@ public class MedicationTableViewerItem {
 			if (comment != null) {
 				item.disposalComment = comment;
 			} else {
-				item.disposalComment = "";
+				item.disposalComment = StringTool.leer;
 			}
 		}
 	}

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationViewHelper.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationViewHelper.java
@@ -24,6 +24,7 @@ import ch.elexis.core.services.holder.MedicationServiceHolder;
 import ch.elexis.core.ui.medication.handlers.ApplyCustomSortingHandler;
 import ch.rgw.tools.Money;
 
+import ch.rgw.tools.StringTool;
 public class MedicationViewHelper {
 	private static final int FILTER_PRESCRIPTION_AFTER_N_DAYS = 30;
 	
@@ -72,7 +73,7 @@ public class MedicationViewHelper {
 		
 		double rounded = Math.round(100.0 * cost) / 100.0;
 		if (canCalculate) {
-			return TTCOST +" "+Double.toString(rounded);
+			return TTCOST +StringTool.space+Double.toString(rounded);
 		} else {
 			if (rounded == 0.0) {
 				return TTCOST + " ?";

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationViewerHelper.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/MedicationViewerHelper.java
@@ -24,13 +24,14 @@ import ch.elexis.core.model.prescription.EntryType;
 import ch.elexis.core.ui.icons.ImageSize;
 import ch.elexis.core.ui.icons.Images;
 
+import ch.rgw.tools.StringTool;
 public class MedicationViewerHelper {
 	
 	public static TableViewerColumn createTypeColumn(TableViewer viewer, TableColumnLayout layout,
 		int columnIndex){
 		TableViewerColumn ret = new TableViewerColumn(viewer, SWT.NONE);
 		TableColumn tblclmnStateDisposition = ret.getColumn();
-		tblclmnStateDisposition.setToolTipText(Messages.MedicationComposite_column_sortBy + " " 
+		tblclmnStateDisposition.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space 
 			+ Messages.MedicationComposite_column_type);
 		layout.setColumnData(tblclmnStateDisposition, new ColumnPixelData(20, false, false));
 		tblclmnStateDisposition.addSelectionListener(
@@ -38,7 +39,7 @@ public class MedicationViewerHelper {
 		ret.setLabelProvider(new MedicationCellLabelProvider() {
 			@Override
 			public String getText(Object element){
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override
@@ -55,7 +56,7 @@ public class MedicationViewerHelper {
 		final TableColumn tblclmnArticle = ret.getColumn();
 		layout.setColumnData(tblclmnArticle, new ColumnPixelData(250, true, true));
 		tblclmnArticle.setText(Messages.TherapieplanComposite_tblclmnArticle_text);
-		tblclmnArticle.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnArticle.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.TherapieplanComposite_tblclmnArticle_text);
 		tblclmnArticle
 			.addSelectionListener(getSelectionAdapter(viewer, tblclmnArticle, columnIndex));
@@ -70,7 +71,7 @@ public class MedicationViewerHelper {
 			@Override
 			public String getToolTipText(Object element){
 				MedicationTableViewerItem pres = (MedicationTableViewerItem) element;
-				String label = "";
+				String label = StringTool.leer;
 				
 				if (pres.isActiveMedication()) {
 					String date = pres.getBeginDate();
@@ -81,7 +82,7 @@ public class MedicationViewerHelper {
 					String endDate = pres.getEndDate();
 					if (endDate != null && !endDate.isEmpty()) {
 						String reason = pres.getStopReason() == null ? "?" : pres.getStopReason();
-						label += ("\n" + MessageFormat.format(
+						label += (StringTool.lf + MessageFormat.format(
 							Messages.MedicationComposite_stopDateAndReason, endDate, reason));
 					}
 				} else {
@@ -142,7 +143,7 @@ public class MedicationViewerHelper {
 		layout.setColumnData(tblclmnEnacted, new ColumnPixelData(60, true, true));
 		tblclmnEnacted.setImage(Images.resize(Images.IMG_NEXT_WO_SHADOW.getImage(),
 			ImageSize._12x12_TableColumnIconSize));
-		tblclmnEnacted.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnEnacted.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.MedicationComposite_column_beginDate);
 		tblclmnEnacted
 			.addSelectionListener(getSelectionAdapter(viewer, tblclmnEnacted, columnIndex));
@@ -164,11 +165,11 @@ public class MedicationViewerHelper {
 		layout.setColumnData(tblclmnComment,
 			new ColumnWeightData(1, ColumnWeightData.MINIMUM_WIDTH, true));
 		tblclmnComment.setText(Messages.TherapieplanComposite_tblclmnComment_text);
-		tblclmnComment.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnComment.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.TherapieplanComposite_tblclmnComment_text);
 		tblclmnComment
 			.addSelectionListener(getSelectionAdapter(viewer, tblclmnComment, columnIndex));
-		tblclmnComment.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnComment.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.TherapieplanComposite_tblclmnComment_text);
 		ret.setLabelProvider(new MedicationCellLabelProvider() {
 			
@@ -189,7 +190,7 @@ public class MedicationViewerHelper {
 		layout.setColumnData(tblclmnStop, stopColumnPixelData);
 		tblclmnStop.setImage(Images.resize(Images.IMG_ARROWSTOP_WO_SHADOW.getImage(),
 			ImageSize._12x12_TableColumnIconSize));
-		tblclmnStop.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnStop.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.MedicationComposite_column_endDate);
 		tblclmnStop.addSelectionListener(getSelectionAdapter(viewer, tblclmnStop, columnIndex));
 		ret.setLabelProvider(new MedicationCellLabelProvider() {
@@ -200,7 +201,7 @@ public class MedicationViewerHelper {
 					&& pres.getEntryType() != EntryType.SELF_DISPENSED) {
 					return pres.getEndDate();
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		return ret;
@@ -215,7 +216,7 @@ public class MedicationViewerHelper {
 			new ColumnWeightData(1, ColumnWeightData.MINIMUM_WIDTH, true);
 		layout.setColumnData(tblclmnReason, reasonColumnWeightData);
 		tblclmnReason.setText(Messages.MedicationComposite_stopReason);
-		tblclmnReason.setToolTipText(Messages.MedicationComposite_column_sortBy + " "
+		tblclmnReason.setToolTipText(Messages.MedicationComposite_column_sortBy + StringTool.space
 			+ Messages.MedicationComposite_stopReason);
 		tblclmnReason.addSelectionListener(getSelectionAdapter(viewer, tblclmnReason, columnIndex));
 		ret.setLabelProvider(new MedicationCellLabelProvider() {
@@ -229,7 +230,7 @@ public class MedicationViewerHelper {
 						return stopReason;
 					}
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		return ret;
@@ -269,7 +270,7 @@ public class MedicationViewerHelper {
 	//				// SLLOW
 	//				MedicationTableViewerItem pres = (MedicationTableViewerItem) element;
 	//				if (!pres.isFixedMediation() || pres.isReserveMedication())
-	//					return "";
+	//					return StringTool.leer;
 	//					
 	//				TimeTool tt = pres.getSuppliedUntilDate();
 	//				if (tt != null && tt.isAfterOrEqual(new TimeTool())) {

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/ViewerSortOrder.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/ViewerSortOrder.java
@@ -8,6 +8,7 @@ import ch.elexis.core.model.IPrescription;
 import ch.elexis.core.model.prescription.EntryType;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public enum ViewerSortOrder {
 		MANUAL("manuell", 0, new ManualViewerComparator()),
 		DEFAULT("standard", 1, new DefaultViewerComparator());
@@ -84,10 +85,10 @@ public enum ViewerSortOrder {
 				String l1 = p1.getArtikelLabel();
 				String l2 = p2.getArtikelLabel();
 				if (l1 == null) {
-					l1 = "";
+					l1 = StringTool.leer;
 				}
 				if (l2 == null) {
-					l2 = "";
+					l2 = StringTool.leer;
 				}
 				rc = l1.compareTo(l2);
 				break;
@@ -126,11 +127,11 @@ public enum ViewerSortOrder {
 			case 6:
 				String stopReason1 = p1.getStopReason();
 				if (stopReason1 == null)
-					stopReason1 = "";
+					stopReason1 = StringTool.leer;
 				
 				String stopReason2 = p2.getStopReason();
 				if (stopReason2 == null)
-					stopReason2 = "";
+					stopReason2 = StringTool.leer;
 				
 				rc = stopReason1.compareTo(stopReason2);
 				break;

--- a/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/provider/MedicationFilter.java
+++ b/bundles/ch.elexis.core.ui.medication/src/ch/elexis/core/ui/medication/views/provider/MedicationFilter.java
@@ -6,8 +6,9 @@ import org.eclipse.jface.viewers.ViewerFilter;
 import ch.elexis.core.jdt.NonNull;
 import ch.elexis.core.ui.medication.views.MedicationTableViewerItem;
 
+import ch.rgw.tools.StringTool;
 public class MedicationFilter extends ViewerFilter {
-	private String searchString = "";
+	private String searchString = StringTool.leer;
 	private Viewer viewer;
 	
 	public MedicationFilter(Viewer viewer){
@@ -18,7 +19,7 @@ public class MedicationFilter extends ViewerFilter {
 		if (s.equalsIgnoreCase(searchString))
 			return;
 			
-		s = s.replace("*", "");
+		s = s.replace("*", StringTool.leer);
 		searchString = ".*" + s.toLowerCase() + ".*";
 		
 		viewer.getControl().setRedraw(false);
@@ -48,7 +49,7 @@ public class MedicationFilter extends ViewerFilter {
 	}
 	
 	public void clearSearchText(){
-		this.searchString = "";
+		this.searchString = StringTool.leer;
 	}
 	
 }

--- a/bundles/ch.elexis.core.ui.stock/src/ch/elexis/core/ui/stock/dialogs/ImportArticleDialog.java
+++ b/bundles/ch.elexis.core.ui.stock/src/ch/elexis/core/ui/stock/dialogs/ImportArticleDialog.java
@@ -117,7 +117,7 @@ public class ImportArticleDialog extends TitleAreaDialog {
 		
 		tFilePath = new Text(ret, SWT.BORDER);
 		tFilePath.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		tFilePath.setText("");
+		tFilePath.setText(StringTool.leer);
 		Button btnBrowse = new Button(ret, SWT.NONE);
 		btnBrowse.addSelectionListener(new SelectionAdapter() {
 			@Override
@@ -133,7 +133,7 @@ public class ImportArticleDialog extends TitleAreaDialog {
 		btnBrowse.setText("auswählen..");
 		
 		reportLink = new Link(ret, SWT.NONE);
-		reportLink.setText("");
+		reportLink.setText(StringTool.leer);
 		reportLink.setVisible(false);
 		reportLink.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, true, 3, 1));
 		// Event handling when users click on links.
@@ -330,15 +330,15 @@ public class ImportArticleDialog extends TitleAreaDialog {
 					
 					buf.append(lastRow);
 					buf.append(" Artikel gelesen.");
-					buf.append("\n");
-					buf.append("\n");
+					buf.append(StringTool.lf);
+					buf.append(StringTool.lf);
 					buf.append(importCount);
 					buf.append(" Artikel erfolgreich nach Lager '");
 					buf.append(stock.getLabel());
 					buf.append("' importiert.");
-					buf.append("\n");
+					buf.append(StringTool.lf);
 					if (articleNotFoundInStock > 0) {
-						buf.append("\n");
+						buf.append(StringTool.lf);
 						buf.append(articleNotFoundInStock);
 						buf.append(" Artikel nicht im Lager '");
 						buf.append(stock.getLabel());
@@ -346,12 +346,12 @@ public class ImportArticleDialog extends TitleAreaDialog {
 					}
 					
 					if (articleNotFoundByGtin > 0) {
-						buf.append("\n");
+						buf.append(StringTool.lf);
 						buf.append(articleNotFoundByGtin);
 						buf.append(" Artikel nicht in der Datenbank gefunden.");
 					}
 					if (unexpectedErrors > 0) {
-						buf.append("\n");
+						buf.append(StringTool.lf);
 						buf.append(unexpectedErrors);
 						buf.append(" Artikel konnten nicht verarbeitet werden.");
 					}
@@ -371,7 +371,7 @@ public class ImportArticleDialog extends TitleAreaDialog {
 			reportBuilder.append(col2);
 			reportBuilder.append(";");
 			reportBuilder.append(col3);
-			reportBuilder.append("\n");
+			reportBuilder.append(StringTool.lf);
 		}
 	}
 	

--- a/bundles/ch.elexis.core.ui.usage/src/ch/elexis/core/ui/usage/StartupHandler.java
+++ b/bundles/ch.elexis.core.ui.usage/src/ch/elexis/core/ui/usage/StartupHandler.java
@@ -24,7 +24,8 @@ import ch.elexis.core.ui.usage.settings.UsageSettings;
 import ch.elexis.core.ui.usage.util.StatisticsManager;
 import ch.elexis.core.ui.util.PerspectiveUtil;
 
-@Component(property = EventConstants.EVENT_TOPIC + "=" + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+import ch.rgw.tools.StringTool;
+@Component(property = EventConstants.EVENT_TOPIC + StringTool.equals + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
 public class StartupHandler implements EventHandler {
 	
 	@Override

--- a/bundles/ch.elexis.core.ui.usage/src/ch/elexis/core/ui/usage/util/StatisticsManager.java
+++ b/bundles/ch.elexis.core.ui.usage/src/ch/elexis/core/ui/usage/util/StatisticsManager.java
@@ -29,6 +29,7 @@ import ch.elexis.core.ui.usage.model.ModelFactory;
 import ch.elexis.core.ui.usage.model.Statistics;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public enum StatisticsManager {
 	
 		INSTANCE;
@@ -185,7 +186,7 @@ public enum StatisticsManager {
 			os.close();
 			return aString;
 		} catch (IOException e) {
-			LoggerFactory.getLogger(StatisticsManager.class).error("", e);
+			LoggerFactory.getLogger(StatisticsManager.class).error(StringTool.leer, e);
 		}
 		return null;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/Hub.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/Hub.java
@@ -49,6 +49,7 @@ import ch.rgw.tools.TimeTool;
  * 
  * @since 3.0.0 major rewrites
  */
+import ch.rgw.tools.StringTool;
 public class Hub extends AbstractUIPlugin {
 	// Globale Konstanten
 	public static final String APPLICATION_NAME = "Elexis"; //$NON-NLS-1$
@@ -150,7 +151,7 @@ public class Hub extends AbstractUIPlugin {
 		if (CoreHub.actUser == null) {
 			sb.append(Messages.Hub_nouserloggedin);
 		} else {
-			sb.append(" ").append(CoreHub.actUser.getLabel()); //$NON-NLS-1$
+			sb.append(StringTool.space).append(CoreHub.actUser.getLabel()); //$NON-NLS-1$
 		}
 		if (CoreHub.actMandant == null) {
 			sb.append(Messages.Hub_nomandantor);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/CommentAction.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/CommentAction.java
@@ -9,12 +9,13 @@ import org.eclipse.swt.widgets.Shell;
 import ch.elexis.core.ui.dialogs.base.InputDialog;
 import ch.elexis.core.ui.icons.Images;
 
+import ch.rgw.tools.StringTool;
 public class CommentAction extends Action {
 	private String comment;
 	private final Shell shell;
 	
 	public CommentAction(Shell shell, String comment){
-		super("", Action.AS_PUSH_BUTTON);
+		super(StringTool.leer, Action.AS_PUSH_BUTTON);
 		Assert.isNotNull(shell);
 		this.shell = shell;
 		this.comment = comment;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/GlobalActions.java
@@ -862,7 +862,7 @@ public class GlobalActions {
 				prn.startPage();
 				FontMetrics fmt = gc.getFontMetrics();
 				String pers = k.getPostAnschrift(true);
-				String[] lines = pers.split("\n"); //$NON-NLS-1$
+				String[] lines = pers.split(StringTool.lf); //$NON-NLS-1$
 				for (String line : lines) {
 					gc.drawString(line, 0, y);
 					y += fmt.getHeight();
@@ -890,7 +890,7 @@ public class GlobalActions {
 	 * @return a PrinterData object describing the selected printer
 	 */
 	private PrinterData getPrinterData(final String type){
-		String cfgPrefix = "Drucker/" + type + "/"; //$NON-NLS-1$ //$NON-NLS-2$ $NON-NLS-2$
+		String cfgPrefix = "Drucker/" + type + StringTool.slash; //$NON-NLS-1$ //$NON-NLS-2$ $NON-NLS-2$
 		
 		PrinterData pd = null;
 		String printer = CoreHub.localCfg.get(cfgPrefix + "Name", null); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/HistoryLoader.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/HistoryLoader.java
@@ -37,6 +37,7 @@ import ch.rgw.tools.VersionedResource;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class HistoryLoader extends BackgroundJob {
 	StringBuilder sb;
 	private List<IEncounter> lKons;
@@ -153,13 +154,13 @@ public class HistoryLoader extends BackgroundJob {
 					if (multiline) {
 						// TODO use system line separator
 						// replace Windows line separator
-						s = s.replaceAll("\r\n", "<br/>"); //$NON-NLS-1$ //$NON-NLS-2$
+						s = s.replaceAll(StringTool.crlf, "<br/>"); //$NON-NLS-1$ //$NON-NLS-2$
 						// replace remaining "manual" line separators
-						s = s.replaceAll("\n", "<br/>"); //$NON-NLS-1$ //$NON-NLS-2$
+						s = s.replaceAll(StringTool.lf, "<br/>"); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 					
 				} else {
-					s = ""; //$NON-NLS-1$
+					s = StringTool.leer; //$NON-NLS-1$
 				}
 				String label = maskHTML(k.getLabel());
 				// make kons text grey if kons Fall is not the selected Fall

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/LazyTreeLoader.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/LazyTreeLoader.java
@@ -34,6 +34,7 @@ import ch.rgw.tools.Tree;
  * 
  * @param <T>
  */
+import ch.rgw.tools.StringTool;
 @Deprecated
 public class LazyTreeLoader<T> extends AbstractDataLoaderJob implements LazyTreeListener {
 	String parentColumn;
@@ -68,7 +69,7 @@ public class LazyTreeLoader<T> extends AbstractDataLoaderJob implements LazyTree
 		}
 		result = new LazyTree<T>(null, null, filter, this);
 		qbe.clear();
-		qbe.add(parentColumn, "=", "NIL"); //$NON-NLS-1$ //$NON-NLS-2$
+		qbe.add(parentColumn, StringTool.equals, "NIL"); //$NON-NLS-1$ //$NON-NLS-2$
 		List<T> list = load();
 		for (T t : list) {
 			((LazyTree) result).add(t, this);
@@ -92,7 +93,7 @@ public class LazyTreeLoader<T> extends AbstractDataLoaderJob implements LazyTree
 		qbe.clear();
 		PersistentObject obj = (PersistentObject) l.contents;
 		if (obj != null) {
-			qbe.add(parentColumn, "=", parentField == null ? obj.getId() : obj.get(parentField)); //$NON-NLS-1$
+			qbe.add(parentColumn, StringTool.equals, parentField == null ? obj.getId() : obj.get(parentField)); //$NON-NLS-1$
 			List ret = load();
 			for (PersistentObject o : (List<PersistentObject>) ret) {
 				l.add(o, this);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/ScannerEvents.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/ScannerEvents.java
@@ -23,6 +23,7 @@ import ch.elexis.core.constants.Preferences;
 import ch.elexis.core.data.activator.CoreHub;
 import ch.elexis.core.ui.util.IScannerListener;
 
+import ch.rgw.tools.StringTool;
 public class ScannerEvents implements Listener {
 	private static int BUF_LIMIT = 500;
 	private static int BUF_MINIMUM = 30;
@@ -72,9 +73,9 @@ public class ScannerEvents implements Listener {
 	 */
 	private String getBarcode(StringBuffer strBuf){
 		String barcode = strBuf.toString();
-		barcode = barcode.replaceAll(new Character(SWT.CR).toString(), ""); //$NON-NLS-1$
-		barcode = barcode.replaceAll(new Character(SWT.LF).toString(), ""); //$NON-NLS-1$
-		barcode = barcode.replaceAll(new Character((char) 0).toString(), ""); //$NON-NLS-1$
+		barcode = barcode.replaceAll(new Character(SWT.CR).toString(), StringTool.leer); //$NON-NLS-1$
+		barcode = barcode.replaceAll(new Character(SWT.LF).toString(), StringTool.leer); //$NON-NLS-1$
+		barcode = barcode.replaceAll(new Character((char) 0).toString(), StringTool.leer); //$NON-NLS-1$
 		if (barcode.length() > barcodeLength) {
 			return barcode.substring(barcode.length() - barcodeLength);
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/TreeLoader.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/actions/TreeLoader.java
@@ -30,6 +30,7 @@ import ch.rgw.tools.Tree;
  * 
  * @see ch.rgw.tools.Tree
  */
+import ch.rgw.tools.StringTool;
 @Deprecated
 public class TreeLoader<T> extends AbstractDataLoaderJob {
 	private String parentColumn;
@@ -94,7 +95,7 @@ public class TreeLoader<T> extends AbstractDataLoaderJob {
 	@SuppressWarnings("unchecked")//$NON-NLS-1$
 	private void loadChildren(Tree<T> branch, String parent){
 		qbe.clear();
-		qbe.add(parentColumn, "=", parent); //$NON-NLS-1$
+		qbe.add(parentColumn, StringTool.equals, parent); //$NON-NLS-1$
 		List<T> list = load();
 		for (T t : list) {
 			Tree<T> ch = branch.add(t);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/BillingProposalViewCreateBillsHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/BillingProposalViewCreateBillsHandler.java
@@ -44,6 +44,7 @@ import ch.elexis.data.Rechnung;
 import ch.elexis.data.Rechnungssteller;
 import ch.rgw.tools.Result;
 
+import ch.rgw.tools.StringTool;
 public class BillingProposalViewCreateBillsHandler extends AbstractHandler implements IHandler {
 	
 	@Override
@@ -102,7 +103,7 @@ public class BillingProposalViewCreateBillsHandler extends AbstractHandler imple
 								}
 								errorneousInfo.append(messages.get(i).getText());
 							}
-							errorneousInfo.append("\n");
+							errorneousInfo.append(StringTool.lf);
 							errorneous++;
 						}
 					}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/CreateMandantTemplateCommand.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/CreateMandantTemplateCommand.java
@@ -17,6 +17,7 @@ import ch.elexis.core.ui.views.textsystem.model.TextTemplate;
 import ch.elexis.data.Brief;
 import ch.elexis.data.Mandant;
 
+import ch.rgw.tools.StringTool;
 public class CreateMandantTemplateCommand extends AbstractHandler {
 	
 	@Override
@@ -43,7 +44,7 @@ public class CreateMandantTemplateCommand extends AbstractHandler {
 				specTemplate.save(template.loadBinary(), template.getMimeType());
 				
 				TextTemplate specTextTemplate =
-					new TextTemplate(specTemplate.getBetreff(), "", specTemplate.getMimeType());
+					new TextTemplate(specTemplate.getBetreff(), StringTool.leer, specTemplate.getMimeType());
 				specTextTemplate.addFormTemplateReference(specTemplate);
 				
 				ElexisEventDispatcher.getInstance().fire(new ElexisEvent(Brief.class, null,

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/ImportSelectedTemplateCommand.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/ImportSelectedTemplateCommand.java
@@ -28,6 +28,7 @@ import ch.elexis.core.ui.views.textsystem.model.TextTemplate;
 import ch.elexis.data.Brief;
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class ImportSelectedTemplateCommand extends AbstractHandler {
 	private static Logger logger = LoggerFactory.getLogger(ImportSelectedTemplateCommand.class);
 	
@@ -72,7 +73,7 @@ public class ImportSelectedTemplateCommand extends AbstractHandler {
 					List<Brief> existing = TextTemplate.findExistingTemplates(
 						textTemplate.isSystemTemplate(),
 						textTemplate.getName(), (String) null,
-						textTemplate.getMandant() != null ? textTemplate.getMandant().getId() : "");
+						textTemplate.getMandant() != null ? textTemplate.getMandant().getId() : StringTool.leer);
 					if(!existing.isEmpty()) {
 						if (MessageDialog.openQuestion(HandlerUtil.getActiveShell(event),
 							"Vorlagen existieren",

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/ImportTemplatesCommand.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/ImportTemplatesCommand.java
@@ -28,6 +28,7 @@ import ch.elexis.data.Brief;
 import ch.elexis.data.Mandant;
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class ImportTemplatesCommand extends AbstractHandler {
 	private static Logger logger = LoggerFactory.getLogger(ImportTemplatesCommand.class);
 	private String mandantId = null;
@@ -111,7 +112,7 @@ public class ImportTemplatesCommand extends AbstractHandler {
 							// add general form tempalte
 							if (sysTemplate == null) {
 								template.setAdressat(mandant.getId());
-								TextTemplate tt = new TextTemplate(name, "", mimeType);
+								TextTemplate tt = new TextTemplate(name, StringTool.leer, mimeType);
 								tt.addFormTemplateReference(template);
 								ttView.update(tt);
 							} else {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/MahnlaufCommand.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/MahnlaufCommand.java
@@ -31,6 +31,7 @@ import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class MahnlaufCommand extends AbstractHandler {
 	private static final String STR_STATUS_DATUM = "StatusDatum"; //$NON-NLS-1$
 	private static final String STR_MANDANT_I_D = "MandantID"; //$NON-NLS-1$
@@ -56,8 +57,8 @@ public class MahnlaufCommand extends AbstractHandler {
 	
 	private void performMahnlaufForMandant(String mandantId){
 		Query<Rechnung> qbe = new Query<Rechnung>(Rechnung.class);
-		qbe.add(STR_RN_STATUS, "=", Integer.toString(RnStatus.OFFEN_UND_GEDRUCKT)); //$NON-NLS-1$
-		qbe.add(STR_MANDANT_I_D, "=", mandantId); //$NON-NLS-1$
+		qbe.add(STR_RN_STATUS, StringTool.equals, Integer.toString(RnStatus.OFFEN_UND_GEDRUCKT)); //$NON-NLS-1$
+		qbe.add(STR_MANDANT_I_D, StringTool.equals, mandantId); //$NON-NLS-1$
 		
 		TimeTool tt = new TimeTool();
 		// Rechnung zu 1. Mahnung
@@ -81,8 +82,8 @@ public class MahnlaufCommand extends AbstractHandler {
 		}
 		// 1. Mahnung zu 2. Mahnung
 		qbe.clear();
-		qbe.add(STR_RN_STATUS, "=", Integer.toString(RnStatus.MAHNUNG_1_GEDRUCKT)); //$NON-NLS-1$
-		qbe.add(STR_MANDANT_I_D, "=", mandantId); //$NON-NLS-1$
+		qbe.add(STR_RN_STATUS, StringTool.equals, Integer.toString(RnStatus.MAHNUNG_1_GEDRUCKT)); //$NON-NLS-1$
+		qbe.add(STR_MANDANT_I_D, StringTool.equals, mandantId); //$NON-NLS-1$
 		tt = new TimeTool();
 		days = rnsSettings.get(Preferences.RNN_DAYSUNTIL2ND, 10);
 		try {
@@ -103,8 +104,8 @@ public class MahnlaufCommand extends AbstractHandler {
 		}
 		// 2. Mahnung zu 3. Mahnung
 		qbe.clear();
-		qbe.add(STR_RN_STATUS, "=", Integer.toString(RnStatus.MAHNUNG_2_GEDRUCKT)); //$NON-NLS-1$
-		qbe.add(STR_MANDANT_I_D, "=", mandantId); //$NON-NLS-1$
+		qbe.add(STR_RN_STATUS, StringTool.equals, Integer.toString(RnStatus.MAHNUNG_2_GEDRUCKT)); //$NON-NLS-1$
+		qbe.add(STR_MANDANT_I_D, StringTool.equals, mandantId); //$NON-NLS-1$
 		tt = new TimeTool();
 		days = rnsSettings.get(Preferences.RNN_DAYSUNTIL3RD, 10);
 		try {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/compatibility/UiStartupHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/compatibility/UiStartupHandler.java
@@ -15,7 +15,8 @@ import org.osgi.service.event.EventHandler;
 
 import ch.elexis.core.ui.UiDesk;
 
-@Component(property = EventConstants.EVENT_TOPIC + "=" + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+import ch.rgw.tools.StringTool;
+@Component(property = EventConstants.EVENT_TOPIC + StringTool.equals + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
 public class UiStartupHandler implements EventHandler {
 	
 	@Override

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/data/Interaction.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/data/Interaction.java
@@ -47,6 +47,7 @@ import ch.rgw.tools.VersionInfo;
  * @author Niklaus Giger
  *
  */
+import ch.rgw.tools.StringTool;
 public class Interaction extends PersistentObject {
 	
 	public static final String TABLENAME = "ch_elexis_interaction"; //$NON-NLS-1$
@@ -92,7 +93,7 @@ public class Interaction extends PersistentObject {
 	
 	private static Logger logger = LoggerFactory.getLogger(Interaction.class);
 	private static int notImported = 0;
-	private static String hash_from_file = "";
+	private static String hash_from_file = StringTool.leer;
 	private static int importerInteractionsCreated = 0;
 	private static final String MATRIX_CSV_URL = "https://raw.githubusercontent.com/zdavatz/oddb2xml_files/master/interactions_de_utf8.csv"; //$NON-NLS-1$
 	private static final File MATRIX_CSV_LOCAL =
@@ -196,17 +197,17 @@ public class Interaction extends PersistentObject {
 	
 	public static String getMeasures(String ATC_1, String ATC_2){
 		Interaction ia = getByATC(ATC_1, ATC_2);
-		return ia == null ? " " : ia.get(FLD_MEASURES);
+		return ia == null ? StringTool.space : ia.get(FLD_MEASURES);
 	}
 	
 	public static String getEffects(String ATC_1, String ATC_2){
 		Interaction ia = getByATC(ATC_1, ATC_2);
-		return ia == null ? " " : ia.get(FLD_EFFECT);
+		return ia == null ? StringTool.space : ia.get(FLD_EFFECT);
 	}
 	
 	public static String getSeverity(String ATC_1, String ATC_2){
 		Interaction ia = getByATC(ATC_1, ATC_2);
-		return ia == null ? " " : ia.get(FLD_SEVERITY);
+		return ia == null ? StringTool.space : ia.get(FLD_SEVERITY);
 	}
 	
 	@Override
@@ -332,8 +333,8 @@ public class Interaction extends PersistentObject {
 							getDefaultConnection()
 								.exec("DELETE FROM " + TABLENAME + " WHERE ID != 'VERSION';"); //$NON-NLS-1$ //$NON-NLS-2$
 							getDefaultConnection().exec("UPDATE " + TABLENAME + " SET " //$NON-NLS-1$
-								+ FLD_ABUSE_ID_FOR_LAST_PARSED + " = '" + "" + "', " //$NON-NLS-2$ $NON-NLS-3$ $NON-NLS-4$
-								+ FLD_ABUSE_ID_FOR_SHA + " = '" + "" + "' WHERE ID = 'VERSION';"); //$NON-NLS-1$ $NON-NLS-2$
+								+ FLD_ABUSE_ID_FOR_LAST_PARSED + " = '" + StringTool.leer + "', " //$NON-NLS-2$ $NON-NLS-3$ $NON-NLS-4$
+								+ FLD_ABUSE_ID_FOR_SHA + " = '" + StringTool.leer + "' WHERE ID = 'VERSION';"); //$NON-NLS-1$ $NON-NLS-2$
 							notImported = 0;
 							importerInteractionsCreated = 0;
 							if (MATRIX_CSV_LOCAL.exists() && getShaFromFile()) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ArticleDefaultSignatureTitleAreaDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ArticleDefaultSignatureTitleAreaDialog.java
@@ -15,6 +15,7 @@ import ch.elexis.core.model.IPrescription;
 import ch.elexis.core.services.holder.MedicationServiceHolder;
 import ch.elexis.core.ui.views.controls.ArticleDefaultSignatureComposite;
 
+import ch.rgw.tools.StringTool;
 public class ArticleDefaultSignatureTitleAreaDialog extends TitleAreaDialog {
 	
 	private IArticle article;
@@ -111,7 +112,7 @@ public class ArticleDefaultSignatureTitleAreaDialog extends TitleAreaDialog {
 	        return number;
 	    }
 
-	    return number.replaceAll("\\.?0*$", "");
+	    return number.replaceAll("\\.?0*$", StringTool.leer);
 	}
 	
 }

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/AssignStickerDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/AssignStickerDialog.java
@@ -45,6 +45,7 @@ import ch.elexis.core.ui.locks.ILockHandler;
 import ch.elexis.core.ui.util.CoreUiUtil;
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public class AssignStickerDialog extends TitleAreaDialog {
 	Identifiable mine;
 	TableViewer viewer;
@@ -127,7 +128,7 @@ public class AssignStickerDialog extends TitleAreaDialog {
 			@Override
 			public String getText(Object element){
 				ISticker s = (ISticker) element;
-				return s.getImportance() + "";
+				return s.getImportance() + StringTool.leer;
 			}
 			
 			@Override

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/BlockSelektor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/BlockSelektor.java
@@ -19,6 +19,7 @@ import org.eclipse.ui.internal.WorkbenchMessages;
 import ch.elexis.data.Leistungsblock;
 import ch.elexis.data.Query;
 
+import ch.rgw.tools.StringTool;
 public class BlockSelektor extends FilteredItemsSelectionDialog {
 	
 	private boolean ignoreErrors;
@@ -31,7 +32,7 @@ public class BlockSelektor extends FilteredItemsSelectionDialog {
 			@Override
 			public String getText(Object element){
 				if (element == null) {
-					return "";
+					return StringTool.leer;
 				}
 				return ((Leistungsblock) element).getLabel();
 			}
@@ -57,8 +58,8 @@ public class BlockSelektor extends FilteredItemsSelectionDialog {
 	protected Control createDialogArea(Composite parent){
 		String oldListLabel = WorkbenchMessages.FilteredItemsSelectionDialog_listLabel;
 		
-		setMessage("");
-		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = ""; //$NON-NLS-1$
+		setMessage(StringTool.leer);
+		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = StringTool.leer; //$NON-NLS-1$
 		Control ret = super.createDialogArea(parent);
 		
 		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = oldListLabel;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ContactSelectionDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ContactSelectionDialog.java
@@ -196,7 +196,7 @@ public class ContactSelectionDialog extends TitleAreaDialog implements PoDoubleC
 		this.hints = h;
 		for (int i = 0; i < hints.length; i++) {
 			if (hints[i] == null) {
-				hints[i] = "";
+				hints[i] = StringTool.leer;
 			}
 		}
 		if (!StringUtils.isBlank(hints[HINT_BIRTHDATE])) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DiagnoseSelektor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DiagnoseSelektor.java
@@ -36,6 +36,7 @@ import ch.elexis.core.model.IXid;
 import ch.elexis.core.services.ICodeElementService.CodeElementTyp;
 import ch.elexis.core.services.ICodeElementServiceContribution;
 
+import ch.rgw.tools.StringTool;
 public class DiagnoseSelektor extends FilteredItemsSelectionDialog {
 	
 	private List<IDiagnosis> diagnoses = new ArrayList<IDiagnosis>();
@@ -58,7 +59,7 @@ public class DiagnoseSelektor extends FilteredItemsSelectionDialog {
 			@Override
 			public String getText(Object element){
 				if (element == null) {
-					return "";
+					return StringTool.leer;
 				}
 				return ((IDiagnose) element).getLabel();
 			}
@@ -68,9 +69,9 @@ public class DiagnoseSelektor extends FilteredItemsSelectionDialog {
 			@Override
 			public String getText(Object element){
 				if (element == null) {
-					return "";
+					return StringTool.leer;
 				}
-				return ((IDiagnose) element).getCodeSystemName() + " "
+				return ((IDiagnose) element).getCodeSystemName() + StringTool.space
 					+ ((IDiagnose) element).getLabel();
 			}
 		});
@@ -81,7 +82,7 @@ public class DiagnoseSelektor extends FilteredItemsSelectionDialog {
 		String oldListLabel = WorkbenchMessages.FilteredItemsSelectionDialog_listLabel;
 		
 		setMessage(Messages.DiagnoseSelektorDialog_Message);
-		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = ""; //$NON-NLS-1$
+		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = StringTool.leer; //$NON-NLS-1$
 		Control ret = super.createDialogArea(parent);
 		
 		WorkbenchMessages.FilteredItemsSelectionDialog_listLabel = oldListLabel;
@@ -163,22 +164,22 @@ public class DiagnoseSelektor extends FilteredItemsSelectionDialog {
 		
 		@Override
 		public String getCodeSystemName(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override
 		public String getCodeSystemCode(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override
 		public String getId(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override
 		public String getCode(){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DisplayLabDokumenteDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DisplayLabDokumenteDialog.java
@@ -49,6 +49,7 @@ import ch.rgw.tools.MimeTool;
 import ch.rgw.tools.TimeSpan;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class DisplayLabDokumenteDialog extends TitleAreaDialog {
 	private final String title;
 	private final java.util.List<LabResult> labResultList;
@@ -145,7 +146,7 @@ public class DisplayLabDokumenteDialog extends TitleAreaDialog {
 					}
 					
 					if(fileExtension == null) {
-						fileExtension = "";
+						fileExtension = StringTool.leer;
 					}
 					
 					File temp = File.createTempFile("lab" + counter, "doc." + fileExtension); //$NON-NLS-1$ //$NON-NLS-2$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DisplayTextDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/DisplayTextDialog.java
@@ -31,6 +31,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.data.Patient;
 
+import ch.rgw.tools.StringTool;
 public class DisplayTextDialog extends TitleAreaDialog {
 	String t, m, cnt;
 	Boolean hS = true;
@@ -68,7 +69,7 @@ public class DisplayTextDialog extends TitleAreaDialog {
 		} else {
 			cnt = cnt.replaceAll("<", "&lt;");
 			cnt = cnt.replaceAll(">", "&gt;");
-			cnt = cnt.replaceAll("\n", "<br />");
+			cnt = cnt.replaceAll(StringTool.lf, "<br />");
 			cnt = cnt.replaceAll("\\*\\.(.{1,30})\\.\\*", "<b>$1</b>");
 			cnt = cnt.replaceAll("\\\\\\.br\\\\", "<br/>");
 			cnt = cnt.replaceAll("\\\\\\.BR\\\\", "<br/>");

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/EtiketteDruckenDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/EtiketteDruckenDialog.java
@@ -25,6 +25,7 @@ import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.data.Brief;
 import ch.elexis.data.Kontakt;
 
+import ch.rgw.tools.StringTool;
 public class EtiketteDruckenDialog extends TitleAreaDialog implements ICallback {
 	final Kontakt kontakt;
 	final String template;
@@ -91,7 +92,7 @@ public class EtiketteDruckenDialog extends TitleAreaDialog implements ICallback 
 			return false;
 		}
 		
-		String printer = CoreHub.localCfg.get("Drucker/Etiketten/Name", "");
+		String printer = CoreHub.localCfg.get("Drucker/Etiketten/Name", StringTool.leer);
 		String tray = CoreHub.localCfg.get("Drucker/Etiketten/Schacht", null);
 		
 		return text.getPlugin().print(printer, tray, false);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KonsFilterDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KonsFilterDialog.java
@@ -112,7 +112,7 @@ public class KonsFilterDialog extends TitleAreaDialog {
 		String cc = tBed.getText();
 		if (!StringTool.isNothing(cc)) {
 			StringTool.tokenizer tk =
-				new StringTool.tokenizer(cc, " ", StringTool.tokenizer.DOUBLE_QUOTED_TOKENS); //$NON-NLS-1$
+				new StringTool.tokenizer(cc, StringTool.space, StringTool.tokenizer.DOUBLE_QUOTED_TOKENS); //$NON-NLS-1$
 			try {
 				List<String> tokens = tk.tokenize();
 				int last = 0;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KonsZumVerrechnenWizardDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KonsZumVerrechnenWizardDialog.java
@@ -41,6 +41,7 @@ import ch.elexis.data.BillingSystem;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class KonsZumVerrechnenWizardDialog extends TitleAreaDialog {
 	private static final String CONFIG = "dialogs/konszumverrechnen/"; //$NON-NLS-1$
 	private static final String ALLMARKED =
@@ -98,12 +99,12 @@ public class KonsZumVerrechnenWizardDialog extends TitleAreaDialog {
 		cbMarked.setLayoutData(SWTHelper.getFillGridData(4, true, 1, false));
 		cbBefore = new Button(ret, SWT.CHECK);
 		cbBefore.setText(TREATMENTBEGINBEFORE);
-		ddc1 = new DayDateCombo(ret, "", TAGEN_BZW_DEM); //$NON-NLS-1$
+		ddc1 = new DayDateCombo(ret, StringTool.leer, TAGEN_BZW_DEM); //$NON-NLS-1$
 		ddc1.spinDaysBack();
 		cbTime = new Button(ret, SWT.CHECK);
 		cbTime.setText(TREATMENTENDBEFORE);
 		
-		ddc2 = new DayDateCombo(ret, "", TAGEN_BZW_DEM); //$NON-NLS-1$
+		ddc2 = new DayDateCombo(ret, StringTool.leer, TAGEN_BZW_DEM); //$NON-NLS-1$
 		ddc2.spinDaysBack();
 		int prev = CoreHub.localCfg.get(CONFIG + "beginBefore", 30) * -1; //$NON-NLS-1$
 		TimeTool ttNow = new TimeTool();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktDetailDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktDetailDialog.java
@@ -96,7 +96,7 @@ public class KontaktDetailDialog extends TitleAreaDialog {
 			liSex = SWTHelper.createLabeledField(ret, LBL_SEX, LabeledInputField.Typ.TEXT);
 			if (vals != null) {
 				/*
-				 * liGebDat.setText(vals[2]==null ? "" : vals[2]); liSex.setText(vals[3]==null ? ""
+				 * liGebDat.setText(vals[2]==null ? StringTool.leer : vals[2]); liSex.setText(vals[3]==null ? StringTool.leer
 				 * : vals[3]); liStrasse.setText(vals[4]); liPlz.setText(vals[5]);
 				 */
 				liName.setText(StringTool.unNull(vals[0]));

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktErfassenDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktErfassenDialog.java
@@ -150,14 +150,14 @@ public class KontaktErfassenDialog extends TitleAreaDialog {
 		lVorname.setText(Messages.KontaktErfassenDialog_firstName); //$NON-NLS-1$
 		tVorname = new Text(ret, SWT.BORDER);
 		tVorname.setText(
-			fld[KontaktSelektor.HINT_FIRSTNAME] == null ? "" : fld[KontaktSelektor.HINT_FIRSTNAME]); //$NON-NLS-1$
+			fld[KontaktSelektor.HINT_FIRSTNAME] == null ? StringTool.leer : fld[KontaktSelektor.HINT_FIRSTNAME]); //$NON-NLS-1$
 		tVorname.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tVorname.setTextLimit(80);
 		
 		lZusatz = new Label(ret, SWT.NONE);
 		lZusatz.setText(Messages.KontaktErfassenDialog_zusatz); //$NON-NLS-1$
 		tZusatz = new Text(ret, SWT.BORDER);
-		tZusatz.setText(fld.length > KontaktSelektor.HINT_ADD ? fld[KontaktSelektor.HINT_ADD] : ""); //$NON-NLS-1$
+		tZusatz.setText(fld.length > KontaktSelektor.HINT_ADD ? fld[KontaktSelektor.HINT_ADD] : StringTool.leer); //$NON-NLS-1$
 		tZusatz.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		
 		new Label(ret, SWT.NONE).setText(Messages.PatientErfassenDialog_sex);//$NON-NLS-1$
@@ -179,45 +179,45 @@ public class KontaktErfassenDialog extends TitleAreaDialog {
 		new Label(ret, SWT.NONE).setText(Messages.KontaktErfassenDialog_birthDate); //$NON-NLS-1$
 		tGebDat = new Text(ret, SWT.BORDER);
 		tGebDat.setText(
-			fld[KontaktSelektor.HINT_BIRTHDATE] == null ? "" : fld[KontaktSelektor.HINT_BIRTHDATE]); //$NON-NLS-1$
+			fld[KontaktSelektor.HINT_BIRTHDATE] == null ? StringTool.leer : fld[KontaktSelektor.HINT_BIRTHDATE]); //$NON-NLS-1$
 		tGebDat.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tGebDat.setTextLimit(8);
 		
 		new Label(ret, SWT.NONE).setText(Messages.PatientErfassenDialog_street); //$NON-NLS-1$
 		tStrasse = new Text(ret, SWT.BORDER);
 		tStrasse.setText(
-			fld.length > KontaktSelektor.HINT_STREET ? fld[KontaktSelektor.HINT_STREET] : ""); //$NON-NLS-1$
+			fld.length > KontaktSelektor.HINT_STREET ? fld[KontaktSelektor.HINT_STREET] : StringTool.leer); //$NON-NLS-1$
 		tStrasse.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tStrasse.setTextLimit(80);
 		
 		new Label(ret, SWT.NONE).setText(Messages.PatientErfassenDialog_zip); //$NON-NLS-1$
 		tPlz = new Text(ret, SWT.BORDER);
-		tPlz.setText(fld.length > KontaktSelektor.HINT_ZIP ? fld[KontaktSelektor.HINT_ZIP] : ""); //$NON-NLS-1$
+		tPlz.setText(fld.length > KontaktSelektor.HINT_ZIP ? fld[KontaktSelektor.HINT_ZIP] : StringTool.leer); //$NON-NLS-1$
 		tPlz.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tPlz.setTextLimit(6);
 		
 		new Label(ret, SWT.NONE).setText(Messages.PatientErfassenDialog_city); //$NON-NLS-1$
 		tOrt = new Text(ret, SWT.BORDER);
 		tOrt.setText(
-			fld.length > KontaktSelektor.HINT_PLACE ? fld[KontaktSelektor.HINT_PLACE] : ""); //$NON-NLS-1$
+			fld.length > KontaktSelektor.HINT_PLACE ? fld[KontaktSelektor.HINT_PLACE] : StringTool.leer); //$NON-NLS-1$
 		tOrt.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tOrt.setTextLimit(50);
 		
 		new Label(ret, SWT.NONE).setText(Messages.PatientErfassenDialog_phone); //$NON-NLS-1$
 		tTel = new Text(ret, SWT.BORDER);
-		tTel.setText(fld.length > 6 ? fld[6] : ""); //$NON-NLS-1$
+		tTel.setText(fld.length > 6 ? fld[6] : StringTool.leer); //$NON-NLS-1$
 		tTel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tTel.setTextLimit(30);
 		
 		new Label(ret, SWT.NONE).setText(Messages.KontaktErfassenDialog_fax); //$NON-NLS-1$
 		tFax = new Text(ret, SWT.BORDER);
-		tFax.setText(fld.length > 8 ? fld[8] : ""); //$NON-NLS-1$
+		tFax.setText(fld.length > 8 ? fld[8] : StringTool.leer); //$NON-NLS-1$
 		tFax.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tFax.setTextLimit(30);
 		
 		new Label(ret, SWT.NONE).setText(Messages.KontaktErfassenDialog_email); //$NON-NLS-1$
 		tEmail = new Text(ret, SWT.BORDER);
-		tEmail.setText(fld.length > 9 ? fld[9] : ""); //$NON-NLS-1$
+		tEmail.setText(fld.length > 9 ? fld[9] : StringTool.leer); //$NON-NLS-1$
 		tEmail.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tEmail.setTextLimit(80);
 		new Label(ret, SWT.NONE).setText(Messages.KontaktErfassenDialog_postanschrift); //$NON-NLS-1$
@@ -335,8 +335,8 @@ public class KontaktErfassenDialog extends TitleAreaDialog {
 			ret[7] = tTel.getText();
 			if (newKontakt == null) {
 				Query<Kontakt> qbe = new Query<Kontakt>(Kontakt.class);
-				qbe.add("Bezeichnung1", "=", ret[0]); //$NON-NLS-1$ //$NON-NLS-2$
-				qbe.add("Bezeichnung2", "=", ret[1]); //$NON-NLS-1$ //$NON-NLS-2$
+				qbe.add("Bezeichnung1", StringTool.equals, ret[0]); //$NON-NLS-1$ //$NON-NLS-2$
+				qbe.add("Bezeichnung2", StringTool.equals, ret[1]); //$NON-NLS-1$ //$NON-NLS-2$
 				List<Kontakt> list = qbe.execute();
 				if ((list != null) && (!list.isEmpty())) {
 					Kontakt k = list.get(0);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktExtDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktExtDialog.java
@@ -39,6 +39,7 @@ import ch.elexis.data.Kontakt;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class KontaktExtDialog extends TitleAreaDialog {
 	private String[] fieldDefinitions;
 	private Kontakt actKontact;
@@ -113,7 +114,7 @@ public class KontaktExtDialog extends TitleAreaDialog {
 			savedValues = new String[fieldDefinitions.length];
 			values = new Text[fieldDefinitions.length];
 			for (int i = 0; i < fieldDefinitions.length; i++) {
-				String[] val = fieldDefinitions[i].split("="); //$NON-NLS-1$
+				String[] val = fieldDefinitions[i].split(StringTool.equals); //$NON-NLS-1$
 				String key = val[0];
 				fields[i] = key;
 				if (val.length == 2) {
@@ -139,7 +140,7 @@ public class KontaktExtDialog extends TitleAreaDialog {
 				String msg_key_tooltip = "KontaktExtInfo_" + key + "_tooltip"; //$NON-NLS-1$ //$NON-NLS-2$
 				msg_key_tooltip = msg_key_tooltip.replaceAll("[^a-zA-Z0-9_]", "_");
 				String label_text = key;
-				String tooltip_text = "";
+				String tooltip_text = StringTool.leer;
 				try {
 					label_text = ResourceBundle.getBundle(ch.elexis.core.l10n.Messages.BUNDLE_NAME)
 							.getString(msg_key_label);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktSelektor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/KontaktSelektor.java
@@ -148,7 +148,7 @@ public class KontaktSelektor extends TitleAreaDialog implements PoDoubleClickLis
 		for (int i = 0; i < hints.length; i++) { // make KontaktErfassenDialog
 			// happy
 			if (hints[i] == null) {
-				hints[i] = "";
+				hints[i] = StringTool.leer;
 			}
 		}
 		if (!StringTool.isNothing(hints[HINT_BIRTHDATE])) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/MediDetailDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/MediDetailDialog.java
@@ -44,6 +44,7 @@ import ch.elexis.core.ui.util.SWTHelper;
 import ch.elexis.data.Artikel;
 import ch.elexis.data.Prescription;
 
+import ch.rgw.tools.StringTool;
 public class MediDetailDialog extends TitleAreaDialog {
 	private IPrescription prescription;
 	private String dosis, intakeOrder, disposalComment;
@@ -209,8 +210,8 @@ public class MediDetailDialog extends TitleAreaDialog {
 			stackLayoutDosage.topControl = compositeDayTimeDosage;
 		}
 		
-		txtIntakeOrder.setText(intakeOrder == null ? "" : intakeOrder);
-		txtDisposalComment.setText(disposalComment == null ? "" : disposalComment);
+		txtIntakeOrder.setText(intakeOrder == null ? StringTool.leer : intakeOrder);
+		txtDisposalComment.setText(disposalComment == null ? StringTool.leer : disposalComment);
 	}
 	
 	@Override
@@ -318,7 +319,7 @@ public class MediDetailDialog extends TitleAreaDialog {
 	 */
 	public String[] getDosageArray(String dosage){
 		String[] retVal = new String[4];
-		Arrays.fill(retVal, "");
+		Arrays.fill(retVal, StringTool.leer);
 		if (dosage != null) {
 			// Match stuff like '1/2', '7/8'
 			if (dosage.matches("^[0-9]/[0-9]$")) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/OrderImportDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/OrderImportDialog.java
@@ -82,6 +82,7 @@ import ch.elexis.data.BestellungEntry;
  * @author Daniel Lutz
  *
  */
+import ch.rgw.tools.StringTool;
 public class OrderImportDialog extends TitleAreaDialog {
 	private static final String ALLE_MARKIEREN = " Alle markieren ";
 	private static final int DIFF_SPINNER_MIN = 1;
@@ -419,11 +420,11 @@ public class OrderImportDialog extends TitleAreaDialog {
 		
 		String ean = eanText.getText().trim();
 		// remove silly characters from scanner
-		ean = ean.replaceAll(new Character(SWT.CR).toString(), "");
-		ean = ean.replaceAll(new Character(SWT.LF).toString(), "");
-		ean = ean.replaceAll(new Character((char) 0).toString(), "");
+		ean = ean.replaceAll(new Character(SWT.CR).toString(), StringTool.leer);
+		ean = ean.replaceAll(new Character(SWT.LF).toString(), StringTool.leer);
+		ean = ean.replaceAll(new Character((char) 0).toString(), StringTool.leer);
 		
-		eanText.setText("");
+		eanText.setText(StringTool.leer);
 		diffSpinner.setSelection(DIFF_SPINNER_DEFAULT);
 		
 		OrderElement orderElement = findOrderElementByEAN(ean);
@@ -554,7 +555,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class CheckboxLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;
@@ -569,7 +570,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class AmountLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;
@@ -582,7 +583,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class StockLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;
@@ -606,7 +607,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class PharamcodeLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;
@@ -619,7 +620,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class EANLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;
@@ -632,7 +633,7 @@ public class OrderImportDialog extends TitleAreaDialog {
 	
 	private class DescriptionLabelProvider extends BaseLabelProvider {
 		public String getText(Object element){
-			String text = "";
+			String text = StringTool.leer;
 			
 			if (element instanceof OrderElement) {
 				OrderElement orderElement = (OrderElement) element;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ReminderDetailDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ReminderDetailDialog.java
@@ -52,6 +52,7 @@ import ch.elexis.data.Patient;
 import ch.elexis.data.Reminder;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ReminderDetailDialog extends TitleAreaDialog {
 	
 	private static final String TX_ALL = Messages.EditReminderDialog_all; //$NON-NLS-1$
@@ -525,7 +526,7 @@ public class ReminderDetailDialog extends TitleAreaDialog {
 			due = dateDue.toString(TimeTool.DATE_GER);
 		}
 		if (reminder == null) {
-			reminder = new Reminder(null, due, Visibility.ALWAYS, "", "");
+			reminder = new Reminder(null, due, Visibility.ALWAYS, StringTool.leer, StringTool.leer);
 		}
 		
 		String contactId =

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ReminderListSelectionDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ReminderListSelectionDialog.java
@@ -26,6 +26,7 @@ import ch.elexis.data.Reminder;
  * 
  * @since 3.7
  */
+import ch.rgw.tools.StringTool;
 public class ReminderListSelectionDialog extends ListSelectionDialog {
 	
 	private Label detailLabel;
@@ -55,7 +56,7 @@ public class ReminderListSelectionDialog extends ListSelectionDialog {
 				if (!arg0.getSelection().isEmpty()) {
 					Reminder reminder =
 						(Reminder) ((IStructuredSelection) arg0.getSelection()).getFirstElement();
-					sb.append("    "+reminder.getSubject() + "\n");
+					sb.append("    "+reminder.getSubject() + StringTool.lf);
 					sb.append("    "+reminder.getMessage());
 				}
 				detailLabel.setText(sb.toString());

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/SelectBestellungDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/SelectBestellungDialog.java
@@ -37,6 +37,7 @@ import ch.elexis.core.model.IOrder;
 import ch.elexis.core.services.IQuery;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class SelectBestellungDialog extends SelectionDialog {
 	
 	private IStructuredContentProvider fContentProvider;
@@ -133,7 +134,7 @@ public class SelectBestellungDialog extends SelectionDialog {
 				if (order.isDone()) {
 					return "*";
 				} else {
-					return "";
+					return StringTool.leer;
 				}
 			}
 		});

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TextTemplateImportConflictDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TextTemplateImportConflictDialog.java
@@ -15,6 +15,7 @@ import org.eclipse.swt.widgets.Text;
 
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public class TextTemplateImportConflictDialog extends TitleAreaDialog {
 	private String name;
 	private Button btnReplace, btnChangeName, btnSkip;
@@ -77,7 +78,7 @@ public class TextTemplateImportConflictDialog extends TitleAreaDialog {
 	}
 	
 	private void clearAndDisableTextField(){
-		txtNewName.setText("");
+		txtNewName.setText(StringTool.leer);
 		txtNewName.setEnabled(false);
 	}
 	

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TextTemplatePrintSettingsDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TextTemplatePrintSettingsDialog.java
@@ -35,6 +35,7 @@ import ch.elexis.core.ui.dialogs.base.InputDialog;
 import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public class TextTemplatePrintSettingsDialog extends TitleAreaDialog {
 	private ComboViewer cvPrinters, cvTrays;
 	private List<PrintService> printServices;
@@ -121,7 +122,7 @@ public class TextTemplatePrintSettingsDialog extends TitleAreaDialog {
 			@Override
 			public void widgetSelected(SelectionEvent e){
 				InputDialog dlg = new InputDialog(getParentShell(), "Zusätzlicher Schacht",
-					"Bitten den Namen des zusätzlichen Schacht konfigurieren.", "", null, SWT.NONE);
+					"Bitten den Namen des zusätzlichen Schacht konfigurieren.", StringTool.leer, null, SWT.NONE);
 				if (dlg.open() == Window.OK) {
 					if (dlg.getValue() != null && !dlg.getValue().isEmpty()) {
 						addCustomMediaTray(dlg.getValue());
@@ -200,7 +201,7 @@ public class TextTemplatePrintSettingsDialog extends TitleAreaDialog {
 		IStructuredSelection selMediaTray = (IStructuredSelection) cvTrays.getSelection();
 		if (selMediaTray != null) {
 			if (selMediaTray.isEmpty()) {
-				selTray = "";
+				selTray = StringTool.leer;
 			} else {
 				selTray = ((MediaTray) selMediaTray.getFirstElement()).toString();
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TotpDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/TotpDialog.java
@@ -41,6 +41,7 @@ import ch.elexis.core.ui.UiDesk;
 import ch.elexis.data.Kontakt;
 import ch.elexis.data.User;
 
+import ch.rgw.tools.StringTool;
 public class TotpDialog extends TitleAreaDialog {
 	
 	protected static Logger log = LoggerFactory.getLogger(TotpDialog.class);
@@ -78,7 +79,7 @@ public class TotpDialog extends TitleAreaDialog {
 		
 		String issuer = "Elexis";
 		
-		String selfContactId = CoreHub.globalCfg.get(Preferences.SELFCONTACT_ID, "");
+		String selfContactId = CoreHub.globalCfg.get(Preferences.SELFCONTACT_ID, StringTool.leer);
 		if (!StringUtils.isEmpty(selfContactId)) {
 			Kontakt selfContact = Kontakt.load(selfContactId);
 			if (selfContact.isAvailable()) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ZusatzAdresseEingabeDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/ZusatzAdresseEingabeDialog.java
@@ -212,7 +212,7 @@ public class ZusatzAdresseEingabeDialog extends TitleAreaDialog {
 		try {
 			zusatzAdresse.persistDTO(zusatzAdresseDTO);
 		} catch (ElexisException e) {
-			MessageDialog.openError(getShell(), "",
+			MessageDialog.openError(getShell(), StringTool.leer,
 				"Speichern nicht möglich. Bitte diesen Dialog schließen und erneut probieren.");
 			return;
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/provider/ContactSelectionLabelProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/provider/ContactSelectionLabelProvider.java
@@ -11,6 +11,7 @@ import ch.elexis.core.model.IPerson;
 import ch.elexis.core.model.Identifiable;
 import ch.elexis.core.ui.util.viewers.DefaultLabelProvider;
 
+import ch.rgw.tools.StringTool;
 public class ContactSelectionLabelProvider extends DefaultLabelProvider {
 	
 	private static DateTimeFormatter dateOfBirthFormatter =
@@ -31,7 +32,7 @@ public class ContactSelectionLabelProvider extends DefaultLabelProvider {
 				label = label + " (" + dateOfBirthString + ")";
 			}
 			if (contact.isUser()) {
-				label = StringUtils.defaultString(contact.getDescription1()) + " "
+				label = StringUtils.defaultString(contact.getDescription1()) + StringTool.space
 					+ StringUtils.defaultString(contact.getDescription2()) + " - " + label;
 			}
 			return label;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/provider/KontaktSelektorLabelProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/dialogs/provider/KontaktSelektorLabelProvider.java
@@ -6,6 +6,7 @@ import ch.elexis.data.Kontakt;
 import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Person;
 
+import ch.rgw.tools.StringTool;
 public class KontaktSelektorLabelProvider extends DefaultLabelProvider {
 	@Override
 	public String getText(Object element){
@@ -17,7 +18,7 @@ public class KontaktSelektorLabelProvider extends DefaultLabelProvider {
 				label = label + " (" + k.get(Person.BIRTHDATE) + ")";
 			}
 			if (StringConstants.ONE.equals(k.get(Kontakt.FLD_IS_USER))) {
-				label = k.get(Kontakt.FLD_NAME1) + " " + k.get(Kontakt.FLD_NAME2) + " - " + label;
+				label = k.get(Kontakt.FLD_NAME1) + StringTool.space + k.get(Kontakt.FLD_NAME2) + " - " + label;
 			}
 			return label;
 		} else if (element instanceof PersistentObject) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/KontaktMatcher.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/KontaktMatcher.java
@@ -246,7 +246,7 @@ public class KontaktMatcher {
 					Messages.KontaktMatcher_PersonNotFound,
 					name + StringTool.space + vorname
 						+ (StringTool.isNothing(gebdat) ? StringTool.leer : SEP + gebdat) + SEP
-						+ strasse + SEP + plz + " " + ort,
+						+ strasse + SEP + plz + StringTool.space + ort,
 					resolve1, hints);
 			}
 			return null;
@@ -258,9 +258,9 @@ public class KontaktMatcher {
 		if (createMode == CreateMode.ASK) {
 			return (Person) KontaktSelektor.showInSync(Person.class,
 				Messages.KontaktMatcher_PersonNotUnique,
-				name + " " + vorname
+				name + StringTool.space + vorname
 					+ (StringTool.isNothing(gebdat) ? StringTool.leer : SEP + gebdat) + SEP
-					+ strasse + SEP + plz + " " + ort,
+					+ strasse + SEP + plz + StringTool.space + ort,
 				resolve1, hints);
 		} else {
 			return (Person) matchAddress(found.toArray(new Kontakt[0]), strasse, plz, ort, natel);
@@ -333,13 +333,13 @@ public class KontaktMatcher {
 	 * 
 	 * @param str
 	 *            a string containing possibly zip and possibly place
-	 * @return always a two element array, [0] is zip or "", [1] is place or ""
+	 * @return always a two element array, [0] is zip or StringTool.leer, [1] is place or StringTool.leer
 	 */
 	public static String[] normalizeAddress(String str){
 		String[] ret = str.split("\\s+", 2); //$NON-NLS-1$
 		if (ret.length < 2) {
 			String[] rx = new String[2];
-			rx[0] = "";
+			rx[0] = StringTool.leer;
 			rx[1] = ret[0];
 			return rx;
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/EpisodeElement.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/EpisodeElement.java
@@ -64,7 +64,7 @@ public class EpisodeElement extends XChangeElement {
 		if (text != null) {
 			return text.getText();
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	public String getDiagnosis(){
@@ -75,7 +75,7 @@ public class EpisodeElement extends XChangeElement {
 			String ret = de.getCode() + " (" + de.getCodeSystem() + ")";
 			return ret;
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	static class DiagnosisElement extends XChangeElement {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/RecordElement.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/RecordElement.java
@@ -27,6 +27,7 @@ import ch.rgw.tools.VersionedResource;
 import ch.rgw.tools.VersionedResource.ResourceItem;
 import ch.rgw.tools.XMLTool;
 
+import ch.rgw.tools.StringTool;
 public class RecordElement extends XChangeElement {
 	static final String ELEMENT_TEXT = "text";
 	static final String ATTR_AUTHOR = "author";
@@ -81,7 +82,7 @@ public class RecordElement extends XChangeElement {
 		StringBuilder sb = new StringBuilder();
 		sb.append(Messages.RecordElement_EntryDate).append(getAttr(ATTR_DATE))
 			.append(Messages.RecordElement_CreatedBy).append( //$NON-NLS-1$ //$NON-NLS-2$
-				getAttr(ATTR_AUTHOR)).append("\n");
+				getAttr(ATTR_AUTHOR)).append(StringTool.lf);
 		List<Element> children = getElement().getChildren();
 		if (children != null) {
 			for (Element child : children) {
@@ -89,7 +90,7 @@ public class RecordElement extends XChangeElement {
 					continue;
 				}
 				sb.append(child.getName()).append(":\n");
-				sb.append(child.getText()).append("\n");
+				sb.append(child.getText()).append(StringTool.lf);
 			}
 		}
 		Element eText = getElement().getChild(ELEMENT_TEXT);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/XChangeElement.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/exchange/elements/XChangeElement.java
@@ -29,6 +29,7 @@ import ch.rgw.tools.XMLTool;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public abstract class XChangeElement {
 	public static final String ATTR_ID = "id";
 	public static final String ATTR_DATE = "date";
@@ -119,7 +120,7 @@ public abstract class XChangeElement {
 	 */
 	public String getAttr(final String name){
 		String ret = ex.getAttributeValue(name);
-		return ret == null ? "" : ret;
+		return ret == null ? StringTool.leer : ret;
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Leistungscodes.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Leistungscodes.java
@@ -133,7 +133,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 				AbrechnungsTypDialog at = new AbrechnungsTypDialog(getShell(), null);
 				if (at.open() == Dialog.OK) {
 					String[] result = at.getResult();
-					String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + result[0]; //$NON-NLS-1$
+					String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + result[0]; //$NON-NLS-1$
 					log.info("Dialog.OK localized values: name {} leistung {} ausgabe {}", result[0], result[1], result[2]);
 					String leistungscode = getDbAusgabeName(result[1]);
 					String rnOutputter = getDbAusgabeName(result[2]);
@@ -209,7 +209,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 								log.info("DoubleClick Okay: name '{}'  localized leistung: '{}' ausgabe: '{}'", result[0], result[1], result[2]);
 								String leistungscode = getDbLeistungscodeName(result[1]);
 								String rnOutputter = getDbAusgabeName(result[2]);
-								String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + result[0]; //$NON-NLS-1$
+								String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + result[0]; //$NON-NLS-1$
 								log.info("Dialog.OK db values: name '{}' leistung '{}' ausgabe '{}' key '{}'", 
 										result[0], leistungscode, rnOutputter, key);
 								CoreHub.globalCfg.set(key + "/name", result[0]); //$NON-NLS-1$
@@ -330,7 +330,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 		// *** and rebuild the table contents
 		if (systeme != null) {
 			for (String s : systeme) {
-				String cfgkey = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + s + "/"; //$NON-NLS-1$ //$NON-NLS-2$
+				String cfgkey = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + s + StringTool.slash; //$NON-NLS-1$ //$NON-NLS-2$
 				TableItem it = new TableItem(table, SWT.NONE);
 				String name = CoreHub.globalCfg.get(cfgkey + "name", "default"); //$NON-NLS-1$ //$NON-NLS-2$
 				it.setText(0, name);
@@ -715,8 +715,8 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 						// *** SCRIPT-variant, is directly passed through
 					} else {
 						// *** simple listing, line by line
-						String tmp = result[1].replaceAll("\r\n", DEFINITIONSDELIMITER); //$NON-NLS-1$
-						tmp = tmp.replaceAll("\n", DEFINITIONSDELIMITER); //$NON-NLS-1$
+						String tmp = result[1].replaceAll(StringTool.crlf, DEFINITIONSDELIMITER); //$NON-NLS-1$
+						tmp = tmp.replaceAll(StringTool.lf, DEFINITIONSDELIMITER); //$NON-NLS-1$
 						tmp = tmp.replaceAll("\r", DEFINITIONSDELIMITER); //$NON-NLS-1$
 						if ((tmp.isEmpty()) || (tmp.split(DEFINITIONSDELIMITER).length < 2)) {
 							errorString = errorString + Messages.Leistungscodes_ErrorAtLeast2Items;
@@ -916,7 +916,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 						InputDialog inp = new InputDialog(getShell(),
 							l + Messages.Leistungscodes_add, msg, StringTool.leer, null); //$NON-NLS-1$
 						if (inp.open() == Dialog.OK) {
-							String[] req = inp.getValue().split("="); //$NON-NLS-1$
+							String[] req = inp.getValue().split(StringTool.equals); //$NON-NLS-1$
 							if (req.length != 2) {
 								SWTHelper.showError(Messages.Leistungscodes_badEntry,
 									Messages.Leistungscodes_explainEntry);
@@ -1056,7 +1056,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 		private void removeRequiredStringGesetzFromFallExtInfo(){
 			String selection = ldConstants.getSelection();
 			if (selection != null && StringUtils.containsIgnoreCase(selection, "Gesetz")) {
-				String[] split = selection.split("=");
+				String[] split = selection.split(StringTool.equals);
 				String message = MessageFormat
 					.format("Remove the selected field [{0}] from all Faelle?\nPlease validate that a law is set!", split[0]);
 				boolean performDelete =
@@ -1128,7 +1128,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 		final String tempCaseID = "marlovits-14x@8w1"; //$NON-NLS-1$
 		
 		JdbcLink j = PersistentObject.getConnection();
-		String minID = ""; //$NON-NLS-1$
+		String minID = StringTool.leer; //$NON-NLS-1$
 		try {
 			// *** get just any case
 			minID = j.queryString("select id from faelle limit 1"); //$NON-NLS-1$
@@ -1745,14 +1745,14 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 				if (opt.trim().equalsIgnoreCase("(SQL)")) { //$NON-NLS-1$
 					opt = (l.length >= 4) ? "   (SQL: " + l[3].replaceAll(ITEMDELIMITER, "; ") + ")" //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
 							: StringTool.leer;
-					return type + " " + l[0] + opt; //$NON-NLS-1$
+					return type + StringTool.space + l[0] + opt; //$NON-NLS-1$
 				} else {
-					return type + " " + l[0] + opt; //$NON-NLS-1$
+					return type + StringTool.space + l[0] + opt; //$NON-NLS-1$
 				}
 			} else {
 				String opt = (l.length >= 3) ? "   (" + l[2].replaceAll(ITEMDELIMITER, "; ") + ")" //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
 						: StringTool.leer;
-				return "? " + " " + l[0] + opt; //$NON-NLS-1$ //$NON-NLS-2$
+				return "? " + StringTool.space + l[0] + opt; //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 		
@@ -1779,7 +1779,7 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 				fieldName = fields[0];
 				fieldType = fields[1];
 				optionsIn = fields.length > 2 ? fields[2] : StringTool.leer;
-				optionsIn = optionsIn.replaceAll(ITEMDELIMITER, "\n"); //$NON-NLS-1$
+				optionsIn = optionsIn.replaceAll(ITEMDELIMITER, StringTool.lf); //$NON-NLS-1$
 				
 				if (fieldType.equalsIgnoreCase("K")) { //$NON-NLS-1$
 					ll = Messages.Leistungscodes_contactHL;
@@ -1872,8 +1872,8 @@ public class Leistungscodes extends PreferencePage implements IWorkbenchPreferen
 				}
 				
 				// *** append options as ;-delimited list
-				options = options.replaceAll("\r\n", ITEMDELIMITER); //$NON-NLS-1$
-				options = (options.replaceAll("\n", ITEMDELIMITER)).replaceAll("\r", ITEMDELIMITER); //$NON-NLS-1$ //$NON-NLS-2$
+				options = options.replaceAll(StringTool.crlf, ITEMDELIMITER); //$NON-NLS-1$
+				options = (options.replaceAll(StringTool.lf, ITEMDELIMITER)).replaceAll("\r", ITEMDELIMITER); //$NON-NLS-1$ //$NON-NLS-2$
 				req = req + ARGUMENTSSDELIMITER + options;
 				
 				// *** return result

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/RolesToAccessRightsPreferencePage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/RolesToAccessRightsPreferencePage.java
@@ -62,6 +62,7 @@ import ch.elexis.core.ui.util.viewers.DefaultLabelProvider;
 import ch.elexis.data.Query;
 import ch.elexis.data.Role;
 
+import ch.rgw.tools.StringTool;
 public class RolesToAccessRightsPreferencePage extends PreferencePage
 		implements IWorkbenchPreferencePage, IValueChangeListener {
 	private DataBindingContext m_bindingContext;
@@ -265,7 +266,7 @@ public class RolesToAccessRightsPreferencePage extends PreferencePage
 					cell.setForeground(UiDesk.getColor(UiDesk.COL_BLACK));
 					break;
 				default:
-					cell.setText("");
+					cell.setText(StringTool.leer);
 					cell.setForeground(UiDesk.getColor(UiDesk.COL_BLACK));
 				}
 			}
@@ -279,7 +280,7 @@ public class RolesToAccessRightsPreferencePage extends PreferencePage
 			TreeColumn tc = tvc.getColumn();
 			tc.setData("role", role);
 			tc.setWidth(20);
-			tc.setText(role.getLabel().charAt(0) + "");
+			tc.setText(role.getLabel().charAt(0) + StringTool.leer);
 			String translation = role.getTranslatedLabel();
 			if (translation != null && translation.length() > 0) {
 				tc.setToolTipText(translation);
@@ -414,7 +415,7 @@ public class RolesToAccessRightsPreferencePage extends PreferencePage
 	@Override
 	public void handleValueChange(ValueChangeEvent event){
 		Role r = (Role) wv.getValue();
-		txtRoleName.setText((r == null) ? "" : r.getRoleName());
+		txtRoleName.setText((r == null) ? StringTool.leer : r.getRoleName());
 	}
 	
 	private void refreshViewer(){

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ScannerPref.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ScannerPref.java
@@ -35,6 +35,7 @@ import ch.elexis.core.constants.Preferences;
 import ch.elexis.core.data.activator.CoreHub;
 import ch.elexis.core.ui.actions.ScannerEvents;
 
+import ch.rgw.tools.StringTool;
 public class ScannerPref extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 	public static final String ID = "ch.elexis.preferences.ScannerPrefs"; //$NON-NLS-1$
 	
@@ -128,7 +129,7 @@ public class ScannerPref extends FieldEditorPreferencePage implements IWorkbench
 		btnClear.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e){
-				txtTest.setText(""); //$NON-NLS-1$
+				txtTest.setText(StringTool.leer); //$NON-NLS-1$
 				txtTest.setFocus();
 			}
 			

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ServiceDiagnosePrefs.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ServiceDiagnosePrefs.java
@@ -47,6 +47,7 @@ import ch.elexis.core.ui.constants.ExtensionPointConstantsUi;
 import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.views.IDetailDisplay;
 
+import ch.rgw.tools.StringTool;
 public class ServiceDiagnosePrefs extends PreferencePage implements IWorkbenchPreferencePage {
 	private static final String FAVORITES = "Favoriten";
 	private ComboViewer cmbViewer;
@@ -188,7 +189,7 @@ public class ServiceDiagnosePrefs extends PreferencePage implements IWorkbenchPr
 		TableViewerColumn tvCol = new TableViewerColumn(viewer, SWT.NONE);
 		tvCol.setLabelProvider(new ColumnLabelProvider());
 		TableColumn column = tvCol.getColumn();
-		column.setText("");
+		column.setText(StringTool.leer);
 		column.setWidth(150);
 		column.setResizable(false);
 		column.setMoveable(false);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/SettingsPreferenceStore.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/SettingsPreferenceStore.java
@@ -30,6 +30,7 @@ import ch.rgw.io.Settings;
  * 
  * @author Gerry
  */
+import ch.rgw.tools.StringTool;
 public class SettingsPreferenceStore implements IPreferenceStore {
 	/**
 	 * The default context is the context where getDefault and setDefault methods will search. This
@@ -85,7 +86,7 @@ public class SettingsPreferenceStore implements IPreferenceStore {
 		if (z == null) {
 			z = base.get(field + SETTINGS_PREFERENCE_STORE_DEFAULT, null);
 			if (z == null) {
-				z = ""; //$NON-NLS-1$
+				z = StringTool.leer; //$NON-NLS-1$
 			}
 		}
 		return z;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/StockManagementPreferencePage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/StockManagementPreferencePage.java
@@ -56,6 +56,7 @@ import ch.elexis.data.Mandant;
 import ch.elexis.data.Query;
 import ch.elexis.data.Stock;
 
+import ch.rgw.tools.StringTool;
 public class StockManagementPreferencePage extends PreferencePage
 		implements IWorkbenchPreferencePage {
 	private DataBindingContext m_bindingContext;
@@ -145,7 +146,7 @@ public class StockManagementPreferencePage extends PreferencePage
 		mntmAddStock.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e){
-				Stock stock = new Stock("", Integer.MAX_VALUE);
+				Stock stock = new Stock(StringTool.leer, Integer.MAX_VALUE);
 				tableViewer.add(stock);
 				tableViewer.setSelection(new StructuredSelection(stock));
 			}
@@ -283,7 +284,7 @@ public class StockManagementPreferencePage extends PreferencePage
 				if (ret == Window.OK) {
 					Mandant p = (Mandant) ks.getSelection();
 					s.setOwner(p);
-					String label = (p != null) ? p.getLabel() : "";
+					String label = (p != null) ? p.getLabel() : StringTool.leer;
 					lblOwnerText.setText(label);
 				} else {
 					s.setOwner(null);
@@ -313,11 +314,11 @@ public class StockManagementPreferencePage extends PreferencePage
 				if (ret == Window.OK) {
 					Kontakt p = (Kontakt) ks.getSelection();
 					s.setResponsible(p);
-					String label = (p != null) ? p.getLabel() : "";
+					String label = (p != null) ? p.getLabel() : StringTool.leer;
 					lblResponsibleText.setText(label);
 				} else {
 					s.setResponsible(null);
-					lblResponsibleText.setText("");
+					lblResponsibleText.setText(StringTool.leer);
 				}
 			}
 		});
@@ -455,7 +456,7 @@ public class StockManagementPreferencePage extends PreferencePage
 					}
 				} else {
 					CoreHub.globalCfg.remove(Preferences.INVENTORY_DEFAULT_ARTICLE_PROVIDER);
-					lblDefaultArticleProvider.setText("");
+					lblDefaultArticleProvider.setText(StringTool.leer);
 				}
 			}
 		});
@@ -464,7 +465,7 @@ public class StockManagementPreferencePage extends PreferencePage
 		lblDefaultArticleProvider
 			.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		String id = CoreHub.globalCfg.get(Preferences.INVENTORY_DEFAULT_ARTICLE_PROVIDER, null);
-		lblDefaultArticleProvider.setText("");
+		lblDefaultArticleProvider.setText(StringTool.leer);
 		new Label(compDefaultProvider, SWT.NONE);
 		if (id != null) {
 			Kontakt load = Kontakt.load(id);
@@ -483,13 +484,13 @@ public class StockManagementPreferencePage extends PreferencePage
 				if (owner != null) {
 					lblOwnerText.setText(owner.getLabel());
 				} else {
-					lblOwnerText.setText("");
+					lblOwnerText.setText(StringTool.leer);
 				}
 				Kontakt responsible = stock.getResponsible();
 				if (responsible != null) {
 					lblResponsibleText.setText(responsible.getLabel());
 				} else {
-					lblResponsibleText.setText("");
+					lblResponsibleText.setText(StringTool.leer);
 				}
 				String machineUuid = stock.getDriverUuid();
 				if (machineUuid != null && !machineUuid.isEmpty()) {
@@ -497,11 +498,11 @@ public class StockManagementPreferencePage extends PreferencePage
 						.getInfoStringForDriver(UUID.fromString(machineUuid), false);
 					lblMachineuuid.setText(info);
 				} else {
-					lblMachineuuid.setText("");
+					lblMachineuuid.setText(StringTool.leer);
 				}
 			} else {
-				lblOwnerText.setText("");
-				lblResponsibleText.setText("");
+				lblOwnerText.setText(StringTool.leer);
+				lblResponsibleText.setText(StringTool.leer);
 			}
 		});
 		

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserCasePreferences.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserCasePreferences.java
@@ -91,7 +91,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 		getPreferenceStore().setValue(Preferences.USR_DEFCASEREASON, Fall.getDefaultCaseReason());
 		getPreferenceStore().setValue(Preferences.USR_DEFLAW, Fall.getDefaultCaseLaw());
 		// read the sorting for this user form prefs, convert to LinkedList for editing
-		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, "");
+		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, StringTool.leer);
 		String[] topItemsSorting = topItemsSortingStr.split(PREFSDELIMITER_REGEX);
 		topItemsLinkedList = new LinkedList<String>(Arrays.asList(topItemsSorting));
 	}
@@ -129,7 +129,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 		diagnoseLbl.setText(Messages.UserCasePreferences_DefaultDiagnose);
 		diagnoseTxt = new Text(diagnoseParent, SWT.BORDER);
 		diagnoseTxt.setEditable(false);
-		String diagnoseId = CoreHub.userCfg.get(Preferences.USR_DEFDIAGNOSE, "");
+		String diagnoseId = CoreHub.userCfg.get(Preferences.USR_DEFDIAGNOSE, StringTool.leer);
 		if (diagnoseId.length() > 1) {
 			PersistentObject diagnose = CoreHub.poFactory.createFromString(diagnoseId);
 			if (diagnose != null)
@@ -148,8 +148,8 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 						CoreHub.userCfg.set(Preferences.USR_DEFDIAGNOSE, diagnose.storeToString());
 						diagnoseTxt.setText(diagnose.getLabel());
 					} else {
-						CoreHub.userCfg.set(Preferences.USR_DEFDIAGNOSE, "");
-						diagnoseTxt.setText("");
+						CoreHub.userCfg.set(Preferences.USR_DEFDIAGNOSE, StringTool.leer);
+						diagnoseTxt.setText(StringTool.leer);
 					}
 				}
 			}
@@ -159,8 +159,8 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 		diagnoseDelBtn.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e){
-				CoreHub.userCfg.set(Preferences.USR_DEFDIAGNOSE, "");
-				diagnoseTxt.setText("");
+				CoreHub.userCfg.set(Preferences.USR_DEFDIAGNOSE, StringTool.leer);
+				diagnoseTxt.setText(StringTool.leer);
 			}
 		});
 		
@@ -226,7 +226,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 		infoTxt.setText(Messages.UserCasePreferences_InfoLabelForSortingBillingSystems);
 		
 		Label lllabel2 = new Label(getFieldEditorParent(), SWT.NONE);
-		lllabel2.setText(""); //$NON-NLS-1$
+		lllabel2.setText(StringTool.leer); //$NON-NLS-1$
 		Composite sorterListComp = new Composite(getFieldEditorParent(), SWT.NONE);
 		GridLayout sorterListLayout = new GridLayout();
 		sorterListLayout.marginWidth = 0;
@@ -326,7 +326,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 	void moveItemToPresorted(){
 		String[] selStr = sorterList2.getSelection();
 		topItemsLinkedList.add(selStr[0]);
-		topItemsLinkedList.remove(""); //$NON-NLS-1$ // remove any empty items
+		topItemsLinkedList.remove(StringTool.leer); //$NON-NLS-1$ // remove any empty items
 		sorterList2.setItems(sortBillingSystems(BillingSystem.getAbrechnungsSysteme(), topItemsLinkedList,
 			true));
 		sorterList2.select(topItemsLinkedList.size() - 1);
@@ -336,7 +336,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 	void moveItemToNotPresorted(){
 		String[] selStr = sorterList2.getSelection();
 		topItemsLinkedList.remove(selStr[0]);
-		topItemsLinkedList.remove(""); //$NON-NLS-1$ // remove any empty items
+		topItemsLinkedList.remove(StringTool.leer); //$NON-NLS-1$ // remove any empty items
 		sorterList2.setItems(sortBillingSystems(BillingSystem.getAbrechnungsSysteme(), topItemsLinkedList,
 			true));
 		int newSel = sorterList2.indexOf(selStr[0]);
@@ -370,7 +370,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 	void setButtonEnabling(){
 		// get separator and current sel position
 		int separatorPos;
-		if ((topItemsLinkedList.size() > 0) && (!topItemsLinkedList.get(0).equalsIgnoreCase(""))) //$NON-NLS-1$
+		if ((topItemsLinkedList.size() > 0) && (!topItemsLinkedList.get(0).equalsIgnoreCase(StringTool.leer))) //$NON-NLS-1$
 			separatorPos = topItemsLinkedList.size();
 		else
 			separatorPos = -1;
@@ -399,11 +399,11 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 	
 	public static int getBillingSystemsMenuSeparatorPos(String[] input){
 		// read the sorting for this user form prefs, convert to LinkedList for editing
-		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, ""); //$NON-NLS-1$
+		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, StringTool.leer); //$NON-NLS-1$
 		String[] topItemsSorting = topItemsSortingStr.split(PREFSDELIMITER_REGEX);
 		LinkedList<String> lTopItemsLinkedList =
 			new LinkedList<String>(Arrays.asList(topItemsSorting));
-		if ((lTopItemsLinkedList.size() > 0) && (!lTopItemsLinkedList.get(0).equalsIgnoreCase(""))) //$NON-NLS-1$
+		if ((lTopItemsLinkedList.size() > 0) && (!lTopItemsLinkedList.get(0).equalsIgnoreCase(StringTool.leer))) //$NON-NLS-1$
 			return lTopItemsLinkedList.size();
 		else
 			return -1;
@@ -420,7 +420,7 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 	 */
 	public static String[] sortBillingSystems(String[] input){
 		// read the sorting for this user form prefs, convert to LinkedList for editing
-		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, ""); //$NON-NLS-1$
+		String topItemsSortingStr = CoreHub.userCfg.get(Preferences.USR_TOPITEMSSORTING, StringTool.leer); //$NON-NLS-1$
 		String[] topItemsSorting = topItemsSortingStr.split(PREFSDELIMITER_REGEX);
 		LinkedList<String> lTopItemsLinkedList =
 			new LinkedList<String>(Arrays.asList(topItemsSorting));
@@ -475,11 +475,11 @@ public class UserCasePreferences extends FieldEditorPreferencePage implements
 		
 		// now append the sorted items to the copied top items
 		if (alwaysShowSeparator
-			|| ((topItemsSorting.size() > 0) && (!topItemsSorting.get(0).equalsIgnoreCase("")))) { //$NON-NLS-1$
+			|| ((topItemsSorting.size() > 0) && (!topItemsSorting.get(0).equalsIgnoreCase(StringTool.leer)))) { //$NON-NLS-1$
 			lTopItemsSorting.add(MENUSEPARATOR);
 		}
 		lTopItemsSorting.addAll(sortedList);
-		lTopItemsSorting.remove(""); //$NON-NLS-1$
+		lTopItemsSorting.remove(StringTool.leer); //$NON-NLS-1$
 		
 		String[] output = new String[lTopItemsSorting.size()];
 		lTopItemsSorting.toArray(output);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserManagementPreferencePage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserManagementPreferencePage.java
@@ -86,6 +86,7 @@ import ch.elexis.data.Rechnungssteller;
 import ch.elexis.data.Role;
 import ch.elexis.data.User;
 
+import ch.rgw.tools.StringTool;
 public class UserManagementPreferencePage extends PreferencePage
 		implements IWorkbenchPreferencePage, IUnlockable {
 	private TableViewer tableViewerUsers;
@@ -170,7 +171,7 @@ public class UserManagementPreferencePage extends PreferencePage
 						null, iiv);
 					int retVal = id.open();
 					if (retVal == Dialog.OK) {
-						User newUser = new User(null, id.getValue(), "");
+						User newUser = new User(null, id.getValue(), StringTool.leer);
 						updateUserList();
 						tableViewerUsers.setSelection(new StructuredSelection(newUser));
 					}
@@ -438,7 +439,7 @@ public class UserManagementPreferencePage extends PreferencePage
 					Person p = (Person) ks.getSelection();
 					p.set(Anwender.FLD_IS_USER, StringConstants.ONE);
 					user.setAssignedContact(p);
-					linkContact.setText(p.getPersonalia() + " " + CHANGE_LINK);
+					linkContact.setText(p.getPersonalia() + StringTool.space + CHANGE_LINK);
 				}
 			}
 		});
@@ -505,7 +506,7 @@ public class UserManagementPreferencePage extends PreferencePage
 					Mandant mand = Mandant.load(ac.getId());
 					mand.setRechnungssteller(kontakt);
 					linkRechnungssteller
-						.setText(mand.getRechnungssteller().getLabel() + " " + CHANGE_LINK);
+						.setText(mand.getRechnungssteller().getLabel() + StringTool.space + CHANGE_LINK);
 				}
 			}
 		});
@@ -634,7 +635,7 @@ public class UserManagementPreferencePage extends PreferencePage
 			@Override
 			public String getColumnText(Object element, int columnIndex){
 				Mandant m = (Mandant) element;
-				return m.getName() + " " + m.getVorname();
+				return m.getName() + StringTool.space + m.getVorname();
 			}
 		});
 		updateRoles();
@@ -683,7 +684,7 @@ public class UserManagementPreferencePage extends PreferencePage
 			Anwender anw = user.getAssignedContact();
 			wvAnwender.setValue(anw);
 			String text = (anw != null) ? anw.getPersonalia() : "Nicht gesetzt";
-			linkContact.setText(text + " " + CHANGE_LINK);
+			linkContact.setText(text + StringTool.space + CHANGE_LINK);
 			
 			userInfoLabel.setText(text + " [" + user.getId() + "]");
 			
@@ -717,7 +718,7 @@ public class UserManagementPreferencePage extends PreferencePage
 					
 					Rechnungssteller rs = m.getRechnungssteller();
 					String rst = (rs != null) ? rs.getLabel() : "Nicht gesetzt";
-					linkRechnungssteller.setText(rst + " " + CHANGE_LINK);
+					linkRechnungssteller.setText(rst + StringTool.space + CHANGE_LINK);
 				}
 			}
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserPreferences.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserPreferences.java
@@ -124,7 +124,7 @@ public class UserPreferences extends PreferencePage implements IWorkbenchPrefere
 					blob.put(ims.getNode());
 					SWTHelper.showInfo(Messages.UserPreferences_ConfigSaved,
 						MessageFormat.format(Messages.UserPreferences_ConfigWasSaved, name));
-					cbUserSave.setText(""); //$NON-NLS-1$
+					cbUserSave.setText(StringTool.leer); //$NON-NLS-1$
 				}
 			}
 		});

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserTextPref.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/UserTextPref.java
@@ -30,6 +30,7 @@ import ch.elexis.core.ui.text.EnhancedTextField;
 /**
  * Benutzerspezifische Einstellungen
  */
+import ch.rgw.tools.StringTool;
 public class UserTextPref extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 	
 	public static final String ID = "ch.elexis.preferences.UserPreferences"; //$NON-NLS-1$
@@ -57,7 +58,7 @@ public class UserTextPref extends FieldEditorPreferencePage implements IWorkbenc
 		}
 		Set<String> makroNames = makros.keySet();
 		for (String name : makroNames) {
-			addField(new BooleanFieldEditor(EnhancedTextField.MACRO_ENABLED + "/"
+			addField(new BooleanFieldEditor(EnhancedTextField.MACRO_ENABLED + StringTool.slash
 				+ makros.get(name), name, getFieldEditorParent()));
 		}
 	}
@@ -95,14 +96,14 @@ public class UserTextPref extends FieldEditorPreferencePage implements IWorkbenc
 			String clazz = iConfigurationElement.getAttribute("KonsMakro");
 			if (clazz != null && !clazz.isEmpty() && !name.equals("enabled")) {
 				boolean enabled =
-					CoreHub.userCfg.get(EnhancedTextField.MACRO_ENABLED + "/" + clazz, false);
+					CoreHub.userCfg.get(EnhancedTextField.MACRO_ENABLED + StringTool.slash + clazz, false);
 				// set disabled as default ...
 				if (!enabled) {
-					CoreHub.userCfg.set(EnhancedTextField.MACRO_ENABLED + "/" + clazz, false);
+					CoreHub.userCfg.set(EnhancedTextField.MACRO_ENABLED + StringTool.slash + clazz, false);
 				}
 			} else if (clazz != null && !clazz.isEmpty() && name.equals("enabled")) {
 				// set enabled for makros with name enabled
-				CoreHub.userCfg.set(EnhancedTextField.MACRO_ENABLED + "/" + clazz, true);
+				CoreHub.userCfg.set(EnhancedTextField.MACRO_ENABLED + StringTool.slash + clazz, true);
 			}
 		}
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/inputs/KontaktFieldEditor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/inputs/KontaktFieldEditor.java
@@ -27,6 +27,7 @@ import ch.elexis.core.ui.dialogs.KontaktSelektor;
 import ch.elexis.data.Kontakt;
 import ch.rgw.io.Settings;
 
+import ch.rgw.tools.StringTool;
 public class KontaktFieldEditor extends FieldEditor {
 	private Label contactLabel;
 	private Settings cfg;
@@ -65,7 +66,7 @@ public class KontaktFieldEditor extends FieldEditor {
 		if (contactLabel == null) {
 			return;
 		}
-		selected = Kontakt.load(cfg.get(getPreferenceName(), ""));
+		selected = Kontakt.load(cfg.get(getPreferenceName(), StringTool.leer));
 		if (selected.isValid()) {
 			contactLabel.setText(selected.getLabel());
 		} else {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/inputs/MultilineFieldEditor.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/inputs/MultilineFieldEditor.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.widgets.Text;
 
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public class MultilineFieldEditor extends StringFieldEditor {
 	Text textField;
 	int numOfLines;
@@ -80,7 +81,7 @@ public class MultilineFieldEditor extends StringFieldEditor {
 		if (textField != null) {
 			String value = getPreferenceStore().getString(getPreferenceName());
 			if (isStringList) {
-				value = value.replaceAll(",", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+				value = value.replaceAll(",", StringTool.lf); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			textField.setText(value);
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/ActiveControl.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/selectors/ActiveControl.java
@@ -36,12 +36,13 @@ import ch.elexis.core.ui.util.SWTHelper;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public abstract class ActiveControl extends Composite {
 	private Label lbl;
 	protected Control ctl;
 	protected Composite controllers;
-	protected String textContents = "";
-	private String labelContents = "";
+	protected String textContents = StringTool.leer;
+	private String labelContents = StringTool.leer;
 	private LinkedList<ActiveControlListener> listeners;
 	private HashMap<String, Object> properties = new HashMap<String, Object>();
 	private int flags;
@@ -84,7 +85,7 @@ public abstract class ActiveControl extends Composite {
 			setLayout(new GridLayout(2, false));
 		}
 		flags = displayBits;
-		labelContents = displayName == null ? "" : displayName;
+		labelContents = displayName == null ? StringTool.leer : displayName;
 		if ((displayBits & HIDE_LABEL) == 0) {
 			lbl = new Label(this, SWT.NONE);
 			lbl.setText(displayName);
@@ -156,7 +157,7 @@ public abstract class ActiveControl extends Composite {
 	}
 	
 	public void clear(){
-		textContents = "";
+		textContents = StringTool.leer;
 		push();
 	}
 	

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/services/internal/ContextService.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/services/internal/ContextService.java
@@ -71,7 +71,8 @@ import ch.elexis.data.User;
  * @author thomas
  *
  */
-@Component(property = EventConstants.EVENT_TOPIC + "=" + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+import ch.rgw.tools.StringTool;
+@Component(property = EventConstants.EVENT_TOPIC + StringTool.equals + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
 public class ContextService implements IContextService, EventHandler {
 	
 	private static Logger logger = LoggerFactory.getLogger(ContextService.class);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/BlockMakro.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/BlockMakro.java
@@ -16,6 +16,7 @@ import ch.elexis.data.Konsultation;
 import ch.elexis.data.Leistungsblock;
 import ch.rgw.tools.Result;
 
+import ch.rgw.tools.StringTool;
 public class BlockMakro implements IKonsMakro {
 	
 	@Override
@@ -49,7 +50,7 @@ public class BlockMakro implements IKonsMakro {
 			StringBuilder sb = new StringBuilder();
 			diff.forEach(r -> {
 				if (sb.length() > 0) {
-					sb.append("\n");
+					sb.append(StringTool.lf);
 				}
 				sb.append(r);
 			});

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/EnhancedTextField.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/EnhancedTextField.java
@@ -625,7 +625,7 @@ public class EnhancedTextField extends Composite implements IRichTextDisplay {
 			// und wenn ja, entsprechende Formatierung anwenden.
 			else if (e.text.matches("[\\*/_]")) { //$NON-NLS-1$
 				int start = e.start;
-				String t = ""; //$NON-NLS-1$
+				String t = StringTool.leer; //$NON-NLS-1$
 				while (--start >= 0) {
 					t = text.getTextRange(start, 1);
 					if (t.equals(e.text)) {
@@ -653,7 +653,7 @@ public class EnhancedTextField extends Composite implements IRichTextDisplay {
 		
 		private boolean isMakroEnabled(IKonsMakro extMakro){
 			UserTextPref.setMakroEnabledDefaults();
-			return CoreHub.userCfg.get(EnhancedTextField.MACRO_ENABLED + "/"
+			return CoreHub.userCfg.get(EnhancedTextField.MACRO_ENABLED + StringTool.slash
 				+ extMakro.getClass().getName(), false);
 		}
 		

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/ExternalLink.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/ExternalLink.java
@@ -23,6 +23,7 @@ import ch.elexis.core.ui.Hub;
 import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.util.IKonsExtension;
 
+import ch.rgw.tools.StringTool;
 public class ExternalLink implements IKonsExtension {
 	public static final String ID = "ch.elexis.text.ExternalLink"; //$NON-NLS-1$
 	
@@ -41,7 +42,7 @@ public class ExternalLink implements IKonsExtension {
 	public boolean doXRef(String refProvider, String refID){
 		try {
 			int r = refID.lastIndexOf('.');
-			String ext = ""; //$NON-NLS-1$
+			String ext = StringTool.leer; //$NON-NLS-1$
 			if (r != -1) {
 				ext = refID.substring(r + 1);
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/TextContainer.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/text/TextContainer.java
@@ -209,7 +209,7 @@ public class TextContainer {
 	
 	public Brief createFromTemplateName(final Konsultation kons, final String templatenameRaw,
 		final String typ, final Kontakt adressat, final String subject){
-		String suffix = CoreHub.localCfg.get(TextTemplatePreferences.SUFFIX_STATION, "");
+		String suffix = CoreHub.localCfg.get(TextTemplatePreferences.SUFFIX_STATION, StringTool.leer);
 		Brief template = loadTemplate(templatenameRaw + suffix);
 		if (template == null && suffix.length() > 0) {
 			template = loadTemplate(templatenameRaw);
@@ -341,7 +341,7 @@ public class TextContainer {
 			if (showErrors) {
 				return WARNING_SIGN + bl + WARNING_SIGN;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		return readFromPo(o, q[1], showErrors);
@@ -368,7 +368,7 @@ public class TextContainer {
 			if (showErrors) {
 				return WARNING_SIGN + fieldl + WARNING_SIGN;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		
@@ -381,7 +381,7 @@ public class TextContainer {
 			if (showErrors) {
 				return WARNING_SIGN + fieldl + WARNING_SIGN;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		
@@ -393,7 +393,7 @@ public class TextContainer {
 				if (showErrors) {
 					return WARNING_SIGN + fieldl + WARNING_SIGN;
 				} else {
-					return "";
+					return StringTool.leer;
 				}
 			}
 			current = next;
@@ -423,7 +423,7 @@ public class TextContainer {
 			if (showErrors) {
 				return WARNING_SIGN + name + WARNING_SIGN;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		
@@ -537,7 +537,7 @@ public class TextContainer {
 		if (o != null) {
 			return q[2];
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -557,7 +557,7 @@ public class TextContainer {
 			if (showErrors) {
 				return "???";
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		if (q.length != 3) {
@@ -568,16 +568,16 @@ public class TextContainer {
 			if (showErrors) {
 				return Messages.TextContainer_FieldTypeForContactsOnly;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		Kontakt k = (Kontakt) o;
-		String[] g = q[2].split("/"); //$NON-NLS-1$
+		String[] g = q[2].split(StringTool.slash); //$NON-NLS-1$
 		if (g.length < 2) {
 			if (showErrors) {
 				return Messages.TextContainer_BadFieldDefinition;
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		if (k.istPerson()) {
@@ -599,7 +599,7 @@ public class TextContainer {
 				if (showErrors) {
 					return Messages.TextContainer_FieldTypeForPersonsOnly;
 				} else {
-					return "";
+					return StringTool.leer;
 				}
 			}
 			return g[2];
@@ -700,7 +700,7 @@ public class TextContainer {
 		String sqlPrefix = sql.split(":")[0];
 		String[] sqlPrefixParts = sqlPrefix.split("\\|");
 		String fieldDelimiter = "	"; // default: tab
-		String rowDelimiter = "\n"; // default: newline
+		String rowDelimiter = StringTool.lf; // default: newline
 		if (sqlPrefixParts.length > 1) {
 			fieldDelimiter = sqlPrefixParts[1];
 			// replace escape sequences
@@ -771,19 +771,19 @@ public class TextContainer {
 			if (showErrors) {
 				return "[???" + bl + " ***" + e1.getMessage() + "*** ???]";
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		
 		// create result by reading rows/fields and extracting hashTable fields
 		// from extInfo
-		String fieldContent = "";
-		String result = "";
-		String lRowDelimiter = "";
+		String fieldContent = StringTool.leer;
+		String result = StringTool.leer;
+		String lRowDelimiter = StringTool.leer;
 		try {
 			// loop through all rows of resultSet
 			while (rs.next()) {
-				String delimiter = "";
+				String delimiter = StringTool.leer;
 				result = result + lRowDelimiter;
 				lRowDelimiter = rowDelimiter;
 				// loop through columns
@@ -803,7 +803,7 @@ public class TextContainer {
 							i++;
 							byte[] blob = rs.getBytes(i);
 							if (blob == null) {
-								fieldContent = "";
+								fieldContent = StringTool.leer;
 							} else {
 								// get hashTable, read field
 								Hashtable<Object, Object> ht = fold(blob);
@@ -811,7 +811,7 @@ public class TextContainer {
 							}
 						}
 						// append field to result
-						result = result + delimiter + (fieldContent == null ? "" : fieldContent);
+						result = result + delimiter + (fieldContent == null ? StringTool.leer : fieldContent);
 						delimiter = fieldDelimiter;
 					} catch (Exception e) {
 						// this just catches the case where i > num of
@@ -829,7 +829,7 @@ public class TextContainer {
 			if (showErrors) {
 				return "[???" + bl + " ***" + e.getMessage() + "*** ???]";
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 		// aufräumen
@@ -860,7 +860,7 @@ public class TextContainer {
 	private String convertSpecialCharacters(final String in){
 		// \ddd how to replace octal values?
 		String result = in;
-		result = result.replaceAll("\\\\n", "\n");
+		result = result.replaceAll("\\\\n", StringTool.lf);
 		result = result.replaceAll("\\\\t", "\t");
 		result = result.replaceAll("\\\\b", "\b");
 		result = result.replaceAll("\\\\r", "\r");

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/CoreUiUtil.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/CoreUiUtil.java
@@ -35,7 +35,8 @@ import ch.elexis.core.model.IImage;
 import ch.elexis.core.model.ISticker;
 import ch.elexis.core.ui.UiDesk;
 
-@Component(property = EventConstants.EVENT_TOPIC + "=" + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+import ch.rgw.tools.StringTool;
+@Component(property = EventConstants.EVENT_TOPIC + StringTool.equals + UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
 public class CoreUiUtil implements EventHandler {
 	
 	private static Logger logger = LoggerFactory.getLogger(CoreUiUtil.class);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/GenericObjectDropTarget.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/GenericObjectDropTarget.java
@@ -34,9 +34,10 @@ import ch.elexis.data.PersistentObject;
  * Universal {@link DropTarget}
  * 
  */
+import ch.rgw.tools.StringTool;
 public class GenericObjectDropTarget implements DropTargetListener, ICodeSelectorTarget {
 	IReceiver rc;
-	String name = "";
+	String name = StringTool.leer;
 	private final Color normalColor;
 	private final Color highlightColor;
 	private final Control mine;
@@ -70,7 +71,7 @@ public class GenericObjectDropTarget implements DropTargetListener, ICodeSelecto
 	}
 	
 	public GenericObjectDropTarget(Control target, IReceiver r){
-		this("", target, r, true);
+		this(StringTool.leer, target, r, true);
 	}
 	
 	public GenericObjectDropTarget(String name, Control target, IReceiver r){

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/ImporterPage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/ImporterPage.java
@@ -119,7 +119,7 @@ public abstract class ImporterPage implements IExecutableExtension {
 				return doImport(monitor);
 			} catch (Exception e) {
 				return new Status(Status.ERROR, Hub.PLUGIN_ID, Messages.ImporterPage_importError
-					+ " " + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
+					+ StringTool.space + e.getMessage(), e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -147,7 +147,7 @@ public abstract class ImporterPage implements IExecutableExtension {
 			final Label lFile = new Label(this, SWT.NONE);
 			tFname = new Text(this, SWT.BORDER);
 			tFname.setText(CoreHub.localCfg
-				.get("ImporterPage/" + home.getTitle() + "/filename", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				.get("ImporterPage/" + home.getTitle() + "/filename", StringTool.leer)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			home.results = new String[1];
 			home.results[0] = tFname.getText();
 			lFile.setText(Messages.ImporterPage_file); //$NON-NLS-1$
@@ -210,7 +210,7 @@ public abstract class ImporterPage implements IExecutableExtension {
 			lFile.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			tFname.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			tFname
-				.setText(CoreHub.localCfg.get("ImporterPage/" + home.getTitle() + "/dirname", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				.setText(CoreHub.localCfg.get("ImporterPage/" + home.getTitle() + "/dirname", StringTool.leer)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			home.results = new String[1];
 			home.results[0] = tFname.getText();
 			Button bFile = new Button(this, SWT.PUSH);
@@ -254,7 +254,7 @@ public abstract class ImporterPage implements IExecutableExtension {
 			lSource.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			tSource.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			tSource.setText(CoreHub.localCfg.get(
-				"ImporterPage/" + home.getTitle() + "/ODBC-Source", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				"ImporterPage/" + home.getTitle() + "/ODBC-Source", StringTool.leer)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			home.results = new String[1];
 			home.results[0] = tSource.getText();
 			Button bSource = new Button(this, SWT.PUSH);
@@ -295,7 +295,7 @@ public abstract class ImporterPage implements IExecutableExtension {
 			tSource.setEditable(false);
 			lSource.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			tSource.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
-			tSource.setText(""); //$NON-NLS-1$
+			tSource.setText(StringTool.leer); //$NON-NLS-1$
 			if (preset != null) {
 				tSource.setText(preset[0]);
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/LabeledInputField.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/LabeledInputField.java
@@ -141,12 +141,12 @@ public class LabeledInputField extends Composite {
 		switch (typ) {
 		case LINK:
 			lbl.setForeground(UiDesk.getColorRegistry().get(UiDesk.COL_BLUE)); //$NON-NLS-1$
-			ctl = tk.createText(this, "", SWT.NONE);
+			ctl = tk.createText(this, StringTool.leer, SWT.NONE);
 			ctl.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			break;
 		case TEXT:
 		case MONEY:
-			ctl = tk.createText(this, "", SWT.BORDER);
+			ctl = tk.createText(this, StringTool.leer, SWT.BORDER);
 			((Text) ctl).setTextLimit(limit);
 			ctl.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 			break;
@@ -260,7 +260,7 @@ public class LabeledInputField extends Composite {
 			List list = (List) ctl;
 			String[] sel = list.getSelection();
 			if (sel.length == 0) {
-				return "";
+				return StringTool.leer;
 			} else {
 				return StringTool.join(sel, StringConstants.COMMA);
 			}
@@ -269,7 +269,7 @@ public class LabeledInputField extends Composite {
 		} else if (ctl instanceof Button) {
 			return ((Button) ctl).getText();
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -530,11 +530,11 @@ public class LabeledInputField extends Composite {
 		}
 		
 		public String getLabel(){
-			return mine == null ? "" : mine.getLabel();
+			return mine == null ? StringTool.leer : mine.getLabel();
 		}
 		
 		public String getText(){
-			return mine == null ? "" : mine.getText();
+			return mine == null ? StringTool.leer : mine.getText();
 		}
 		
 		public void setText(String t){
@@ -693,7 +693,7 @@ public class LabeledInputField extends Composite {
 					val = money.getCentsAsString();
 				} catch (ParseException e1) {
 					ExHandler.handle(e1);
-					val = "";
+					val = StringTool.leer;
 				}
 				// double betr=Double.parseDouble(inp.getText())*100.0;
 				// val=Long.toString(Math.round(betr));

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/ListDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/ListDisplay.java
@@ -46,6 +46,7 @@ import ch.elexis.core.ui.locks.IUnlockable;
 /**
  * A List of objects with UI (definable hyperlinks) Replaces DynamicListDisplay
  */
+import ch.rgw.tools.StringTool;
 public class ListDisplay<T> extends Composite implements IUnlockable {
 	public interface LDListener {
 		public void hyperlinkActivated(String l);
@@ -65,7 +66,7 @@ public class ListDisplay<T> extends Composite implements IUnlockable {
 		Clipboard clip = new Clipboard(UiDesk.getDisplay());
 		StringBuilder sb = new StringBuilder();
 		for (String s : list.getItems()) {
-			sb.append(s).append("\n");
+			sb.append(s).append(StringTool.lf);
 		}
 		clip.setContents(new Object[] {
 			sb.toString()

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/NatTableCustomCellPainter.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/NatTableCustomCellPainter.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 
+import ch.rgw.tools.StringTool;
 public class NatTableCustomCellPainter extends TextPainter {
 	
 	BackgroundPainter bgPainter = new BackgroundPainter();
@@ -59,7 +60,7 @@ public class NatTableCustomCellPainter extends TextPainter {
 			//draw every line by itself
 			int yStartPos = rectangle.y
 				+ CellStyleUtil.getVerticalAlignmentPadding(cellStyle, rectangle, contentHeight);
-			String[] lines = text.split("\n"); //$NON-NLS-1$
+			String[] lines = text.split(StringTool.lf); //$NON-NLS-1$
 			for (String line : lines) {
 				int lineContentWidth = Math.min(getLengthFromCache(gc, line), rectangle.width);
 				
@@ -95,7 +96,7 @@ public class NatTableCustomCellPainter extends TextPainter {
 		if (parts != null && parts.length > 0) {
 			for (String string : parts) {
 				if (string.startsWith("<strong>")) {
-					string = string.replaceAll("<strong>", "");
+					string = string.replaceAll("<strong>", StringTool.leer);
 					ret.add(new TextPart(string, TextPart.PartStyle.BOLD));
 				} else {
 					ret.add(new TextPart(string, TextPart.PartStyle.NORMAL));

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/PersistentObjectDropTarget.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/PersistentObjectDropTarget.java
@@ -33,9 +33,10 @@ import ch.elexis.data.PersistentObject;
  * @deprecated use {@link GenericObjectDropTarget} instead
  * 
  */
+import ch.rgw.tools.StringTool;
 public class PersistentObjectDropTarget implements DropTargetListener, ICodeSelectorTarget {
 	IReceiver rc;
-	String name = "";
+	String name = StringTool.leer;
 	private final Color normalColor;
 	private final Color highlightColor;
 	private final Control mine;
@@ -69,7 +70,7 @@ public class PersistentObjectDropTarget implements DropTargetListener, ICodeSele
 	}
 	
 	public PersistentObjectDropTarget(Control target, IReceiver r){
-		this("", target, r, true);
+		this(StringTool.leer, target, r, true);
 	}
 	
 	public PersistentObjectDropTarget(String name, Control target, IReceiver r){

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SWTHelper.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SWTHelper.java
@@ -438,7 +438,7 @@ public class SWTHelper {
 		if (lines > 1) {
 			lNum = SWT.MULTI | SWT.WRAP;
 		}
-		Text ret = tk.createText(parent, "", lNum | flags | SWT.BORDER); //$NON-NLS-1$
+		Text ret = tk.createText(parent, StringTool.leer, lNum | flags | SWT.BORDER); //$NON-NLS-1$
 		GridData gd = getFillGridData(1, true, 1, true);
 		int h = Math.round(ret.getFont().getFontData()[0].height);
 		gd.minimumHeight = (lines + 1) * (h + 2);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SqlWithUiRunner.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/SqlWithUiRunner.java
@@ -31,6 +31,7 @@ import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.JdbcLink.Stm;
 import ch.rgw.tools.JdbcLinkException;
 
+import ch.rgw.tools.StringTool;
 public class SqlWithUiRunner {
 	static Log log = Log.get("SqlWithUiRunner");
 	
@@ -46,7 +47,7 @@ public class SqlWithUiRunner {
 		sqlStrings = new ArrayList<String>();
 		for (int i = 0; i < sql.length; i++) {
 			String sqlString = sql[i];
-			sqlString = sqlString.replaceAll("\r", "");
+			sqlString = sqlString.replaceAll("\r", StringTool.leer);
 			String[] parts = sqlString.split("\n\n");
 			for (String part : parts) {
 				sqlStrings.add(part);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/dnd/IdentifiableDropTarget.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/dnd/IdentifiableDropTarget.java
@@ -26,9 +26,10 @@ import org.eclipse.swt.widgets.Control;
 import ch.elexis.core.data.service.StoreToStringServiceHolder;
 import ch.elexis.core.model.Identifiable;
 
+import ch.rgw.tools.StringTool;
 public class IdentifiableDropTarget implements DropTargetListener {
 	IReceiver receiver;
-	String name = "";
+	String name = StringTool.leer;
 	
 	public IdentifiableDropTarget(Control target, IReceiver receiver){
 		this.receiver = receiver;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/DefaultControlFieldProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/DefaultControlFieldProvider.java
@@ -103,9 +103,9 @@ public class DefaultControlFieldProvider implements ControlFieldProvider {
 		// this.fields=new String[fields.length];
 		lastFiltered = new String[fields.length];
 		for (int i = 0; i < flds.length; i++) {
-			lastFiltered[i] = ""; //$NON-NLS-1$
+			lastFiltered[i] = StringTool.leer; //$NON-NLS-1$
 			if (flds[i].indexOf('=') != -1) {
-				String[] s = flds[i].split("="); //$NON-NLS-1$
+				String[] s = flds[i].split(StringTool.equals); //$NON-NLS-1$
 				fields[i] = s[1];
 				dbFields[i] = s[0];
 			} else {
@@ -158,7 +158,7 @@ public class DefaultControlFieldProvider implements ControlFieldProvider {
 		
 		createSelectors(fields.length);
 		for (int i = 0; i < selectors.length; i++) {
-			selectors[i] = new ElexisText(tk.createText(inner, "", SWT.BORDER)); //$NON-NLS-1$
+			selectors[i] = new ElexisText(tk.createText(inner, StringTool.leer, SWT.BORDER)); //$NON-NLS-1$
 			selectors[i].addModifyListener(ml);
 			selectors[i].addSelectionListener(sl);
 			selectors[i].setToolTipText(Messages.DefaultControlFieldProvider_enterFilter); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/PatientenListeControlFieldProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/util/viewers/PatientenListeControlFieldProvider.java
@@ -41,7 +41,7 @@ public class PatientenListeControlFieldProvider extends DefaultControlFieldProvi
 		String field0 = null;
 		String field1 = null;
 		
-		if (lastFiltered.length >= 2 && lastFiltered[0].contains(" ")) {
+		if (lastFiltered.length >= 2 && lastFiltered[0].contains(StringTool.space)) {
 			Pattern pattern = Pattern.compile("^(\\S+) +(.*)$");
 			Matcher matcher = pattern.matcher(lastFiltered[0]);
 			if (matcher.matches()) {
@@ -80,7 +80,7 @@ public class PatientenListeControlFieldProvider extends DefaultControlFieldProvi
 		String field0 = null;
 		String field1 = null;
 		
-		if (lastFiltered.length >= 2 && lastFiltered[0].contains(" ")) {
+		if (lastFiltered.length >= 2 && lastFiltered[0].contains(StringTool.space)) {
 			Pattern pattern = Pattern.compile("^(\\S+) +(.*)$");
 			Matcher matcher = pattern.matcher(lastFiltered[0]);
 			if (matcher.matches()) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUF2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUF2.java
@@ -54,6 +54,7 @@ import ch.rgw.tools.ExHandler;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class AUF2 extends ViewPart implements IActivationListener {
 	public static final String ID = "ch.elexis.auf"; //$NON-NLS-1$
 	TableViewer tv;
@@ -121,7 +122,7 @@ public class AUF2 extends ViewPart implements IActivationListener {
 					AUF auf = (AUF) selection.getFirstElement();
 					sb.append(auf.storeToString()).append(","); //$NON-NLS-1$
 				}
-				event.data = sb.toString().replace(",$", ""); //$NON-NLS-1$ //$NON-NLS-2$
+				event.data = sb.toString().replace(",$", StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		});
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BBSView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BBSView.java
@@ -53,6 +53,7 @@ import ch.rgw.tools.Tree;
  * 
  * @author gerry
  */
+import ch.rgw.tools.StringTool;
 @Deprecated
 public class BBSView extends ViewPart implements ISelectionChangedListener, ISaveablePart2 {
 	public static final String ID = "ch.elexis.BBSView"; //$NON-NLS-1$
@@ -87,7 +88,7 @@ public class BBSView extends ViewPart implements ISelectionChangedListener, ISav
 		form = tk.createScrolledForm(sash);
 		form.getBody().setLayout(new GridLayout(1, false));
 		form.setText(Messages.BBSView_PleaseEnterSubject); //$NON-NLS-1$
-		origin = tk.createLabel(form.getBody(), ""); //$NON-NLS-1$
+		origin = tk.createLabel(form.getBody(), StringTool.leer); //$NON-NLS-1$
 		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 		origin.setLayoutData(gd);
 		msg = tk.createFormText(form.getBody(), false);
@@ -98,7 +99,7 @@ public class BBSView extends ViewPart implements ISelectionChangedListener, ISav
 		msg.setColor(Messages.BBSView_rot, UiDesk.getColor(UiDesk.COL_RED)); //$NON-NLS-1$
 		msg.setColor(Messages.BBSView_gruen, UiDesk.getColor(UiDesk.COL_GREEN)); //$NON-NLS-1$
 		msg.setColor(Messages.BBSView_blau, UiDesk.getColor(UiDesk.COL_BLUE)); //$NON-NLS-1$
-		input = tk.createText(form.getBody(), "", SWT.WRAP | SWT.MULTI | SWT.BORDER); //$NON-NLS-1$
+		input = tk.createText(form.getBody(), StringTool.leer, SWT.WRAP | SWT.MULTI | SWT.BORDER); //$NON-NLS-1$
 		gd = new GridData(GridData.FILL_HORIZONTAL | GridData.FILL_VERTICAL);
 		input.setLayoutData(gd);
 		Button send = tk.createButton(form.getBody(), Messages.BBSView_DoSend, SWT.PUSH); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellView.java
@@ -93,6 +93,7 @@ import ch.elexis.data.Bestellung;
 import ch.elexis.data.Kontakt;
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class BestellView extends ViewPart implements ISaveablePart2 {
 	
 	public static final String ID = "ch.elexis.BestellenView"; //$NON-NLS-1$
@@ -521,7 +522,7 @@ public class BestellView extends ViewPart implements ISaveablePart2 {
 					StringBuilder sb = new StringBuilder();
 					for (IOrderEntry noSupItem : noSupplierItems) {
 						sb.append(noSupItem.getArticle().getLabel());
-						sb.append("\n");
+						sb.append(StringTool.lf);
 					}
 					runOrder =
 						SWTHelper.askYesNo(Messages.BestellView_NoSupplierArticle, MessageFormat

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/DiagnosenDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/DiagnosenDisplay.java
@@ -292,7 +292,7 @@ public class DiagnosenDisplay extends Composite implements IUnlockable {
 	
 	private void createColumns(){
 		String[] titles = {
-			"", Messages.Display_Column_Code, Messages.Display_Column_Designation, StringTool.leer
+			StringTool.leer, Messages.Display_Column_Code, Messages.Display_Column_Designation, StringTool.leer
 		};
 		int[] weights = {
 			0, 15, 70, 15
@@ -320,7 +320,7 @@ public class DiagnosenDisplay extends Composite implements IUnlockable {
 					if (diagnosis instanceof IDiagnosisReference) {
 						IDiagnosisReference diagnosisRef = (IDiagnosisReference) element;
 						if (diagnosisRef.getReferredClass().toLowerCase().contains("freetext")) {
-							return "";
+							return StringTool.leer;
 						}
 					}
 					return diagnosis.getCode();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FaelleView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FaelleView.java
@@ -62,6 +62,7 @@ import ch.rgw.tools.ExHandler;
 /**
  * Eine alternative, platzsparendere Fälle-View
  */
+import ch.rgw.tools.StringTool;
 public class FaelleView extends ViewPart implements IRefreshable {
 	public static final String ID = "ch.elexis.schoebufaelle"; //$NON-NLS-1$
 	TableViewer tv;
@@ -261,7 +262,7 @@ public class FaelleView extends ViewPart implements IRefreshable {
 			}
 			
 		};
-		filterClosedAction = new Action("", Action.AS_CHECK_BOX) {
+		filterClosedAction = new Action(StringTool.leer, Action.AS_CHECK_BOX) {
 			private ViewerFilter closedFilter;
 			{
 				setToolTipText(Messages.FaelleView_ShowOnlyOpenCase); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
@@ -228,7 +228,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 				boolean isDisabled = BillingSystem.isDisabled(abrechungsMethodeStr);
 				IFall fall = getSelectedFall();
 				// get previously selected item/gesetz if we need to reset
-				String gesetz = ""; //$NON-NLS-1$
+				String gesetz = StringTool.leer; //$NON-NLS-1$
 				if (fall != null)
 					gesetz = fall.getAbrechnungsSystem();
 				if (ch.rgw.tools.StringTool.isNothing(gesetz))
@@ -601,7 +601,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 		cAbrechnung.setItems(Abrechnungstypen);
 		if (f == null) {
 			form.setText(Messages.FallDetailBlatt2_NoCaseSelected); //$NON-NLS-1$
-			tBezeichnung.setText("");
+			tBezeichnung.setText(StringTool.leer);
 			tBezeichnung.setMessage(Messages.FallDetailBlatt2_29);
 			cReason.select(0);
 			return;
@@ -760,7 +760,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 		String delim = StringTool.leer;
 		for (int uhi = 0; uhi < unusedHashStringArray.length; uhi++) {
 			String unusedItem = unusedHashStringArray[uhi];
-			String[] itemParts = unusedItem.split("="); //$NON-NLS-1$
+			String[] itemParts = unusedItem.split(StringTool.equals); //$NON-NLS-1$
 			String controlName = itemParts[0];
 			String[] controlDefParts = itemParts[1].split(ARGUMENTSSDELIMITER);
 			String controlType = controlDefParts[0];
@@ -813,7 +813,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 		for (int i = 0; i < arr.length; i++) {
 			String subkey = (String) arr[i];
 			String abrSystem = getSelectedFall().getAbrechnungsSystem();
-			String key = Preferences.LEISTUNGSCODES_CFG_KEY + "/" + abrSystem; //$NON-NLS-1$
+			String key = Preferences.LEISTUNGSCODES_CFG_KEY + StringTool.slash + abrSystem; //$NON-NLS-1$
 			String bed = CoreHub.globalCfg.get(key + "/bedingungen", StringTool.leer); //$NON-NLS-1$
 			boolean isAlreadyShown = false;
 			if (subkey.equalsIgnoreCase(FallConstants.FLD_EXTINFO_BILLING))
@@ -994,7 +994,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 	 * @param fieldList
 	 *            this is the fieldList from the prefs for required OR optional fields
 	 * @param TitleBarText
-	 *            if not "" and not null then show a bar-separator on top of the fields
+	 *            if not StringTool.leer and not null then show a bar-separator on top of the fields
 	 * @param deletable
 	 *            is this deletable? - show delete button
 	 *            <p>
@@ -1095,8 +1095,8 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 						// textContainer.replaceSQLClause(dummyBrief, "SQL:" +
 						// r[3]);
 						String itemsStr = (String) TextContainer.replaceSQLClause("SQL:" + r[3]); //$NON-NLS-1$
-						itemsStr = itemsStr.replaceAll("\r\n", ITEMDELIMITER); //$NON-NLS-1$
-						itemsStr = (itemsStr.replaceAll("\n", ITEMDELIMITER)).replaceAll("\r", //$NON-NLS-1$//$NON-NLS-2$
+						itemsStr = itemsStr.replaceAll(StringTool.crlf, ITEMDELIMITER); //$NON-NLS-1$
+						itemsStr = (itemsStr.replaceAll(StringTool.lf, ITEMDELIMITER)).replaceAll("\r", //$NON-NLS-1$//$NON-NLS-2$
 							ITEMDELIMITER);
 						items = itemsStr.split(ITEMDELIMITER);
 					}
@@ -1432,7 +1432,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 					@SuppressWarnings("unchecked")
 					Map<Object, Object> ht = f.getMap("extinfo"); //$NON-NLS-1$
 					if (SWTHelper.askYesNo(StringTool.leer,
-						Messages.FallDetailBlatt2_DoYouWantToDeleteThisData + key + "/" //$NON-NLS-1$
+						Messages.FallDetailBlatt2_DoYouWantToDeleteThisData + key + StringTool.slash //$NON-NLS-1$
 							+ ht.get(key) + Messages.FallDetailBlatt2_reallyFromTheCase)) { //$NON-NLS-2$ //$NON-NLS-3$
 						ht.remove(key);
 						f.setMap("extinfo", ht); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
@@ -88,6 +88,7 @@ import ch.rgw.tools.IFilter;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class FallListeView extends ViewPart implements IActivationListener, ISaveablePart2 {
 	private static boolean noPatientHandled = true;
 	public static final String ID = "ch.elexis.FallListeView"; //$NON-NLS-1$
@@ -114,7 +115,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 			setFall(f, null);
 		}
 	};
-	private IAction filterClosedAction = new Action("", Action.AS_CHECK_BOX) {
+	private IAction filterClosedAction = new Action(StringTool.leer, Action.AS_CHECK_BOX) {
 		private ViewerFilter closedFilter;
 		{
 			setToolTipText(Messages.FaelleView_ShowOnlyOpenCase);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FavoritenComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FavoritenComposite.java
@@ -53,6 +53,7 @@ import ch.elexis.data.PersistentObject;
 import ch.elexis.data.VerrechenbarFavorites;
 import ch.elexis.data.VerrechenbarFavorites.Favorite;
 
+import ch.rgw.tools.StringTool;
 public class FavoritenComposite extends Composite {
 	
 	private TableViewer tv;
@@ -273,7 +274,7 @@ public class FavoritenComposite extends Composite {
 	private class ColorizedLabelProvider extends LabelProvider implements IColorProvider {
 		@Override
 		public String getText(Object element){
-			return "";
+			return StringTool.leer;
 		}
 		
 		@Override

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FieldDisplayView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FieldDisplayView.java
@@ -76,7 +76,7 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 		form = tk.createScrolledForm(parent);
 		form.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 		form.getBody().setLayout(new GridLayout());
-		text = tk.createText(form.getBody(), "", SWT.MULTI | SWT.V_SCROLL); //$NON-NLS-1$
+		text = tk.createText(form.getBody(), StringTool.leer, SWT.MULTI | SWT.V_SCROLL); //$NON-NLS-1$
 		text.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 		text.addFocusListener(new FocusAdapter() {
 			
@@ -156,7 +156,7 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 							text.setText(po.get(myField));
 						}
 					} else if (ev.getType() == ElexisEvent.EVENT_DESELECTED) {
-						text.setText(""); //$NON-NLS-1$
+						text.setText(StringTool.leer); //$NON-NLS-1$
 						
 					}
 					

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
@@ -51,6 +51,7 @@ import ch.elexis.data.Konsultation;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class HistoryDisplay extends Composite implements BackgroundJobListener,
 		ElexisEventListener {
 	FormText text;
@@ -225,7 +226,7 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 								true);
 						}
 					} else {
-						text.setText(ContextServiceHolder.get().getActivePatient().orElse(null) != null ? ""
+						text.setText(ContextServiceHolder.get().getActivePatient().orElse(null) != null ? StringTool.leer
 								: Messages.HistoryDisplay_NoPatientSelected,
 							false, false);
 					}
@@ -244,7 +245,7 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 						+ " bis " + toDate
 						+ "</span></p>";
 				}
-				return "";
+				return StringTool.leer;
 				
 			}
 		});

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsDetailView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsDetailView.java
@@ -613,7 +613,7 @@ public class KonsDetailView extends ViewPart
 				if (biller.getId().equals(mandator.getId())) {
 					sb.append("(").append(mandator.getDescription3()).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
 				} else {
-					sb.append("(").append(mandator.getDescription3()).append("/").append( //$NON-NLS-1$ //$NON-NLS-2$
+					sb.append("(").append(mandator.getDescription3()).append(StringTool.slash).append( //$NON-NLS-1$ //$NON-NLS-2$
 						biller.getDescription3()).append(")"); //$NON-NLS-1$
 				}
 				hlMandant
@@ -632,7 +632,7 @@ public class KonsDetailView extends ViewPart
 			diagnosesDisplay.setEnabled(true);
 			if (BillingServiceHolder.get().isEditable(encounter).isOK()) {
 				text.setEnabled(true);
-				text.setToolTipText("");
+				text.setToolTipText(StringTool.leer);
 				lBeh.setForeground(UiDesk.getColor(UiDesk.COL_BLACK));
 				lBeh.setBackground(defaultBackground);
 			} else {
@@ -653,7 +653,7 @@ public class KonsDetailView extends ViewPart
 			hlMandant.setBackground(hlMandant.getParent().getBackground());
 			diagnosesDisplay.clear();
 			billedDisplay.clear();
-			text.setText(""); //$NON-NLS-1$
+			text.setText(StringTool.leer); //$NON-NLS-1$
 			text.setEnabled(false);
 			billedDisplay.setEnabled(false);
 			diagnosesDisplay.setEnabled(false);
@@ -679,7 +679,7 @@ public class KonsDetailView extends ViewPart
 	}
 	
 	void setKonsText(final IEncounter encounter, final int version){
-		String ntext = ""; //$NON-NLS-1$
+		String ntext = StringTool.leer; //$NON-NLS-1$
 		if ((version >= 0) && (version <= encounter.getVersionedEntry().getHeadVersion())) {
 			VersionedResource vr = encounter.getVersionedEntry();
 			ResourceItem entry = vr.getVersion(version);
@@ -691,7 +691,7 @@ public class KonsDetailView extends ViewPart
 				.append(" (").append(entry.remark).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
 			versionDisplayAction.setText(sb.toString());
 		} else {
-			versionDisplayAction.setText("");
+			versionDisplayAction.setText(StringTool.leer);
 		}
 		text.setText(ntext);
 		text.setKons(encounter);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ODDBView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ODDBView.java
@@ -79,7 +79,7 @@ public class ODDBView extends ViewPart implements ISaveablePart2 {
 			return ret.toString();
 		} catch (IOException e) {
 			ExHandler.handle(e);
-			return "";
+			return StringTool.leer;
 		}
 	}
 	

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
@@ -295,15 +295,15 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 		Composite bottom = form.getBody();
 		bottom.setLayout(new GridLayout(2, false));
 		tk.createLabel(bottom, Messages.PatHeuteView_consultations); //$NON-NLS-1$
-		tPat = tk.createText(bottom, "", SWT.BORDER); //$NON-NLS-1$
+		tPat = tk.createText(bottom, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		tPat.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tPat.setEditable(false);
 		tk.createLabel(bottom, Messages.PatHeuteView_accTime); //$NON-NLS-1$
-		tTime = tk.createText(bottom, "", SWT.BORDER); //$NON-NLS-1$
+		tTime = tk.createText(bottom, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		tTime.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tTime.setEditable(false);
 		tk.createLabel(bottom, Messages.PatHeuteView_accAmount); //$NON-NLS-1$
-		tMoney = tk.createText(bottom, "", SWT.BORDER); //$NON-NLS-1$
+		tMoney = tk.createText(bottom, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		tMoney.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tMoney.setEditable(false);
 		// Group grpSel=new Group(parent,SWT.BORDER);
@@ -315,10 +315,10 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 		Composite cSel = fSel.getBody();
 		cSel.setLayout(new GridLayout(2, false));
 		tk.createLabel(cSel, Messages.PatHeuteView_accTime); //$NON-NLS-1$
-		tTime2 = tk.createText(cSel, "", SWT.BORDER); //$NON-NLS-1$
+		tTime2 = tk.createText(cSel, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		tTime2.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tk.createLabel(cSel, Messages.PatHeuteView_accAmount); //$NON-NLS-1$
-		tMoney2 = tk.createText(cSel, "", SWT.BORDER); //$NON-NLS-1$
+		tMoney2 = tk.createText(cSel, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		tMoney2.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		tTime2.setEditable(false);
 		tMoney2.setEditable(false);
@@ -365,8 +365,8 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 	
 	private void selection(final Konsultation k){
 		if (k == null) {
-			tTime2.setText("");
-			tMoney2.setText("");
+			tTime2.setText(StringTool.leer);
+			tMoney2.setText(StringTool.leer);
 		} else {
 			try {
 				tTime2.setText(Integer.toString(k.getMinutes()));
@@ -482,7 +482,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 									text = st.v.getText();
 								}
 								if (text == null) {
-									text = ""; //$NON-NLS-1$
+									text = StringTool.leer; //$NON-NLS-1$
 								} else {
 									text = text.replaceAll(";", ","); //$NON-NLS-1$ //$NON-NLS-2$
 								}
@@ -492,12 +492,12 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 									sb.append("Codesystem?");
 								}
 								sb.append("; ").append( //$NON-NLS-1$
-									code == null ? "" : code) //$NON-NLS-1$
+									code == null ? StringTool.leer : code) //$NON-NLS-1$
 									.append("; ").append(text).append(";") //$NON-NLS-1$ //$NON-NLS-2$
 									.append(st.num).append(";").append( //$NON-NLS-1$
 										st.cost.getAmountAsString()).append(";").append( //$NON-NLS-1$
 										st.sum.getAmountAsString()).append(";").append( //$NON-NLS-1$
-										st.getGewinn().getAmountAsString()).append("\r\n"); //$NON-NLS-1$
+										st.getGewinn().getAmountAsString()).append(StringTool.crlf); //$NON-NLS-1$
 								fw.write(sb.toString());
 							}
 							fw.close();
@@ -653,16 +653,16 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 				sb.append("Folgende Konsultationen enthalten ungültige Leistungen: \n");
 				for (Konsultation k : corruptKons) {
 					sb.append(k.getLabel() + ", " + k.getFall().getPatient().getLabel());
-					sb.append("\n");
+					sb.append(StringTool.lf);
 				}
-				sb.append("\n");
+				sb.append(StringTool.lf);
 			}
 			
 			if (missingCaseKons.size() > 0) {
 				sb.append("Folgende Konsultationen sind keinem Fall zugewiesen: \n");
 				for (Konsultation k : missingCaseKons) {
 					sb.append(k.getLabel());
-					sb.append("\n");
+					sb.append(StringTool.lf);
 				}
 			}
 			
@@ -857,7 +857,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			for (int i = 0; i < kons.length; i++) {
 				table[i + 1] = new String[2];
 				Konsultation k = kons[i];
-				table[i + 1][0] = k.getFall().getPatient().getLabel() + "\n" //$NON-NLS-1$
+				table[i + 1][0] = k.getFall().getPatient().getLabel() + StringTool.lf //$NON-NLS-1$
 					+ k.getLabel();
 				StringBuilder sb = new StringBuilder();
 				List<Verrechnet> lstg = k.getLeistungen();
@@ -874,8 +874,8 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 						}
 					}
 					subsum.addMoney(preis);
-					sb.append(num).append(" ").append(v.getLabel()).append(" ") //$NON-NLS-1$ //$NON-NLS-2$
-						.append(preis.getAmountAsString()).append("\n"); //$NON-NLS-1$
+					sb.append(num).append(StringTool.space).append(v.getLabel()).append(StringTool.space) //$NON-NLS-1$ //$NON-NLS-2$
+						.append(preis.getAmountAsString()).append(StringTool.lf); //$NON-NLS-1$
 				}
 				sb.append(Messages.PatHeuteView_total).append(subsum.getAmountAsString()); //$NON-NLS-1$
 				total.addMoney(subsum);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
@@ -95,6 +95,7 @@ import ch.elexis.data.Reminder;
 import ch.rgw.io.Settings;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ReminderView extends ViewPart implements IActivationListener, HeartListener {
 	
 	public static final String ID = "ch.elexis.reminderview"; //$NON-NLS-1$
@@ -165,7 +166,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 						if (list.size() != 0) {
 							StringBuilder sb = new StringBuilder();
 							for (Reminder r : list) {
-								sb.append(r.getSubject() + "\n");
+								sb.append(r.getSubject() + StringTool.lf);
 								sb.append(r.getMessage() + "\n\n");
 							}
 							SWTHelper.alert(Messages.ReminderView_importantRemindersCaption,
@@ -891,7 +892,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 		private void applyDueDateFilter(Query<Reminder> qbe){
 			TimeTool dueDateDays = new TimeTool();
 			dueDateDays.addDays(filterDueDateDays);
-			qbe.add(Reminder.FLD_DUE, Query.NOT_EQUAL, "");
+			qbe.add(Reminder.FLD_DUE, Query.NOT_EQUAL, StringTool.leer);
 			qbe.add(Reminder.FLD_DUE, Query.LESS_OR_EQUAL,
 				dueDateDays.toString(TimeTool.DATE_COMPACT));
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezeptBlatt.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezeptBlatt.java
@@ -118,7 +118,7 @@ public class RezeptBlatt extends ViewPart implements ICallback, IActivationListe
 		actBrief =
 			text.createFromTemplateName(Konsultation.getAktuelleKons(), template, Brief.RP,
 				(Patient) ElexisEventDispatcher.getSelected(Patient.class),
-				template + " " + rp.getDate());
+				template + StringTool.space + rp.getDate());
 		updateTextLock();
 		List<Prescription> lines = rp.getLines();
 		String[][] fields = new String[lines.size()][];
@@ -159,7 +159,7 @@ public class RezeptBlatt extends ViewPart implements ICallback, IActivationListe
 		TimeTool now = new TimeTool();
 		actBrief = text.createFromTemplateName(Konsultation.getAktuelleKons(), template,
 			Brief.UNKNOWN, (Patient) ElexisEventDispatcher.getSelected(Patient.class),
-			template + " " + now.toString(TimeTool.DATE_GER));
+			template + StringTool.space + now.toString(TimeTool.DATE_GER));
 		updateTextLock();
 		List<Prescription> lines = Arrays.asList(prescriptions);
 		String[][] fields = new String[lines.size()][];

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezepteView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezepteView.java
@@ -94,6 +94,7 @@ import ch.rgw.tools.ExHandler;
  * 
  * @author Gerry
  */
+import ch.rgw.tools.StringTool;
 public class RezepteView extends ViewPart implements IActivationListener, ISaveablePart2 {
 	public static final String ID = "ch.elexis.Rezepte"; //$NON-NLS-1$
 	private final FormToolkit tk = UiDesk.getToolkit();
@@ -261,9 +262,9 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 							IArticle art = (IArticle) obj;
 							IPrescription ret =
 								new IPrescriptionBuilder(CoreModelServiceHolder.get(),
-									ContextServiceHolder.get(), art, recipe.getPatient(), "")
+									ContextServiceHolder.get(), art, recipe.getPatient(), StringTool.leer)
 										.build();
-							ret.setRemark("");
+							ret.setRemark(StringTool.leer);
 							ret.setEntryType(EntryType.RECIPE);
 							ret.setRecipe(recipe);
 							CoreModelServiceHolder.get().save(ret);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ScriptView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ScriptView.java
@@ -62,6 +62,7 @@ import ch.rgw.tools.ExHandler;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class ScriptView extends ViewPart {
 	public static final String ID = "ch.elexis.scriptsView"; //$NON-NLS-1$
 	private IAction newScriptAction, editScriptAction, removeScriptAction, execScriptAction,
@@ -203,7 +204,7 @@ public class ScriptView extends ViewPart {
 							null);
 					if (inp.open() == Dialog.OK) {
 						try {
-							Script.create(inp.getValue(), "");
+							Script.create(inp.getValue(), StringTool.leer);
 						} catch (ElexisException e) {
 							ExHandler.handle(e);
 							SWTHelper.showError("Fehler bei Scripterstellung", e.getMessage());
@@ -338,7 +339,7 @@ public class ScriptView extends ViewPart {
 			for (Text text : inputs) {
 				String varname = (String) text.getData("varname");
 				String varcontents = text.getText();
-				sb.append(varname).append("=").append(varcontents).append(",");
+				sb.append(varname).append(StringTool.equals).append(varcontents).append(",");
 			}
 			sb.deleteCharAt(sb.length() - 1);
 			result = sb.toString();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/SearchView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/SearchView.java
@@ -154,7 +154,7 @@ public class SearchView extends ViewPart implements ISaveablePart2 {
 				if (element instanceof PersistentObject) {
 					PersistentObject po = (PersistentObject) element;
 					String type = "?"; //$NON-NLS-1$
-					String label = ""; //$NON-NLS-1$
+					String label = StringTool.leer; //$NON-NLS-1$
 					if (po instanceof Konsultation) {
 						type = Messages.SearchView_consultation; //$NON-NLS-1$
 						

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/StockView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/StockView.java
@@ -103,6 +103,7 @@ import ch.elexis.scripting.CSVWriter;
 import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.Money;
 
+import ch.rgw.tools.StringTool;
 public class StockView extends ViewPart implements ISaveablePart2, IActivationListener {
 	public StockView(){}
 	
@@ -167,7 +168,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 			}
 		});
 		ToolBarManager tbm = new ToolBarManager();
-		tbm.add(new Action("", Action.AS_CHECK_BOX) {
+		tbm.add(new Action(StringTool.leer, Action.AS_CHECK_BOX) {
 			@Override
 			public ImageDescriptor getImageDescriptor(){
 				return Images.IMG_FILTER.getImageDescriptor();
@@ -457,7 +458,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 							msg.append(success);
 							msg.append(" Artikel wurden erfolgreich exportiert.");
 							if (errorUnkownArticle > 0) {
-								msg.append("\n");
+								msg.append(StringTool.lf);
 								msg.append(errorUnkownArticle);
 								msg.append(
 									" Artikel konnten nicht exportiert werden (Unbekannte Artikel Typen).");

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TextView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TextView.java
@@ -60,6 +60,7 @@ import ch.rgw.io.FileTool;
 import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.MimeTool;
 
+import ch.rgw.tools.StringTool;
 public class TextView extends ViewPart implements IActivationListener {
 	public final static String ID = "ch.elexis.TextView"; //$NON-NLS-1$
 	TextContainer txt;
@@ -334,7 +335,7 @@ public class TextView extends ViewPart implements IActivationListener {
 							});
 							String filename = fdl.open();
 							if (filename != null) {
-								if (FileTool.getExtension(filename).equals("")) { //$NON-NLS-1$
+								if (FileTool.getExtension(filename).equals(StringTool.leer)) { //$NON-NLS-1$
 									filename += ".odt"; //$NON-NLS-1$
 								}
 								File file = new File(filename);
@@ -422,7 +423,7 @@ public class TextView extends ViewPart implements IActivationListener {
 			log.debug("TextView.saveAs"); //$NON-NLS-1$
 			InputDialog il =
 				new InputDialog(getViewSite().getShell(), Messages.TextView_saveText,
-					Messages.TextView_enterTitle, "", null); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					Messages.TextView_enterTitle, StringTool.leer, null); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			if (il.open() == Dialog.OK) {
 				actBrief.setBetreff(il.getValue());
 				return actBrief.save(txt.getPlugin().storeToByteArray(), txt.getPlugin()
@@ -452,7 +453,7 @@ public class TextView extends ViewPart implements IActivationListener {
 	}
 	
 	void setName(){
-		String n = ""; //$NON-NLS-1$
+		String n = StringTool.leer; //$NON-NLS-1$
 		if (actBrief == null) {
 			setPartName(Messages.TextView_noLetterSelected); //$NON-NLS-1$
 		} else {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
@@ -217,7 +217,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 		newAction.setToolTipText(Messages.VerrechnungsDisplay_AddItem);
 		toolBarManager.add(newAction);
 
-		toolBarManager.add(new Action("", Action.AS_CHECK_BOX) {
+		toolBarManager.add(new Action(StringTool.leer, Action.AS_CHECK_BOX) {
 			
 			@Override
 			public ImageDescriptor getImageDescriptor(){
@@ -358,7 +358,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 			
 			@Override
 			public String getText(Object element){
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override
@@ -381,7 +381,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					IBilled billed = (IBilled) element;
 					return Double.toString(billed.getAmount());
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		
@@ -393,7 +393,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					IBilled billed = (IBilled) element;
 					return getServiceCode(billed);
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		
@@ -405,7 +405,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					IBilled billed = (IBilled) element;
 					return billed.getText();
 				}
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override
@@ -427,7 +427,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					Money price = billed.getTotal();
 					return price.getAmountAsString();
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		
@@ -435,7 +435,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 		col.setLabelProvider(new ColumnLabelProvider() {
 			@Override
 			public String getText(Object element){
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override
@@ -499,7 +499,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					Messages.VerrechnungsDisplay_Amount, sum.getAmountAsString(),
 					Messages.VerrechnungsDisplay_Time, sumMinutes));
 		} else {
-			billedLabel.setText("");
+			billedLabel.setText(StringTool.leer);
 		}
 		layout();
 	}
@@ -527,7 +527,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 					StringBuilder sb = new StringBuilder();
 					diff.forEach(r -> {
 						if (sb.length() > 0) {
-							sb.append("\n");
+							sb.append(StringTool.lf);
 						}
 						sb.append(r);
 					});
@@ -662,7 +662,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 							StringBuilder sb = new StringBuilder();
 							diff.forEach(r -> {
 								if (sb.length() > 0) {
-									sb.append("\n");
+									sb.append(StringTool.lf);
 								}
 								sb.append(r);
 							});
@@ -730,7 +730,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 			if (billable instanceof ICustomService || (billable instanceof IArticle
 				&& ((IArticle) billable).getTyp() == ArticleTyp.EIGENARTIKEL)) {
 				if (billable.getId().equals(ret)) {
-					ret = "";
+					ret = StringTool.leer;
 				}
 			}
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/artikel/ArtikelContextMenu.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/artikel/ArtikelContextMenu.java
@@ -29,6 +29,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.viewers.CommonViewer;
 import ch.elexis.data.Artikel;
 
+import ch.rgw.tools.StringTool;
 public class ArtikelContextMenu {
 	private IAction deleteAction, createAction, editAction;
 	CommonViewer cv;
@@ -96,10 +97,10 @@ public class ArtikelContextMenu {
 				InputDialog inp =
 					new InputDialog(cv.getViewerWidget().getControl().getShell(), art.getClass()
 						.getName() + Messages.ArtikelContextMenu_create,
-						Messages.ArtikelContextMenu_pleaseEnterNameForArticle, "", null); //$NON-NLS-1$
+						Messages.ArtikelContextMenu_pleaseEnterNameForArticle, StringTool.leer, null); //$NON-NLS-1$
 				if (inp.open() == InputDialog.OK) {
 					String name = inp.getValue();
-					Artikel n = new Artikel(name, art.getCodeSystemName(), ""); //$NON-NLS-1$
+					Artikel n = new Artikel(name, art.getCodeSystemName(), StringTool.leer); //$NON-NLS-1$
 					if (add == null) {
 						EditEigenartikelUi.executeWithParams(n);
 					} else {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/BlockDetailDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/BlockDetailDisplay.java
@@ -405,7 +405,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 					BlockElementViewerItem item = (BlockElementViewerItem) element;
 					return Integer.toString(item.getCount());
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		
@@ -417,7 +417,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 					BlockElementViewerItem item = (BlockElementViewerItem) element;
 					return item.getCode();
 				}
-				return "";
+				return StringTool.leer;
 			}
 		});
 		
@@ -429,7 +429,7 @@ public class BlockDetailDisplay implements IDetailDisplay {
 					BlockElementViewerItem item = (BlockElementViewerItem) element;
 					return item.getText();
 				}
-				return "";
+				return StringTool.leer;
 			}
 			
 			@Override

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/CodeSelectorFactory.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/codesystems/CodeSelectorFactory.java
@@ -82,6 +82,7 @@ import ch.rgw.tools.ExHandler;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public abstract class CodeSelectorFactory implements IExecutableExtension {
 	private static final String CAPTION_ERROR = Messages.CodeSelectorFactory_error; //$NON-NLS-1$
 	/** Anzahl der in den oberen zwei Listen zu haltenden Elemente */
@@ -525,7 +526,7 @@ public abstract class CodeSelectorFactory implements IExecutableExtension {
 							StringBuilder sb = new StringBuilder();
 							diff.forEach(r -> {
 								if (sb.length() > 0) {
-									sb.append("\n");
+									sb.append(StringTool.lf);
 								}
 								sb.append(r);
 							});

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ArticleDefaultSignatureComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ArticleDefaultSignatureComposite.java
@@ -41,6 +41,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.CreatePrescriptionHelper;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class ArticleDefaultSignatureComposite extends Composite {
 	
 	private WritableValue<IArticleDefaultSignature> signatureItem =
@@ -122,7 +123,7 @@ public class ArticleDefaultSignatureComposite extends Composite {
 		compositeDayTimeDosage.setLayout(layout);
 		txtSignatureMorning = new Text(compositeDayTimeDosage, SWT.BORDER);
 		txtSignatureMorning.setMessage(Messages.ArticleDefaultSignatureComposite_morning);
-		txtSignatureMorning.setToolTipText(""); //$NON-NLS-1$
+		txtSignatureMorning.setToolTipText(StringTool.leer); //$NON-NLS-1$
 		txtSignatureMorning.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		
 		Label label = new Label(compositeDayTimeDosage, SWT.None);
@@ -168,7 +169,7 @@ public class ArticleDefaultSignatureComposite extends Composite {
 					stackLayoutDosage.topControl = compositeFreeTextDosage;
 				} else {
 					stackLayoutDosage.topControl = compositeDayTimeDosage;
-					txtFreeTextDosage.setText(""); //$NON-NLS-1$
+					txtFreeTextDosage.setText(StringTool.leer); //$NON-NLS-1$
 				}
 				stackCompositeDosage.layout();
 			};
@@ -225,7 +226,7 @@ public class ArticleDefaultSignatureComposite extends Composite {
 		lblCalcEndDate.setText("(" + Messages.ArticleDefaultSignatureComposite_date_none + ")");
 		lblCalcEndDate.setData(null);
 		Text txtEnddate = new Text(compositeMedicationTypeDetail, SWT.BORDER | SWT.CENTER);
-		txtEnddate.setText("");
+		txtEnddate.setText(StringTool.leer);
 		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
 		gd.widthHint = 30;
 		txtEnddate.setLayoutData(gd);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ClientCustomTextComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ClientCustomTextComposite.java
@@ -48,6 +48,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.data.Kontakt;
 import ch.elexis.data.Patient;
 
+import ch.rgw.tools.StringTool;
 public class ClientCustomTextComposite extends Composite {
 	
 	private StyledText txtClientCustomText;
@@ -132,7 +133,7 @@ public class ClientCustomTextComposite extends Composite {
 			}
 		});
 		
-		btnEditCustomText = toolkit.createButton(this, "", SWT.TOGGLE);
+		btnEditCustomText = toolkit.createButton(this, StringTool.leer, SWT.TOGGLE);
 		TableWrapData twd_btnEditCustomText =
 			new TableWrapData(TableWrapData.LEFT, TableWrapData.TOP, 1, 1);
 		twd_btnEditCustomText.valign = TableWrapData.MIDDLE;
@@ -166,7 +167,7 @@ public class ClientCustomTextComposite extends Composite {
 		if (editMode) {
 			// Edit the variable usage
 			txtClientCustomText.setText(CoreHub.globalCfg.get(
-				ClientCustomTextComposite.class.getName(), ""));
+				ClientCustomTextComposite.class.getName(), StringTool.leer));
 		} else {
 			CoreHub.globalCfg.set(ClientCustomTextComposite.class.getName(),
 				txtClientCustomText.getText());
@@ -180,7 +181,7 @@ public class ClientCustomTextComposite extends Composite {
 		styleList.clear();
 		String outputParsed =
 			findAndReplaceTemplates(CoreHub.globalCfg.get(
-				ClientCustomTextComposite.class.getName(), ""));
+				ClientCustomTextComposite.class.getName(), StringTool.leer));
 		String output = initializeStyleRanges(outputParsed);
 		txtClientCustomText.setText(output);
 		txtClientCustomText.setStyleRanges(styleList.toArray(new StyleRange[0]));
@@ -294,12 +295,12 @@ public class ClientCustomTextComposite extends Composite {
 			return "ERR";
 		if (arr[0].equalsIgnoreCase("Patient")) {
 			if (arr[1] == null)
-				return "";
+				return StringTool.leer;
 			Patient pat = ElexisEventDispatcher.getSelectedPatient();
 			if (pat == null)
-				return "";
+				return StringTool.leer;
 			String result = pat.get(arr[1]);
-			return (result != null) ? result : "";
+			return (result != null) ? result : StringTool.leer;
 		} else {
 			return "ERR";
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ClientCustomTextTokenEditDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/ClientCustomTextTokenEditDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Text;
 import ch.elexis.core.data.events.ElexisEventDispatcher;
 import ch.elexis.data.Patient;
 
+import ch.rgw.tools.StringTool;
 public class ClientCustomTextTokenEditDialog extends TitleAreaDialog {
 	
 	String _token;
@@ -79,12 +80,12 @@ public class ClientCustomTextTokenEditDialog extends TitleAreaDialog {
 			Patient pat = ElexisEventDispatcher.getSelectedPatient();
 			
 			if (arr[1] == null || pat == null) {
-				txtTokenText.setText("");
+				txtTokenText.setText(StringTool.leer);
 				return area;
 			}
 
 			String result = pat.get(arr[1]);
-			txtTokenText.setText((result != null) ? result : "");
+			txtTokenText.setText((result != null) ? result : StringTool.leer);
 		} 
 		
 		return area;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/GenericSelectionComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/GenericSelectionComposite.java
@@ -44,6 +44,7 @@ import ch.elexis.data.PersistentObject;
  * @author thomas
  *
  */
+import ch.rgw.tools.StringTool;
 public class GenericSelectionComposite extends Composite implements ISelectionProvider {
 	
 	private ListenerList selectionListeners = new ListenerList();
@@ -103,7 +104,7 @@ public class GenericSelectionComposite extends Composite implements ISelectionPr
 			}
 			selectLabel.setText(sb.toString());
 		} else {
-			selectLabel.setText("");
+			selectLabel.setText(StringTool.leer);
 		}
 		getParent().layout();
 	}
@@ -229,7 +230,7 @@ public class GenericSelectionComposite extends Composite implements ISelectionPr
 			} else if (object != null) {
 				return object.toString();
 			} else {
-				return "";
+				return StringTool.leer;
 			}
 		}
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/InteractionLink.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/InteractionLink.java
@@ -24,6 +24,7 @@ import ch.elexis.core.model.IArticle;
 import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.data.Interaction;
 
+import ch.rgw.tools.StringTool;
 public class InteractionLink {
 	
 	/**
@@ -31,7 +32,7 @@ public class InteractionLink {
 	 */
 	private Link interactionLink = null;
 	static Logger logger = LoggerFactory.getLogger(InteractionLink.class);
-	private String destUrl = "";
+	private String destUrl = StringTool.leer;
 	private static int lastUpTime;
 
 	public InteractionLink(Composite parent, int style){
@@ -45,23 +46,23 @@ public class InteractionLink {
 	}
 	
 	private void setSuppressed() {
-		interactionLink.setText(""); //$NON-NLS-1$
+		interactionLink.setText(StringTool.leer); //$NON-NLS-1$
 		interactionLink.setToolTipText(Messages.SuppressInteractionCheckTooltip);
 		interactionLink.setForeground(UiDesk.getColorRegistry().get(UiDesk.COL_BLACK));
 
 	}
 	
 	public String updateAtcs(List<IArticle> gtins){
-		interactionLink.setText(""); //$NON-NLS-1$
+		interactionLink.setText(StringTool.leer); //$NON-NLS-1$
 		if (CoreHub.userCfg.get(Preferences.USR_SUPPRESS_INTERACTION_CHECK, true)) {
 			setSuppressed();
-			return ""; //$NON-NLS-1$
+			return StringTool.leer; //$NON-NLS-1$
 		}
 
-		String severity = " "; //$NON-NLS-1$
+		String severity = StringTool.space; //$NON-NLS-1$
 		Color color = UiDesk.getColor(UiDesk.COL_WHITE);
 		String epha = Messages.VerrDetailDialog_InteractionEpha;
-		String tooltip = ""; //$NON-NLS-1$
+		String tooltip = StringTool.leer; //$NON-NLS-1$
 		StringBuilder buildUrl = new StringBuilder(Messages.VerrDetailDialog_InteractionBaseURL);
 		
 		ArrayList<String> atcs = new ArrayList<String>();
@@ -74,10 +75,10 @@ public class InteractionLink {
 			}
 		});
 		if (atcs.size() > 1) {
-			destUrl = buildUrl.toString().replaceAll(",+$", "");
+			destUrl = buildUrl.toString().replaceAll(",+$", StringTool.leer);
 			logger.info("For {} ATCs {} set destUrl to {}", atcs.size(), atcs, destUrl);
 		} else {
-			destUrl = "";
+			destUrl = StringTool.leer;
 		}
 		
 		// Reset tooltip text and color to nothing
@@ -136,7 +137,7 @@ public class InteractionLink {
 					}
 				}
 			});
-			if (!severity.contentEquals(" ")) {//$NON-NLS-1$
+			if (!severity.contentEquals(StringTool.space)) {//$NON-NLS-1$
 				color = UiDesk.getColorFromRGB(Interaction.Colors.get(severity));
 				interactionLink.setText(epha + ": " + Interaction.Ratings.get(severity)); //$NON-NLS-1$
 				interactionLink.setBackground(color);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/KontaktSelectionComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/KontaktSelectionComposite.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Label;
 import ch.elexis.core.ui.dialogs.KontaktSelektor;
 import ch.elexis.data.Kontakt;
 
+import ch.rgw.tools.StringTool;
 public class KontaktSelectionComposite extends Composite implements ISelectionProvider {
 	
 	private ListenerList selectionListeners = new ListenerList();
@@ -94,7 +95,7 @@ public class KontaktSelectionComposite extends Composite implements ISelectionPr
 			});
 			selectLabel.setText(sb.toString());
 		} else {
-			selectLabel.setText(""); //$NON-NLS-1$
+			selectLabel.setText(StringTool.leer); //$NON-NLS-1$
 		}
 		getParent().layout();
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/PagingComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/PagingComposite.java
@@ -22,6 +22,7 @@ import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.icons.Images;
 import ch.elexis.core.ui.util.SWTHelper;
 
+import ch.rgw.tools.StringTool;
 public abstract class PagingComposite extends Composite {
 	private int currentPage;
 	private volatile boolean isLazyLoadingBusy;
@@ -49,7 +50,7 @@ public abstract class PagingComposite extends Composite {
 		
 		ToolBar toolBar = new ToolBar(main, SWT.RIGHT | SWT.FLAT);
 		ToolItem prevToolItem = new ToolItem(toolBar, SWT.PUSH);
-		prevToolItem.setToolTipText("");
+		prevToolItem.setToolTipText(StringTool.leer);
 		prevToolItem.setImage(Images.IMG_PREVIOUS.getImage());
 		prevToolItem.addSelectionListener(new SelectionAdapter() {
 			
@@ -60,11 +61,11 @@ public abstract class PagingComposite extends Composite {
 		});
 		
 		textToolItem = new ToolItem(toolBar, SWT.PUSH | SWT.CENTER);
-		textToolItem.setToolTipText("");
-		textToolItem.setText("");
+		textToolItem.setToolTipText(StringTool.leer);
+		textToolItem.setText(StringTool.leer);
 		
 		ToolItem nextToolItem = new ToolItem(toolBar, SWT.PUSH);
-		nextToolItem.setToolTipText("");
+		nextToolItem.setToolTipText(StringTool.leer);
 		nextToolItem.setImage(Images.IMG_NEXT.getImage());
 		nextToolItem.addSelectionListener(new SelectionAdapter() {
 			
@@ -108,7 +109,7 @@ public abstract class PagingComposite extends Composite {
 		if (!isDisposed()) {
 			setVisible(currentPage > 0);
 			if (textToolItem != null) {
-				textToolItem.setText(currentPage + "/" + maxPage);
+				textToolItem.setText(currentPage + StringTool.slash + maxPage);
 				textToolItem.setToolTipText("Gesamtanzahl: " + elementsCount);
 			}
 			

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/StockDetailComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/controls/StockDetailComposite.java
@@ -50,6 +50,7 @@ import ch.elexis.core.model.IStockEntry;
 import ch.elexis.core.ui.editors.ContactSelectionDialogCellEditor;
 import ch.elexis.core.ui.util.CoreUiUtil;
 
+import ch.rgw.tools.StringTool;
 public class StockDetailComposite extends Composite {
 	
 	private WritableValue<IArticle> wvArtikel = new WritableValue<>(null, IArticle.class);
@@ -438,11 +439,11 @@ public class StockDetailComposite extends Composite {
 		protected Object getValue(Object element){
 			IStock stock = (IStock) element;
 			if (stock == null || wvArtikel.getValue() == null) {
-				return "";
+				return StringTool.leer;
 			}
 			IStockEntry se = stockEntries.get(stock);
 			if (se == null) {
-				return "";
+				return StringTool.leer;
 			}
 			
 			int value = 0;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/provider/StockEntryLabelProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/provider/StockEntryLabelProvider.java
@@ -20,6 +20,7 @@ import ch.elexis.core.ui.icons.Images;
 import ch.elexis.data.Mandant;
 import ch.elexis.data.StockEntry;
 
+import ch.rgw.tools.StringTool;
 public class StockEntryLabelProvider extends LabelProvider
 		implements ITableLabelProvider, ITableColorProvider {
 	
@@ -48,15 +49,15 @@ public class StockEntryLabelProvider extends LabelProvider
 						return code;
 					}
 				}
-				return "";
+				return StringTool.leer;
 			case 2:
-				return (article != null) ? article.getGtin() : "";
+				return (article != null) ? article.getGtin() : StringTool.leer;
 			case 3:
-				return (article != null) ? article.getLabel() : "";
+				return (article != null) ? article.getLabel() : StringTool.leer;
 			case 4:
 				return (article != null && article.getSellingPrice() != null)
 						? article.getSellingPrice().toString()
-						: "";
+						: StringTool.leer;
 			case 5:
 				return Integer.toString(se.getMinimumStock());
 			case 6:

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/AccountListView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/AccountListView.java
@@ -52,6 +52,7 @@ import ch.rgw.tools.Money;
  * TODO reloading the list is not yet possible
  */
 
+import ch.rgw.tools.StringTool;
 public class AccountListView extends ViewPart implements IActivationListener, ISaveablePart2 {
 	
 	public static final String ID = "ch.elexis.views.rechnung.AccountListView"; //$NON-NLS-1$
@@ -147,11 +148,11 @@ public class AccountListView extends ViewPart implements IActivationListener, IS
 			
 			public String getColumnText(Object element, int columnIndex){
 				if (!(element instanceof AccountListEntry)) {
-					return ""; //$NON-NLS-1$
+					return StringTool.leer; //$NON-NLS-1$
 				}
 				
 				AccountListEntry entry = (AccountListEntry) element;
-				String text = ""; //$NON-NLS-1$
+				String text = StringTool.leer; //$NON-NLS-1$
 				
 				switch (columnIndex) {
 				case NAME:

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/AccountView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/AccountView.java
@@ -68,6 +68,7 @@ import ch.rgw.tools.TimeTool;
  * This view shows the current patient's account
  */
 
+import ch.rgw.tools.StringTool;
 public class AccountView extends ViewPart implements IActivationListener, ISaveablePart2 {
 	
 	public static final String ID = "ch.elexis.views.rechnung.AccountView"; //$NON-NLS-1$
@@ -144,11 +145,11 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 		accountArea.setLayout(new GridLayout(3, false));
 		tk.createLabel(accountArea, Messages.AccountView_account); //$NON-NLS-1$
 		tk.createLabel(accountArea, Messages.AccountView_accountAmount); //$NON-NLS-1$
-		balanceLabel = tk.createLabel(accountArea, ""); //$NON-NLS-1$
+		balanceLabel = tk.createLabel(accountArea, StringTool.leer); //$NON-NLS-1$
 		balanceLabel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
-		tk.createLabel(accountArea, ""); // dummy //$NON-NLS-1$
+		tk.createLabel(accountArea, StringTool.leer); // dummy //$NON-NLS-1$
 		tk.createLabel(accountArea, Messages.AccountView_goodFromBills); //$NON-NLS-1$
-		excessLabel = tk.createLabel(accountArea, ""); //$NON-NLS-1$
+		excessLabel = tk.createLabel(accountArea, StringTool.leer); //$NON-NLS-1$
 		excessLabel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		
 		// account entries
@@ -227,11 +228,11 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 			
 			public String getColumnText(Object element, int columnIndex){
 				if (!(element instanceof AccountTransaction)) {
-					return "";
+					return StringTool.leer;
 				}
 				
 				AccountTransaction entry = (AccountTransaction) element;
-				String text = "";
+				String text = StringTool.leer;
 				
 				Account account = null;
 				switch (columnIndex) {
@@ -246,7 +247,7 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 					if (rechnung != null && rechnung.exists()) {
 						text = rechnung.getNr();
 					} else {
-						text = ""; //$NON-NLS-1$
+						text = StringTool.leer; //$NON-NLS-1$
 					}
 					break;
 				case REMARKS:
@@ -333,7 +334,7 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 		accountExcessJob.invalidate();
 		accountExcessJob.schedule();
 		
-		String title = ""; //$NON-NLS-1$
+		String title = StringTool.leer; //$NON-NLS-1$
 		if (actPatient != null) {
 			title = actPatient.getLabel();
 		} else {
@@ -355,7 +356,7 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 			return;
 		}
 		
-		String balanceText = ""; //$NON-NLS-1$
+		String balanceText = StringTool.leer; //$NON-NLS-1$
 		String excessText = "..."; //$NON-NLS-1$
 		
 		if (actPatient != null) {
@@ -431,7 +432,7 @@ public class AccountView extends ViewPart implements IActivationListener, ISavea
 	 * AccountEntry(TimeTool date, Money amount, String remarks) { this.date = date; this.amount =
 	 * amount; this.remarks = remarks;
 	 * 
-	 * if (remarks == null) { remarks = ""; } } }
+	 * if (remarks == null) { remarks = StringTool.leer; } } }
 	 */
 	
 	private void makeActions(){

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/BillSummary.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/BillSummary.java
@@ -62,6 +62,7 @@ import ch.rgw.tools.Money;
  * This view shows the current patient's account
  */
 
+import ch.rgw.tools.StringTool;
 public class BillSummary extends ViewPart implements IActivationListener, ElexisEventListener,
 		ISaveablePart2 {
 	
@@ -168,15 +169,15 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 		generalArea.setLayout(new GridLayout(2, false));
 		
 		tk.createLabel(generalArea, Messages.BillSummary_total); //$NON-NLS-1$
-		totalLabel = tk.createLabel(generalArea, ""); //$NON-NLS-1$
+		totalLabel = tk.createLabel(generalArea, StringTool.leer); //$NON-NLS-1$
 		totalLabel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		
 		tk.createLabel(generalArea, Messages.BillSummary_paid); //$NON-NLS-1$
-		paidLabel = tk.createLabel(generalArea, ""); //$NON-NLS-1$
+		paidLabel = tk.createLabel(generalArea, StringTool.leer); //$NON-NLS-1$
 		paidLabel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		
 		tk.createLabel(generalArea, Messages.BillSummary_open2); //$NON-NLS-1$
-		openLabel = tk.createLabel(generalArea, ""); //$NON-NLS-1$
+		openLabel = tk.createLabel(generalArea, StringTool.leer); //$NON-NLS-1$
 		openLabel.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
 		
 		// bills
@@ -234,11 +235,11 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 			
 			public String getColumnText(Object element, int columnIndex){
 				if (!(element instanceof Rechnung)) {
-					return ""; //$NON-NLS-1$
+					return StringTool.leer; //$NON-NLS-1$
 				}
 				
 				Rechnung rechnung = (Rechnung) element;
-				String text = ""; //$NON-NLS-1$
+				String text = StringTool.leer; //$NON-NLS-1$
 				
 				switch (columnIndex) {
 				case NUMBER:
@@ -301,7 +302,7 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 	private void setPatient(Patient patient){
 		actPatient = patient;
 		
-		String title = ""; //$NON-NLS-1$
+		String title = StringTool.leer; //$NON-NLS-1$
 		if (actPatient != null) {
 			title = actPatient.getLabel();
 		} else {
@@ -323,9 +324,9 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 			return;
 		}
 		
-		String totalText = ""; //$NON-NLS-1$
-		String paidText = ""; //$NON-NLS-1$
-		String openText = ""; //$NON-NLS-1$
+		String totalText = StringTool.leer; //$NON-NLS-1$
+		String paidText = StringTool.leer; //$NON-NLS-1$
+		String openText = StringTool.leer; //$NON-NLS-1$
 		
 		if (actPatient != null) {
 			Money total = new Money(0);
@@ -408,7 +409,7 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 	 * AccountEntry(TimeTool date, Money amount, String remarks) { this.date = date; this.amount =
 	 * amount; this.remarks = remarks;
 	 * 
-	 * if (remarks == null) { remarks = ""; } } }
+	 * if (remarks == null) { remarks = StringTool.leer; } } }
 	 */
 	
 	private void makeActions(){
@@ -426,7 +427,7 @@ public class BillSummary extends ViewPart implements IActivationListener, Elexis
 	}
 	
 	private void exportToClipboard(){
-		String clipboardText = ""; //$NON-NLS-1$
+		String clipboardText = StringTool.leer; //$NON-NLS-1$
 		String lineSeparator = System.getProperty("line.separator"); //$NON-NLS-1$
 		
 		if (actPatient != null) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/BillingProposalView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/BillingProposalView.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlElement;
+import ch.rgw.tools.StringTool;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
@@ -516,7 +517,7 @@ public class BillingProposalView extends ViewPart {
 				if (costBearer != null) {
 					item.insurerName = costBearer.getLabel(true);
 				} else {
-					item.insurerName = "";
+					item.insurerName = StringTool.leer;
 				}
 			}
 			

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/InvoiceCorrectionView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/InvoiceCorrectionView.java
@@ -232,7 +232,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 				&& !invoiceCorrectionDTO.getErrors().isEmpty()) {
 				StringBuilder builder = new StringBuilder();
 				for (ElexisException e : invoiceCorrectionDTO.getErrors()) {
-					builder.append("\n" + e.getMessage());
+					builder.append(StringTool.lf + e.getMessage());
 				}
 				MessageDialog.openWarning(getSite().getShell(), "Rechnungskorrektur",
 					"Die Rechnung " + invoiceCorrectionDTO.getInvoiceNumber()
@@ -365,7 +365,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 			gd1.marginHeight = 0;
 			body.setLayout(gd1);
 			
-			ExpandableComposite expandable = WidgetFactory.createExpandableComposite(tk, form, ""); //$NON-NLS-1$
+			ExpandableComposite expandable = WidgetFactory.createExpandableComposite(tk, form, StringTool.leer); //$NON-NLS-1$
 			expandable.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 			expandable.setExpanded(false);
 			expandable.setText("Rechnungsangaben");
@@ -398,7 +398,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 					Text text = new Text(group, SWT.BORDER | SWT.READ_ONLY);
 					text.setBackground(colWhite);
 					text.setLayoutData(gd);
-					text.setText(detailText != null ? detailText : "");
+					text.setText(detailText != null ? detailText : StringTool.leer);
 				}
 			}
 			new Label(group, SWT.NONE).setText("Bemerkung");
@@ -409,7 +409,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 			txtMulti.setBackground(UiDesk.getColor(UiDesk.COL_WHITE));
 			txtMulti.setLayoutData(gd2);
 			txtMulti.setText(invoiceCorrectionDTO.getBemerkung() != null
-					? invoiceCorrectionDTO.getBemerkung() : "");
+					? invoiceCorrectionDTO.getBemerkung() : StringTool.leer);
 			
 			if (invoiceCorrectionDTO.getNewInvoiceNumber() != null) {
 				if (!invoiceCorrectionDTO.getNewInvoiceNumber().isEmpty()) {
@@ -525,7 +525,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 			gd1.marginWidth = 0;
 			gd1.marginHeight = 0;
 			body.setLayout(gd1);
-			ExpandableComposite expandable = WidgetFactory.createExpandableComposite(tk, form, ""); //$NON-NLS-1$
+			ExpandableComposite expandable = WidgetFactory.createExpandableComposite(tk, form, StringTool.leer); //$NON-NLS-1$
 			expandable.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 			expandable.setExpanded(false);
 			expandable.setText("Fallangaben");
@@ -586,7 +586,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 				gd1.marginHeight = 1;
 				body.setLayout(gd1);
 				ExpandableComposite expandable =
-					WidgetFactory.createExpandableComposite(tk, form, ""); //$NON-NLS-1$
+					WidgetFactory.createExpandableComposite(tk, form, StringTool.leer); //$NON-NLS-1$
 				expandable.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 				expandable.setExpanded(false);
 				expandable.addExpansionListener(new ExpansionAdapter() {
@@ -1056,7 +1056,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 					return leistungDTO.getPrice() != null
 							? leistungDTO.getPrice().getAmountAsString() : "0";
 				default:
-					return "";
+					return StringTool.leer;
 				}
 				
 			}
@@ -1212,7 +1212,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 				case 0:
 					return diagnosesDTO.getLabel();
 				default:
-					return "";
+					return StringTool.leer;
 				}
 			}
 		}
@@ -1376,7 +1376,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 								txtBemerkung.append(actualInvoice.getBemerkung());
 							}
 							if (txtBemerkung.length() > 0) {
-								txtBemerkung.append("\n");
+								txtBemerkung.append(StringTool.lf);
 							}
 							txtBemerkung.append(invoiceCorrectionDTO.getOutputText());
 							actualInvoice.setBemerkung(txtBemerkung.toString());
@@ -1404,7 +1404,7 @@ public class InvoiceCorrectionView extends ViewPart implements IUnlockable {
 		if (actualInvoice != null && invoiceCorrectionDTO != null) {
 			
 			actualInvoice.setExtInfoStoredObjectByKey(Rechnung.INVOICE_CORRECTION,
-				StringUtils.isEmpty(invoiceCorrectionDTO.getNewInvoiceNumber()) ? ""
+				StringUtils.isEmpty(invoiceCorrectionDTO.getNewInvoiceNumber()) ? StringTool.leer
 						: invoiceCorrectionDTO.getNewInvoiceNumber());
 		}
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/InvoiceCorrectionWizard.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/InvoiceCorrectionWizard.java
@@ -24,6 +24,7 @@ import ch.elexis.core.ui.UiDesk;
 import ch.elexis.data.dto.InvoiceCorrectionDTO;
 import ch.elexis.data.dto.InvoiceHistoryEntryDTO;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceCorrectionWizard extends Wizard {
 	
 	Page1 page1;
@@ -218,7 +219,7 @@ public class InvoiceCorrectionWizard extends Wizard {
 				int i = invoiceCorrectionDTO.getHistory().indexOf(element);
 				return String.valueOf(++i) + ".   " + ((InvoiceHistoryEntryDTO) element).getText();
 			}
-			return "";
+			return StringTool.leer;
 		}
 	}
 }

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/KonsZumVerrechnenView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/KonsZumVerrechnenView.java
@@ -110,6 +110,7 @@ import ch.rgw.tools.Tree;
  * @author Gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class KonsZumVerrechnenView extends ViewPart implements ISaveablePart2 {
 	public static final String ID = "ch.elexis.BehandlungenVerrechnenView"; //$NON-NLS-1$
 	CommonViewer cv;
@@ -285,7 +286,7 @@ public class KonsZumVerrechnenView extends ViewPart implements ISaveablePart2 {
 					(org.eclipse.swt.widgets.Tree) (event.widget);
 				TreeItem obj = theWidget.getSelection()[0];
 				TreeItem parent = obj.getParentItem();
-				String viewID = "";
+				String viewID = StringTool.leer;
 				if (parent == null) {
 					// no parent at all -> must be patient
 					viewID = UiResourceConstants.PatientDetailView2_ID;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RechnungsBlatt.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RechnungsBlatt.java
@@ -444,7 +444,7 @@ public class RechnungsBlatt extends Composite implements IActivationListener {
 					int zahl = verrechnet.getZahl();
 					Money preis = verrechnet.getNettoPreis();
 					preis.multiply(zahl);
-					return "  - " + zahl + " " + verrechnet.getLabel() + " (" + preis.toString() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					return "  - " + zahl + StringTool.space + verrechnet.getLabel() + " (" + preis.toString() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						+ ")"; //$NON-NLS-1$
 				} else {
 					return element.toString();
@@ -481,7 +481,7 @@ public class RechnungsBlatt extends Composite implements IActivationListener {
 							new HashMap<Konsultation, List<VerrechnetCopy>>();
 						// prepare heading label that will look like this dd.MM.yyyy (cancelled) - amountOfMoney
 						StringBuilder sbHeadingLabel = new StringBuilder();
-						sbHeadingLabel.append(Messages.AccountView_bill + " " + actRn.getDatumRn()); //$NON-NLS-1$
+						sbHeadingLabel.append(Messages.AccountView_bill + StringTool.space + actRn.getDatumRn()); //$NON-NLS-1$
 						sbHeadingLabel.append(Messages.RechnungsBlatt_stornoLabel);
 						
 						// store all verrechnetCopies and add label with sum of all cancelled items
@@ -548,7 +548,7 @@ public class RechnungsBlatt extends Composite implements IActivationListener {
 					int amount = vc.getZahl();
 					Money price = vc.getNettoPreis();
 					price.multiply(amount);
-					return "  - " + amount + " " + vc.getLabel() + " (" + price.toString() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					return "  - " + amount + StringTool.space + vc.getLabel() + " (" + price.toString() //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						+ ")"; //$NON-NLS-1$
 				} else if (element instanceof Konsultation) {
 					return "Konsultation " + ((Konsultation) element).getDatum();
@@ -647,7 +647,7 @@ public class RechnungsBlatt extends Composite implements IActivationListener {
 			Kontakt adressat = actRn.getFall().getInvoiceRecipient();
 			rnAdressat
 				.setText(Messages.RechnungsBlatt_adressee
-					+ ((adressat != null) ? adressat.getLabel() : ""));
+					+ ((adressat != null) ? adressat.getLabel() : StringTool.leer));
 			form.setText(actRn.getLabel());
 			List<String> trace = actRn.getTrace(Rechnung.STATUS_CHANGED);
 			for (String s : trace) {
@@ -665,7 +665,7 @@ public class RechnungsBlatt extends Composite implements IActivationListener {
 				}
 				tRejects.setText(rjj.toString());
 			} else {
-				tRejects.setText("");
+				tRejects.setText(StringTool.leer);
 			}
 			List<String> outputs = actRn.getTrace(Rechnung.OUTPUT);
 			for (String o : outputs) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnControlFieldProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnControlFieldProvider.java
@@ -93,7 +93,7 @@ class RnControlFieldProvider implements ViewerConfigurer.ControlFieldProvider {
 	private HyperlinkAdapter /* hlStatus, */ hlPatient;
 	private Label /* hDateFrom, hDateUntil, */ lPatient;
 	Text tNr, tBetrag;
-	String oldSelectedBillingSystem = ""; //$NON-NLS-1$
+	String oldSelectedBillingSystem = StringTool.leer; //$NON-NLS-1$
 	
 	Patient actPatient;
 	
@@ -248,7 +248,7 @@ class RnControlFieldProvider implements ViewerConfigurer.ControlFieldProvider {
 			ret[1] = actPatient.getId();
 		}
 		ret[2] = tNr.getText();
-		ret[3] = tBetrag.getText().replaceAll("\\.", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		ret[3] = tBetrag.getText().replaceAll("\\.", StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$
 		if (StringTool.isNothing(ret[2])) {
 			ret[2] = null;
 		} else { // Wenn RnNummer gegeben ist, alles andere auf Standard.
@@ -276,7 +276,7 @@ class RnControlFieldProvider implements ViewerConfigurer.ControlFieldProvider {
 	
 	public void clearValues(){
 		cbStat.select(0);
-		tNr.setText(""); //$NON-NLS-1$
+		tNr.setText(StringTool.leer); //$NON-NLS-1$
 		actPatient = null;
 		lPatient.setText(ALLE);
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnDialogs.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnDialogs.java
@@ -76,6 +76,7 @@ import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class RnDialogs {
 	public static final int ERR_STORNO = 1;
 	private static final String RECHNUNG_IST_STORNIERT = "Rechnung ist storniert";
@@ -666,7 +667,7 @@ public class RnDialogs {
 				}
 			});
 			tDirName = new Text(cSaveCopy, SWT.BORDER | SWT.READ_ONLY);
-			tDirName.setText(CoreHub.localCfg.get("rechnung/RnListExportDirname", "")); //$NON-NLS-1$
+			tDirName.setText(CoreHub.localCfg.get("rechnung/RnListExportDirname", StringTool.leer)); //$NON-NLS-1$
 			tDirName.setLayoutData(SWTHelper.getFillGridData(2, true, 1, false));
 			return ret;
 		}
@@ -689,7 +690,7 @@ public class RnDialogs {
 		}
 		
 		public void CSVWriteTable(){
-			String pathToSave = RnListExportDirname + "/" + RnListExportFileName;
+			String pathToSave = RnListExportDirname + StringTool.slash + RnListExportFileName;
 			CSVWriter csv = null;
 			int nrLines = 0;
 			try {
@@ -737,7 +738,7 @@ public class RnDialogs {
 					Fall fall = rn.getFall();
 					Patient p = fall.getPatient();
 					String[] line = new String[header.length];
-					line[0] = ""; //201512210402js: Leere Spalte zum Eintragen der gewünschten Aktion.
+					line[0] = StringTool.leer; //201512210402js: Leere Spalte zum Eintragen der gewünschten Aktion.
 					line[1] = rn.getNr();
 					line[2] = rn.getDatumRn();
 					line[3] = rn.getDatumVon();
@@ -764,9 +765,9 @@ public class RnDialogs {
 					String a = statuschgs.toString();
 					if (a != null && a.length() > 1) {
 						//Die Uhrzeiten rauswerfen:
-						a = a.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-						//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-						a = a.replaceAll(", ", "\n");
+						a = a.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+						//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+						a = a.replaceAll(", ", StringTool.lf);
 						//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 						line[12] = a.substring(1, a.length() - 1);
 					}
@@ -776,9 +777,9 @@ public class RnDialogs {
 						if (rnStatus != null && rnStatus.length() > 1) {
 							//Die Uhrzeiten rauswerfen:
 							rnStatus =
-								rnStatus.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-							//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-							rnStatus = rnStatus.replaceAll(", ", "\n");
+								rnStatus.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+							//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+							rnStatus = rnStatus.replaceAll(", ", StringTool.lf);
 							//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 							line[13] = rnStatus.substring(1, rnStatus.length() - 1);
 						}
@@ -787,9 +788,9 @@ public class RnDialogs {
 					String rnOutput = outputs.toString();
 					if (rnOutput != null && rnOutput.length() > 1) {
 						//Die Uhrzeiten rauswerfen:
-						rnOutput = rnOutput.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-						//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-						rnOutput = rnOutput.replaceAll(", ", "\n");
+						rnOutput = rnOutput.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+						//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+						rnOutput = rnOutput.replaceAll(", ", StringTool.lf);
 						//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 						line[14] = rnOutput.substring(1, rnOutput.length() - 1);
 					}
@@ -797,9 +798,9 @@ public class RnDialogs {
 					String rnPayment = payments.toString();
 					if (rnPayment != null && rnPayment.length() > 1) {
 						//Die Uhrzeiten rauswerfen:
-						rnPayment = rnPayment.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-						//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-						rnPayment = rnPayment.replaceAll(", ", "\n");
+						rnPayment = rnPayment.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+						//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+						rnPayment = rnPayment.replaceAll(", ", StringTool.lf);
 						//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 						line[15] = rnPayment.substring(1, rnPayment.length() - 1);
 					}
@@ -830,9 +831,9 @@ public class RnDialogs {
 					//201512210146js: Das Folgende ist aus BillSummary - dort wird dafür keine Funktion bereitgestellt,
 					// TODO: Prüfen, ob das eine Redundanz DORT und HIER ist vs. obenn erwähnter getKontostand(), getAccountExcess() etc.
 					// maybe called from foreign thread
-					String totalText = ""; //$NON-NLS-1$
-					String paidText = ""; //$NON-NLS-1$
-					String openText = ""; //$NON-NLS-1$
+					String totalText = StringTool.leer; //$NON-NLS-1$
+					String paidText = StringTool.leer; //$NON-NLS-1$
+					String openText = StringTool.leer; //$NON-NLS-1$
 					// Davon, dass p != null ist, darf man eigentlich ausgehen, da ja Rechnungen zu p gehören etc.
 					if (p != null) {
 						Money total = new Money(0);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnListeDruckDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnListeDruckDialog.java
@@ -25,6 +25,7 @@ import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 import ch.rgw.tools.Tree;
 
+import ch.rgw.tools.StringTool;
 public class RnListeDruckDialog extends TitleAreaDialog implements ICallback {
 	ArrayList<Rechnung> rnn = new ArrayList<Rechnung>();
 	private TextContainer text;
@@ -78,7 +79,7 @@ public class RnListeDruckDialog extends TitleAreaDialog implements ICallback {
 			Messages.RnActions_bills); //$NON-NLS-1$ //$NON-NLS-2$
 		text.getPlugin().insertText("[Titel]", //$NON-NLS-1$
 			Messages.RnActions_billsListPrintetAt + new TimeTool().toString(TimeTool.DATE_GER)
-				+ "\n", //$NON-NLS-1$ //$NON-NLS-2$
+				+ StringTool.lf, //$NON-NLS-1$ //$NON-NLS-2$
 			SWT.CENTER);
 		String[][] table = new String[rnn.size() + 1][];
 		Money sum = new Money();
@@ -97,7 +98,7 @@ public class RnListeDruckDialog extends TitleAreaDialog implements ICallback {
 			table[i][2] = betrag.getAmountAsString();
 		}
 		table[i] = new String[3];
-		table[i][0] = ""; //$NON-NLS-1$
+		table[i][0] = StringTool.leer; //$NON-NLS-1$
 		table[i][1] = Messages.RnActions_sum; //$NON-NLS-1$
 		table[i][2] = sum.getAmountAsString();
 		text.getPlugin().setFont("Helvetica", SWT.NORMAL, 9); //$NON-NLS-1$

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnListeExportDialog.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/RnListeExportDialog.java
@@ -39,6 +39,7 @@ import ch.rgw.tools.Money;
 import ch.rgw.tools.Tree;
 
 //201512211341js: Info: This dialog starts the generation of output ONLY AFTER [OK] has been pressed.
+import ch.rgw.tools.StringTool;
 class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 	ArrayList<Rechnung> rnn;
 	private Logger log = LoggerFactory.getLogger(RnActions.class);
@@ -110,7 +111,7 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 			}
 		});
 		tDirName = new Text(cSaveCopy, SWT.BORDER | SWT.READ_ONLY);
-		tDirName.setText(CoreHub.localCfg.get("rechnung/RnListExportDirname", "")); //$NON-NLS-1$
+		tDirName.setText(CoreHub.localCfg.get("rechnung/RnListExportDirname", StringTool.leer)); //$NON-NLS-1$
 		tDirName.setLayoutData(SWTHelper.getFillGridData(2, true, 1, false));
 		return ret;
 	}
@@ -140,7 +141,7 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 	}
 	
 	public void CSVWriteTable(){
-		String pathToSave = RnListExportDirname + "/" + RnListExportFileName;
+		String pathToSave = RnListExportDirname + StringTool.slash + RnListExportFileName;
 		CSVWriter csv = null;
 		int nrLines = 0;
 		try {
@@ -187,7 +188,7 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 				Fall fall = rn.getFall();
 				Patient p = fall.getPatient();
 				String[] line = new String[header.length];
-				line[0] = ""; //201512210402js: Leere Spalte zum Eintragen der gewünschten Aktion.
+				line[0] = StringTool.leer; //201512210402js: Leere Spalte zum Eintragen der gewünschten Aktion.
 				line[1] = rn.getNr();
 				line[2] = rn.getDatumRn();
 				line[3] = rn.getDatumVon();
@@ -214,9 +215,9 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 				String a = statuschgs.toString();
 				if (a != null && a.length() > 1) {
 					//Die Uhrzeiten rauswerfen:
-					a = a.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-					//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-					a = a.replaceAll(", ", "\n");
+					a = a.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+					//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+					a = a.replaceAll(", ", StringTool.lf);
 					//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 					line[12] = a.substring(1, a.length() - 1);
 				}
@@ -226,9 +227,9 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 					if (rnStatus != null && rnStatus.length() > 1) {
 						//Die Uhrzeiten rauswerfen:
 						rnStatus =
-							rnStatus.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-						//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-						rnStatus = rnStatus.replaceAll(", ", "\n");
+							rnStatus.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+						//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+						rnStatus = rnStatus.replaceAll(", ", StringTool.lf);
 						//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 						line[13] = rnStatus.substring(1, rnStatus.length() - 1);
 					}
@@ -237,9 +238,9 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 				String rnOutput = outputs.toString();
 				if (rnOutput != null && rnOutput.length() > 1) {
 					//Die Uhrzeiten rauswerfen:
-					rnOutput = rnOutput.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-					//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-					rnOutput = rnOutput.replaceAll(", ", "\n");
+					rnOutput = rnOutput.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+					//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+					rnOutput = rnOutput.replaceAll(", ", StringTool.lf);
 					//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 					line[14] = rnOutput.substring(1, rnOutput.length() - 1);
 				}
@@ -247,9 +248,9 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 				String rnPayment = payments.toString();
 				if (rnPayment != null && rnPayment.length() > 1) {
 					//Die Uhrzeiten rauswerfen:
-					rnPayment = rnPayment.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", "");
-					//", " durch "\n" ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
-					rnPayment = rnPayment.replaceAll(", ", "\n");
+					rnPayment = rnPayment.replaceAll(", [0-9][0-9]:[0-9][0-9]:[0-9][0-9]", StringTool.leer);
+					//", " durch StringTool.lf ersetzen (Man könnte auch noch prüfen, ob danach eine Zahl/ein Datum kommt - die dann aber behalten werden muss.)
+					rnPayment = rnPayment.replaceAll(", ", StringTool.lf);
 					//Führende und Trailende [] bei der Ausgabe (!) rauswerfen
 					line[15] = rnPayment.substring(1, rnPayment.length() - 1);
 				}
@@ -280,9 +281,9 @@ class RnListeExportDialog extends TitleAreaDialog implements ICallback {
 				//201512210146js: Das Folgende ist aus BillSummary - dort wird dafür keine Funktion bereitgestellt,
 				// TODO: Prüfen, ob das eine Redundanz DORT und HIER ist vs. obenn erwähnter getKontostand(), getAccountExcess() etc.
 				// maybe called from foreign thread
-				String totalText = ""; //$NON-NLS-1$
-				String paidText = ""; //$NON-NLS-1$
-				String openText = ""; //$NON-NLS-1$
+				String totalText = StringTool.leer; //$NON-NLS-1$
+				String paidText = StringTool.leer; //$NON-NLS-1$
+				String openText = StringTool.leer; //$NON-NLS-1$
 				// Davon, dass p != null ist, darf man eigentlich ausgehen, da ja Rechnungen zu p gehören etc.
 				if (p != null) {
 					Money total = new Money(0);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListBottomComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListBottomComposite.java
@@ -20,6 +20,7 @@ import ch.elexis.core.ui.views.rechnung.Messages;
 import ch.rgw.io.Settings;
 import ch.rgw.tools.Money;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceListBottomComposite extends Composite {
 	
 	private static final String REMINDER_3 = Messages.RechnungsListeView_reminder3; //$NON-NLS-1$
@@ -86,10 +87,10 @@ public class InvoiceListBottomComposite extends Composite {
 		Composite cSum = fSum.getBody();
 		cSum.setLayout(new GridLayout(2, false));
 		tk.createLabel(cSum, Messages.RechnungsListeView_patInList); //$NON-NLS-1$
-		 totalPatientsInListText = tk.createText(cSum, "", SWT.BORDER | SWT.READ_ONLY); //$NON-NLS-1$
+		 totalPatientsInListText = tk.createText(cSum, StringTool.leer, SWT.BORDER | SWT.READ_ONLY); //$NON-NLS-1$
 		totalPatientsInListText.setLayoutData(new GridData(100, SWT.DEFAULT));
 		tk.createLabel(cSum, Messages.RechnungsListeView_accountsInList); //$NON-NLS-1$
-		tSumInvoiceInList = tk.createText(cSum, "", SWT.BORDER | SWT.READ_ONLY); //$NON-NLS-1$
+		tSumInvoiceInList = tk.createText(cSum, StringTool.leer, SWT.BORDER | SWT.READ_ONLY); //$NON-NLS-1$
 		tSumInvoiceInList.setLayoutData(new GridData(100, SWT.DEFAULT));
 		tk.createLabel(cSum, Messages.RechnungsListeView_sumInList); //$NON-NLS-1$
 		tSum = SWTHelper.createText(tk, cSum, 1, SWT.BORDER | SWT.READ_ONLY);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListContentProvider.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListContentProvider.java
@@ -46,6 +46,7 @@ import ch.rgw.tools.JdbcLink;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceListContentProvider implements IStructuredContentProvider {
 	
 	private List<InvoiceEntry> currentContent = new ArrayList<InvoiceEntry>();
@@ -94,7 +95,7 @@ public class InvoiceListContentProvider implements IStructuredContentProvider {
 	private static final String SQL_CONDITION_BILLING_SYSTEM = "FallGesetz = ?";
 	//@formatter:on
 	
-	public static String orderBy = "";
+	public static String orderBy = StringTool.leer;
 	private static int queryLimit = 1000;
 	
 	public Action rnFilterAction =
@@ -183,7 +184,7 @@ public class InvoiceListContentProvider implements IStructuredContentProvider {
 					String patientId = res.getString(7);
 					countPatients.add(patientId);
 					String patientName =
-						res.getString(8) + " " + res.getString(9) + " (" + res.getString(10) + ")";
+						res.getString(8) + StringTool.space + res.getString(9) + " (" + res.getString(10) + ")";
 					String dob = res.getString(11);
 					if (StringUtils.isNumeric(dob)) {
 						patientName += ", " + new TimeTool(dob).toString(TimeTool.DATE_GER);
@@ -244,7 +245,7 @@ public class InvoiceListContentProvider implements IStructuredContentProvider {
 				queryBuilder.setMainQuery(preparedStatement.replaceAll("REPLACE_WITH_LIMIT",
 					" LIMIT " + Integer.toString(queryLimit)));
 			} else {
-				queryBuilder.setMainQuery(preparedStatement.replaceAll("REPLACE_WITH_LIMIT", ""));
+				queryBuilder.setMainQuery(preparedStatement.replaceAll("REPLACE_WITH_LIMIT", StringTool.leer));
 			}
 		} else {
 			queryBuilder.setMainQuery(preparedStatement);
@@ -400,19 +401,19 @@ public class InvoiceListContentProvider implements IStructuredContentProvider {
 		String sortDirectionString = (SWT.UP == sortDirection) ? "ASC" : "DESC";
 		if (InvoiceListSqlQuery.VIEW_FLD_INVOICENO.equals(data)) {
 			orderBy = "ORDER BY LENGTH(" + InvoiceListSqlQuery.VIEW_FLD_INVOICENO + ") "
-				+ sortDirectionString + "," + InvoiceListSqlQuery.VIEW_FLD_INVOICENO + " "
+				+ sortDirectionString + "," + InvoiceListSqlQuery.VIEW_FLD_INVOICENO + StringTool.space
 				+ sortDirectionString;
 		} else if (Rechnung.BILL_DATE_FROM.equals(data)
 			|| InvoiceListSqlQuery.VIEW_FLD_INVOICETOTAL.equals(data)
 			|| InvoiceListSqlQuery.VIEW_FLD_OPENAMOUNT.equals(data)) {
-			orderBy = "ORDER BY " + data + " " + sortDirectionString;
+			orderBy = "ORDER BY " + data + StringTool.space + sortDirectionString;
 		} else if (Kontakt.FLD_NAME1.equals(data)) {
 			orderBy =
 				"ORDER BY PatName1 " + sortDirectionString + ", PatName2 " + sortDirectionString;
 		} else if (InvoiceListSqlQuery.VIEW_FLD_INVOICESTATEDATE.equals(data)) {
-			orderBy = "ORDER BY " + data + " " + sortDirectionString;
+			orderBy = "ORDER BY " + data + StringTool.space + sortDirectionString;
 		} else {
-			orderBy = "";
+			orderBy = StringTool.leer;
 		}
 		
 		reload();
@@ -713,16 +714,16 @@ public class InvoiceListContentProvider implements IStructuredContentProvider {
 							" AND " + sbInner.toString());
 					} else {
 						mainQueryRet =  mainQuery
-							.replace(InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION, "");
+							.replace(InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION, StringTool.leer);
 					}
 					if(sbOuter.length() > 0) {
 						mainQueryRet = mainQueryRet.replace(InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION, " WHERE "+sbOuter.toString());
 					} else {
-						mainQueryRet = mainQueryRet.replace(InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION, "");
+						mainQueryRet = mainQueryRet.replace(InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION, StringTool.leer);
 					}
 					return mainQueryRet;
 				}
-				return "";
+				return StringTool.leer;
 			}
 			
 			/**

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListHeaderComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListHeaderComposite.java
@@ -37,6 +37,7 @@ import ch.elexis.core.ui.views.rechnung.Messages;
 import ch.elexis.data.BillingSystem;
 import ch.elexis.data.Patient;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceListHeaderComposite extends Composite {
 	
 	private final static String ALL_PATIENTS_LABEL = Messages.RnControlFieldProvider_allPatients;
@@ -140,7 +141,7 @@ public class InvoiceListHeaderComposite extends Composite {
 		
 		lblLimitWarn = new Label(this, SWT.NONE);
 		lblLimitWarn.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-		lblLimitWarn.setText("");
+		lblLimitWarn.setText(StringTool.leer);
 		defaultBackgroundColor = lblLimitWarn.getBackground();
 		
 		Label btnClear = new Label(this, SWT.FLAT);
@@ -280,8 +281,8 @@ public class InvoiceListHeaderComposite extends Composite {
 	private void clearValues(){
 		comboViewerStatus.setSelection(new StructuredSelection(InvoiceState.OPEN));
 		comboViewerType.setSelection(new StructuredSelection(ALL_ELEMENTS_LABEL));
-		txtInvoiceno.setText("");
-		txtAmount.setText("");
+		txtInvoiceno.setText(StringTool.leer);
+		txtAmount.setText(StringTool.leer);
 		actPatient = null;
 		lblPatientname.setText(ALL_PATIENTS_LABEL);
 	}
@@ -352,8 +353,8 @@ public class InvoiceListHeaderComposite extends Composite {
 				"Result set was limited to " + queryLimit + ", you do not see all results!");
 			lblLimitWarn.setBackground(UiDesk.getColor(UiDesk.COL_RED));
 		} else {
-			lblLimitWarn.setText("");
-			lblLimitWarn.setToolTipText("");
+			lblLimitWarn.setText(StringTool.leer);
+			lblLimitWarn.setToolTipText(StringTool.leer);
 			lblLimitWarn.setBackground(defaultBackgroundColor);
 		}
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListSqlQuery.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/rechnung/invoice/InvoiceListSqlQuery.java
@@ -24,6 +24,7 @@ import ch.elexis.data.PersistentObject;
 import ch.elexis.data.Rechnung;
 import ch.rgw.tools.JdbcLink;
 
+import ch.rgw.tools.StringTool;
 public class InvoiceListSqlQuery {
 	
 	public static final String VIEW_FLD_INVOICENO = "InvoiceNo";
@@ -49,20 +50,20 @@ public class InvoiceListSqlQuery {
 		if (dbConnection != null && JdbcLink.DBFLAVOR_POSTGRESQL.equalsIgnoreCase(dbConnection.getDBFlavor())) {
 			query =
 				"( SELECT rz.id AS InvoiceId, rz.RnNummer AS InvoiceNo, rz.rndatum, rz.rndatumvon, rz.rndatumbis, rz.statusdatum, rz.InvoiceState, rz.InvoiceTotal, rz.MandantId, f.patientid AS PatientId, k.bezeichnung1 AS PatName1, k.bezeichnung2 AS PatName2, k.geschlecht AS PatSex, k.geburtsdatum AS PatDob, f.id AS FallId, f.gesetz AS FallGesetz, CASE WHEN (f.garantID IS NULL) THEN f.patientid ELSE f.garantID END FallGarantId, f.KostentrID AS FallKostentrID, rz.paymentCount, rz.paidAmount, rz.openAmount FROM (SELECT r.id, r.rnnummer, r.rndatum, r.rndatumvon, r.rndatumbis, r.statusdatum, r.fallid, r.MandantId, CAST(r.rnstatus AS NUMERIC) AS InvoiceState, CAST(r.betrag AS NUMERIC) AS InvoiceTotal, COUNT(z.id) AS paymentCount, CASE WHEN COUNT(z.id) = '0' THEN 0 ELSE SUM(CAST(z.betrag AS NUMERIC)) END paidAmount, CASE WHEN COUNT(z.id) = '0' THEN CAST(r.betrag AS NUMERIC) ELSE (CAST(r.betrag AS NUMERIC) - SUM(CAST(z.betrag AS NUMERIC))) END openAmount FROM RECHNUNGEN r LEFT JOIN zahlungen z ON z.rechnungsID = r.id AND z.deleted = '0' WHERE r.deleted = '0'"
-				+ " " + InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION
+				+ StringTool.space + InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION
 					+ " GROUP BY r.id) rz LEFT JOIN faelle f ON rz.FallID = f.ID LEFT JOIN kontakt k ON f.PatientID = k.id)x "
-					+ InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION+ " ";
+					+ InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION+ StringTool.space;
 		}
 		else
 		{
 			query = "( SELECT rz.id AS InvoiceId, rz.RnNummer AS InvoiceNo, rz.rndatum, rz.rndatumvon, rz.rndatumbis, rz.statusdatum, rz.InvoiceState, rz.InvoiceTotal, rz.MandantId, f.patientid AS PatientId, k.bezeichnung1 AS PatName1, k.bezeichnung2 AS PatName2, k.geschlecht AS PatSex, k.geburtsdatum AS PatDob, f.id AS FallId, f.gesetz AS FallGesetz, CASE WHEN (f.garantID IS NULL) THEN f.patientid ELSE f.garantID END FallGarantId, f.KostentrID AS FallKostentrID, rz.paymentCount, rz.paidAmount, rz.openAmount FROM (SELECT r.id, r.rnnummer, r.rndatum, r.rndatumvon, r.rndatumbis, r.statusdatum, r.fallid, r.MandantId, CAST(r.rnstatus AS SIGNED) AS InvoiceState, CAST(r.betrag AS SIGNED) AS InvoiceTotal, COUNT(z.id) AS paymentCount, CASE WHEN COUNT(z.id) = 0 THEN 0 ELSE SUM(CAST(z.betrag AS SIGNED)) END paidAmount, CASE WHEN COUNT(z.id) = 0 THEN CAST(r.betrag AS SIGNED) ELSE (CAST(r.betrag AS SIGNED) - SUM(CAST(z.betrag AS SIGNED))) END openAmount FROM RECHNUNGEN r LEFT JOIN zahlungen z ON z.rechnungsID = r.id AND z.deleted = 0 WHERE r.deleted = 0"
-			+ " " + InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION
+			+ StringTool.space + InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION
 					+ " GROUP BY r.id) rz LEFT JOIN faelle f ON rz.FallID = f.ID LEFT JOIN kontakt k ON f.PatientID = k.id )x "
-			+ InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION+ " ";
+			+ InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION+ StringTool.space;
 		}
 		if (!withConditions && query != null) {
-			query = query.replaceAll(InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION, "");
-			query = query.replace(InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION, "");
+			query = query.replaceAll(InvoiceListSqlQuery.REPLACEMENT_INVOICE_INNER_CONDITION, StringTool.leer);
+			query = query.replace(InvoiceListSqlQuery.REPLACEMENT_OUTER_CONDITION, StringTool.leer);
 		}
 		return query;
 	}
@@ -90,7 +91,7 @@ public class InvoiceListSqlQuery {
 					InvoiceListSqlQuery.VIEW_FLD_OPENAMOUNT + "," +
 					InvoiceListSqlQuery.VIEW_FLD_INVOICESTATEDATE +
 					" FROM" + 
-					" " +getSqlInvoice(true)+
+					StringTool.space +getSqlInvoice(true)+
 					"REPLACE_WITH_ORDER " + 
 					"REPLACE_WITH_LIMIT";
 		//@formatter:on

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/AbstractProperties.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/AbstractProperties.java
@@ -32,6 +32,7 @@ import ch.elexis.core.ui.util.Log;
  * @author nowhow
  * 
  */
+import ch.rgw.tools.StringTool;
 public abstract class AbstractProperties extends Properties {
 	private static final long serialVersionUID = -9019950244305182074L;
 	
@@ -48,7 +49,7 @@ public abstract class AbstractProperties extends Properties {
 	 * Returns location of the properties file inside of the elexis plugin
 	 */
 	private String getPlatzhalterFilenamePath() throws IOException{
-		URL url = Platform.getBundle("ch.elexis.core.data").getEntry("/"); //$NON-NLS-1$ //$NON-NLS-2$
+		URL url = Platform.getBundle("ch.elexis.core.data").getEntry(StringTool.slash); //$NON-NLS-1$ //$NON-NLS-2$
 		url = FileLocator.toFileURL(url);
 		String bundleLocation = url.getPath();
 		return bundleLocation + File.separator + DIRECTORY + File.separator + getFilename();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/PlatzhalterProperties.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/PlatzhalterProperties.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import ch.elexis.core.ui.util.Log;
 
+import ch.rgw.tools.StringTool;
 public class PlatzhalterProperties extends AbstractProperties {
 	private static final long serialVersionUID = -6366568655870957480L;
 	
@@ -37,9 +38,9 @@ public class PlatzhalterProperties extends AbstractProperties {
 	 * @return
 	 */
 	public List<PlatzhalterTreeData> getList(){
-		PlatzhalterTreeData root = new PlatzhalterTreeData("root", "", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		PlatzhalterTreeData root = new PlatzhalterTreeData("root", StringTool.leer, StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		PlatzhalterTreeData noKategorie =
-			new PlatzhalterTreeData(Messages.PlatzhalterProperties_label_no_category, "", //$NON-NLS-2$ //$NON-NLS-1$
+			new PlatzhalterTreeData(Messages.PlatzhalterProperties_label_no_category, StringTool.leer, //$NON-NLS-2$ //$NON-NLS-1$
 				Messages.PlatzhalterProperties_tooltip_no_category);
 		
 		KategorieProperties katProperties = new KategorieProperties();
@@ -52,7 +53,7 @@ public class PlatzhalterProperties extends AbstractProperties {
 			String keyString = (String) keyEnumeration.nextElement();
 			String value = getProperty(keyString);
 			String category = noKategorie.getName();
-			String name = ""; //$NON-NLS-1$
+			String name = StringTool.leer; //$NON-NLS-1$
 			int openBracket = keyString.indexOf("["); //$NON-NLS-1$
 			int closeBracket = keyString.lastIndexOf("]"); //$NON-NLS-1$
 			int firstPoint = keyString.indexOf("."); //$NON-NLS-1$
@@ -98,7 +99,7 @@ public class PlatzhalterProperties extends AbstractProperties {
 				}
 				if (categoryPtd == null) {
 					String description = katProperties.getDescription(category);
-					categoryPtd = new PlatzhalterTreeData(category, "", //$NON-NLS-1$
+					categoryPtd = new PlatzhalterTreeData(category, StringTool.leer, //$NON-NLS-1$
 						description);
 					catTreeMap.put(category, categoryPtd);
 					root.addChild(categoryPtd);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/PlatzhalterView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/PlatzhalterView.java
@@ -53,6 +53,7 @@ import ch.elexis.core.data.util.Extensions;
 import ch.elexis.core.data.util.SortedList;
 import ch.elexis.core.ui.views.TextView;
 
+import ch.rgw.tools.StringTool;
 public class PlatzhalterView extends ViewPart {
 	public static final String ID = "ch.elexis.views.textsystem.Platzhalterview"; //$NON-NLS-1$
 	
@@ -257,7 +258,7 @@ public class PlatzhalterView extends ViewPart {
 	 */
 	@SuppressWarnings("unchecked")
 	private SortedList<PlatzhalterTreeData> getTreeData(){
-		PlatzhalterTreeData root = new PlatzhalterTreeData("Root", "", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		PlatzhalterTreeData root = new PlatzhalterTreeData("Root", StringTool.leer, StringTool.leer); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		
 		// Basis Platzhalter
 		PlatzhalterProperties props = new PlatzhalterProperties();
@@ -285,10 +286,10 @@ public class PlatzhalterView extends ViewPart {
 				PlatzhalterTreeData treeData =
 						root.getChild(typeName);
 				if(treeData == null) {
-					treeData = new PlatzhalterTreeData(typeName, "", "");
+					treeData = new PlatzhalterTreeData(typeName, StringTool.leer, StringTool.leer);
 				}
 				treeData
-					.addChild(new PlatzhalterTreeData(name, "[" + typeName + "." + name + "]", ""));
+					.addChild(new PlatzhalterTreeData(name, "[" + typeName + "." + name + "]", StringTool.leer));
 			}
 		}
 		
@@ -297,7 +298,7 @@ public class PlatzhalterView extends ViewPart {
 			Extensions.getClasses(ExtensionPointConstantsData.DATA_ACCESS, "DataAccess", "class");//$NON-NLS-1$ //$NON-NLS-2$
 		for (IDataAccess dataAccess : dataAccessList) {
 			PlatzhalterTreeData treeData =
-				new PlatzhalterTreeData(dataAccess.getName(), "", dataAccess.getDescription()); //$NON-NLS-1$
+				new PlatzhalterTreeData(dataAccess.getName(), StringTool.leer, dataAccess.getDescription()); //$NON-NLS-1$
 			if (dataAccess.getList() != null) {
 				for (Element element : dataAccess.getList()) {
 					treeData.addChild(new PlatzhalterTreeData(element.getName(), element

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/TextTemplatePrintSettings.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/TextTemplatePrintSettings.java
@@ -6,13 +6,14 @@ import ch.elexis.core.jdt.Nullable;
 import ch.elexis.core.ui.text.MimeTypeUtil;
 import ch.elexis.data.Mandant;
 
+import ch.rgw.tools.StringTool;
 public class TextTemplatePrintSettings {
 	public static final String TXT_TEMPLATE_PREFIX_PUBLIC = "texttemplates/public/";
 	public static final String TXT_TEMPLATE_PREFIX_PRIVATE = "texttemplates/private/";
 	public static final String TXT_TEMPLATE_PRINTER_SUFFIX = "/printer";
 	public static final String TXT_TEMPLATE_TRAY_SUFFIX = "/tray";
 	
-	private static final String SEPARATOR = "/";
+	private static final String SEPARATOR = StringTool.slash;
 	private String printer;
 	private String tray;
 	

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/TextTemplateView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/TextTemplateView.java
@@ -65,6 +65,7 @@ import ch.elexis.data.Mandant;
 import ch.elexis.data.Query;
 import ch.rgw.tools.ExHandler;
 
+import ch.rgw.tools.StringTool;
 public class TextTemplateView extends ViewPart {
 	public static final String ID = "ch.elexis.views.textsystem.TextTemplateView"; //$NON-NLS-1$
 	
@@ -139,7 +140,7 @@ public class TextTemplateView extends ViewPart {
 		
 		// create TextTemplate model for the form template
 		TextTemplate formTemplate =
-			new TextTemplate(template.getBetreff(), "", template.getMimeType());
+			new TextTemplate(template.getBetreff(), StringTool.leer, template.getMimeType());
 		formTemplate.addFormTemplateReference(template);
 		return formTemplate;
 	}
@@ -235,7 +236,7 @@ public class TextTemplateView extends ViewPart {
 	private void createColumns(final Composite parent){
 		String[] titles =
 			{
-				"", "Name der Vorlage", "Typ", "Mandant", "Adressabfrage", "Drucker/Schacht",
+				StringTool.leer, "Name der Vorlage", "Typ", "Mandant", "Adressabfrage", "Drucker/Schacht",
 				"Beschreibung"
 			};
 		int[] bounds = {
@@ -364,7 +365,7 @@ public class TextTemplateView extends ViewPart {
 			public String getText(Object element){
 				if (element instanceof TextTemplate) {
 					TextTemplate template = (TextTemplate) element;
-					String label = "";
+					String label = StringTool.leer;
 					String printer = template.getPrinter();
 					String tray = template.getTray();
 					if (printer != null) {
@@ -484,7 +485,7 @@ public class TextTemplateView extends ViewPart {
 			
 			//all
 			if (index == -1) {
-				template.setMandant("");
+				template.setMandant(StringTool.leer);
 			} else {
 				// specific mandant only
 				Mandant mandant = mandants.get(index);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/model/TextTemplate.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/textsystem/model/TextTemplate.java
@@ -149,7 +149,7 @@ public class TextTemplate {
 	
 	public void setMandant(String mandantId){
 		if (mandantId == null) {
-			mandantId = "";
+			mandantId = StringTool.leer;
 		}
 		this.mandantId = mandantId;
 		updateTemplateReference(UPDATE_TYPE.MANDANT);
@@ -159,14 +159,14 @@ public class TextTemplate {
 	
 	public void setMandant(Mandant mandant){
 		if (mandant == null) {
-			setMandant("");
+			setMandant(StringTool.leer);
 		} else {
 			setMandant(mandant.getId());
 		}
 	}
 	
 	public Mandant getMandant(){
-		Mandant ret = (mandantId == "" ? null : Mandant.load(mandantId));
+		Mandant ret = (mandantId == StringTool.leer ? null : Mandant.load(mandantId));
 		if (ret != null && ret.exists()) {
 			return ret;
 		}
@@ -256,7 +256,7 @@ public class TextTemplate {
 				DocumentSelectDialog.setDontAskForAddresseeForThisTemplate(bt, !askForAddress);
 				break;
 			case SYS_TEMPLATE:
-				String sysTemplate = systemTemplate ? Brief.SYS_TEMPLATE : "";
+				String sysTemplate = systemTemplate ? Brief.SYS_TEMPLATE : StringTool.leer;
 				bt.set(Brief.FLD_KONSULTATION_ID, sysTemplate);
 				break;
 			default:
@@ -275,11 +275,11 @@ public class TextTemplate {
 		
 		if (systemTemplate || mandantId == null || mandantId.isEmpty()) {
 			cfgTemplateBase =
-				TextTemplatePrintSettings.TXT_TEMPLATE_PREFIX_PUBLIC + type + "/" + name;
+				TextTemplatePrintSettings.TXT_TEMPLATE_PREFIX_PUBLIC + type + StringTool.slash + name;
 		} else {
 			cfgTemplateBase =
-				TextTemplatePrintSettings.TXT_TEMPLATE_PREFIX_PRIVATE + mandantId + "/" + type
-					+ "/" + name;
+				TextTemplatePrintSettings.TXT_TEMPLATE_PREFIX_PRIVATE + mandantId + StringTool.slash + type
+					+ StringTool.slash + name;
 		}
 		
 		if (printer != null)

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectFirstPage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectFirstPage.java
@@ -73,10 +73,10 @@ public class DBConnectFirstPage extends WizardPage {
 		FormText alt = tk.createFormText(body, false);
 		StringBuilder old = new StringBuilder();
 		old.append("<form>"); //$NON-NLS-1$
-		String driver = "";
-		String user = "";
-		String typ = "";
-		String connectString = "";
+		String driver = StringTool.leer;
+		String user = StringTool.leer;
+		String typ = StringTool.leer;
+		String connectString = StringTool.leer;
 		Hashtable<Object, Object> hConn = null;
 		String cnt = CoreHub.localCfg.get(Preferences.CFG_FOLDED_CONNECTION, null);
 		if (cnt != null) {
@@ -141,7 +141,7 @@ public class DBConnectFirstPage extends WizardPage {
 					server.setEnabled(false);
 					dbName.setEnabled(true);
 					defaultUser = "sa"; //$NON-NLS-1$
-					defaultPassword = ""; //$NON-NLS-1$
+					defaultPassword = StringTool.leer; //$NON-NLS-1$
 					break;
 				default:
 					break;
@@ -155,11 +155,11 @@ public class DBConnectFirstPage extends WizardPage {
 		});
 		tk.adapt(dbTypes, true, true);
 		tk.createLabel(body, Messages.DBConnectFirstPage_serevrAddress); //$NON-NLS-1$
-		server = tk.createText(body, "", SWT.BORDER); //$NON-NLS-1$
+		server = tk.createText(body, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		TableWrapData twr = new TableWrapData(TableWrapData.FILL_GRAB);
 		server.setLayoutData(twr);
 		tk.createLabel(body, Messages.DBConnectFirstPage_databaseName); //$NON-NLS-1$
-		dbName = tk.createText(body, "", SWT.BORDER); //$NON-NLS-1$
+		dbName = tk.createText(body, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		TableWrapData twr2 = new TableWrapData(TableWrapData.FILL_GRAB);
 		dbName.setLayoutData(twr2);
 		setControl(form);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectSelectionConnectionWizardPage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectSelectionConnectionWizardPage.java
@@ -182,10 +182,10 @@ public class DBConnectSelectionConnectionWizardPage extends DBConnectWizardPage 
 	}
 	
 	private void createEntityArea(Group grpEntity){
-		String driver = "";
-		String user = "";
-		String typ = "";
-		String connection = "";
+		String driver = StringTool.leer;
+		String user = StringTool.leer;
+		String typ = StringTool.leer;
+		String connection = StringTool.leer;
 		
 		Composite typArea = new Composite(grpEntity, SWT.NONE);
 		typArea.setLayout(new GridLayout(2, false));

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectWizard.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBConnectWizard.java
@@ -162,10 +162,10 @@ public class DBConnectWizard extends Wizard {
 	
 	private String parseHostname(String connectionString){
 		int i = connectionString.indexOf("//")+2;
-		if(i==-1) return "";
+		if(i==-1) return StringTool.leer;
 		String woHeader = connectionString.substring(i);
 		int ij = woHeader.indexOf(":");
-		if(ij==-1) return "";
+		if(ij==-1) return StringTool.leer;
 		return woHeader.substring(0, ij);
 	}
 

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBImportFirstPage.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/DBImportFirstPage.java
@@ -79,20 +79,20 @@ public class DBImportFirstPage extends WizardPage {
 				case POSTGRESQL:
 					server.setEnabled(true);
 					dbName.setEnabled(true);
-					defaultUser = ""; //$NON-NLS-1$
-					defaultPassword = ""; //$NON-NLS-1$
+					defaultUser = StringTool.leer; //$NON-NLS-1$
+					defaultPassword = StringTool.leer; //$NON-NLS-1$
 					break;
 				case H2:
 					server.setEnabled(false);
 					dbName.setEnabled(true);
 					defaultUser = "sa";
-					defaultPassword = "";
+					defaultPassword = StringTool.leer;
 					break;
 				case ODBC:
 					server.setEnabled(false);
 					dbName.setEnabled(true);
 					defaultUser = "sa"; //$NON-NLS-1$
-					defaultPassword = ""; //$NON-NLS-1$
+					defaultPassword = StringTool.leer; //$NON-NLS-1$
 					break;
 				default:
 					break;
@@ -107,12 +107,12 @@ public class DBImportFirstPage extends WizardPage {
 		
 		tk.adapt(dbTypes, true, true);
 		tk.createLabel(body, Messages.DBImportFirstPage_serverAddress); //$NON-NLS-1$
-		server = tk.createText(body, "", SWT.BORDER); //$NON-NLS-1$
+		server = tk.createText(body, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		
 		TableWrapData twr = new TableWrapData(TableWrapData.FILL_GRAB);
 		server.setLayoutData(twr);
 		tk.createLabel(body, Messages.DBImportFirstPage_databaseName); //$NON-NLS-1$
-		dbName = tk.createText(body, "", SWT.BORDER); //$NON-NLS-1$
+		dbName = tk.createText(body, StringTool.leer, SWT.BORDER); //$NON-NLS-1$
 		TableWrapData twr2 = new TableWrapData(TableWrapData.FILL_GRAB);
 		dbName.setLayoutData(twr2);
 		if (wiz.preset != null && wiz.preset.length > 1) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/TestDBConnectionGroup.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/wizards/TestDBConnectionGroup.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Label;
 
 import ch.elexis.core.ui.UiDesk;
 
+import ch.rgw.tools.StringTool;
 public class TestDBConnectionGroup extends Group {
 	
 	private Label lblTestResult;
@@ -49,7 +50,7 @@ public class TestDBConnectionGroup extends Group {
 		new Label(this, SWT.NONE);
 		
 		lblTestResult = new Label(this, SWT.BORDER | SWT.WRAP);
-		lblTestResult.setText("");
+		lblTestResult.setText(StringTool.leer);
 		GridData gd_lblTestResult = new GridData(SWT.FILL, SWT.TOP, true, true, 1, 1);
 		gd_lblTestResult.minimumHeight = 60;
 		lblTestResult.setLayoutData(gd_lblTestResult);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/CSVWriter.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/CSVWriter.java
@@ -48,6 +48,7 @@ import java.util.List;
  * @author Glen Smith
  * 
  */
+import ch.rgw.tools.StringTool;
 public class CSVWriter {
 	
 	private Writer rawWriter;
@@ -75,7 +76,7 @@ public class CSVWriter {
 	public static final char NO_QUOTE_CHARACTER = '\u0000';
 	
 	/** Default line terminator uses platform encoding. */
-	public static final String DEFAULT_LINE_END = "\n";
+	public static final String DEFAULT_LINE_END = StringTool.lf;
 	
 	private static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat(
 		"dd-MMM-yyyy HH:mm:ss");
@@ -115,7 +116,7 @@ public class CSVWriter {
 	 *            the character to use for quoted elements
 	 */
 	public CSVWriter(Writer writer, char separator, char quotechar){
-		this(writer, separator, quotechar, "\n");
+		this(writer, separator, quotechar, StringTool.lf);
 	}
 	
 	/**
@@ -200,7 +201,7 @@ public class CSVWriter {
 	private static String getColumnValue(ResultSet rs, int colType, int colIndex)
 		throws SQLException, IOException{
 		
-		String value = "";
+		String value = StringTool.leer;
 		
 		switch (colType) {
 		case Types.BIT:
@@ -229,7 +230,7 @@ public class CSVWriter {
 		case Types.NUMERIC:
 			BigDecimal bd = rs.getBigDecimal(colIndex);
 			if (bd != null) {
-				value = "" + bd.doubleValue();
+				value = StringTool.leer + bd.doubleValue();
 			}
 			break;
 		case Types.INTEGER:
@@ -237,7 +238,7 @@ public class CSVWriter {
 		case Types.SMALLINT:
 			int intValue = rs.getInt(colIndex);
 			if (!rs.wasNull()) {
-				value = "" + intValue;
+				value = StringTool.leer + intValue;
 			}
 			break;
 		case Types.JAVA_OBJECT:
@@ -271,11 +272,11 @@ public class CSVWriter {
 			value = rs.getString(colIndex);
 			break;
 		default:
-			value = "";
+			value = StringTool.leer;
 		}
 		
 		if (value == null) {
-			value = "";
+			value = StringTool.leer;
 		}
 		
 		return value;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/CountArticles.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/CountArticles.java
@@ -28,6 +28,7 @@ import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class CountArticles {
 	HashMap<IVerrechenbar, Integer> paid = new HashMap<IVerrechenbar, Integer>();
 	HashMap<IVerrechenbar, Integer> unpaid = new HashMap<IVerrechenbar, Integer>();
@@ -145,10 +146,10 @@ public class CountArticles {
 				.append(":\n")
 				.append("Bezahlte Artikel: ")
 				.append(mPaid.getAmountAsString())
-				.append("\n")
+				.append(StringTool.lf)
 				.append("Unbezahlte Artikel: ")
 				.append(mUnpaid.getAmountAsString())
-				.append("\n")
+				.append(StringTool.lf)
 				.append(
 					"(Jeweils per Stichtag "
 						+ new TimeTool(referenceDate).toString(TimeTool.DATE_GER)).append(")\n");

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/Counter.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/Counter.java
@@ -18,6 +18,7 @@ import java.util.Hashtable;
 
 import ch.elexis.data.PersistentObject;
 
+import ch.rgw.tools.StringTool;
 public class Counter {
 	private ArrayList<Float> list = new ArrayList<Float>();
 	private Hashtable<Object, Integer> hash = new Hashtable<Object, Integer>();
@@ -89,7 +90,7 @@ public class Counter {
 		for (ObjCounter oc : cnt) {
 			sb.append(oc.count).append("\t\t"); //$NON-NLS-1$
 			PersistentObject po = (PersistentObject) oc.obj;
-			sb.append(po.getLabel()).append("\n"); //$NON-NLS-1$
+			sb.append(po.getLabel()).append(StringTool.lf); //$NON-NLS-1$
 		}
 		return sb.toString();
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/LaborTaxpunktkorrektur.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/LaborTaxpunktkorrektur.java
@@ -86,7 +86,7 @@ public class LaborTaxpunktkorrektur {
 							changed.addMoney(v.getBruttoPreis().multiply(v.getZahl()));
 						}
 					}
-					writer.write("konvertierte " + k.getVerboseLabel() + "\n");
+					writer.write("konvertierte " + k.getVerboseLabel() + StringTool.lf);
 					i++;
 				}
 				

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/LeistungenExport.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/LeistungenExport.java
@@ -26,6 +26,7 @@ import ch.elexis.data.Verrechnet;
 import ch.rgw.tools.ExHandler;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class LeistungenExport {
 	class patums {
 		String ID;
@@ -119,13 +120,13 @@ public class LeistungenExport {
 						String gesetz = fall.getConfiguredBillingSystemLaw().name();
 						String abr = fall.getAbrechnungsSystem();
 						Kontakt kt = fall.getGarant();
-						String rechnungsempfaenger = "";
+						String rechnungsempfaenger = StringTool.leer;
 						if (kt != null) {
 							rechnungsempfaenger = fall.getGarant().getLabel();
 						}
 						Kontakt costBearer = fall.getCostBearer();
-						String kostentraeger = "";
-						String versnr = "";
+						String kostentraeger = StringTool.leer;
+						String versnr = StringTool.leer;
 						if (costBearer != null) {
 							kostentraeger = costBearer.getLabel();
 							versnr = fall.getRequiredString("Versicherungsnummer");
@@ -136,7 +137,7 @@ public class LeistungenExport {
 							for (Verrechnet v : vr) {
 								String[] col = new String[cols.length];
 								for (int i = 0; i < cols.length; i++) {
-									col[i] = "";
+									col[i] = StringTool.leer;
 								}
 								col[UUID] = v.getId();
 								col[PatientID] = pat.getId();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/MediPreisKorrektur.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/MediPreisKorrektur.java
@@ -23,6 +23,7 @@ import ch.elexis.data.Verrechnet;
 import ch.rgw.tools.Money;
 import ch.rgw.tools.TimeTool;
 
+import ch.rgw.tools.StringTool;
 public class MediPreisKorrektur {
 	FileWriter writer;
 	
@@ -67,8 +68,8 @@ public class MediPreisKorrektur {
 				StringBuilder sb = new StringBuilder();
 				sb.append("Konversion beendet. ").append(i)
 					.append(" Konsultationen wurden umgerechnet\n").append("Alter Betrag: ")
-					.append(old.getAmountAsString()).append("\n").append("Neuer Betrag: ")
-					.append(changed.getAmountAsString()).append("\n");
+					.append(old.getAmountAsString()).append(StringTool.lf).append("Neuer Betrag: ")
+					.append(changed.getAmountAsString()).append(StringTool.lf);
 				return sb.toString();
 			} else {
 				return "\nabgebrochen.";

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/Patientenzaehler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/Patientenzaehler.java
@@ -31,6 +31,7 @@ import ch.rgw.tools.TimeTool;
 
 import com.tiff.common.ui.datepicker.DatePicker;
 
+import ch.rgw.tools.StringTool;
 public class Patientenzaehler extends TitleAreaDialog {
 	DatePicker dpVon, dpBis;
 	public int kons, cases, men, women;
@@ -75,7 +76,7 @@ public class Patientenzaehler extends TitleAreaDialog {
 		Query<Konsultation> qbe = new Query<Konsultation>(Konsultation.class);
 		qbe.add("Datum", ">=", ttVon.toString(TimeTool.DATE_COMPACT));
 		qbe.add("Datum", "<=", ttBis.toString(TimeTool.DATE_COMPACT));
-		qbe.add("MandantID", "=", CoreHub.actMandant.getId());
+		qbe.add("MandantID", StringTool.equals, CoreHub.actMandant.getId());
 		HashMap<String, Patient> maenner = new HashMap<String, Patient>();
 		HashMap<String, Patient> frauen = new HashMap<String, Patient>();
 		HashMap<String, Fall> faelle = new HashMap<String, Fall>();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/TarmedTaxpunktkorrektur.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/scripting/TarmedTaxpunktkorrektur.java
@@ -90,7 +90,7 @@ public class TarmedTaxpunktkorrektur {
 							v.setStandardPreis();
 							changed.addMoney(v.getBruttoPreis().multiply(v.getZahl()));
 						}
-						writer.write("konvertierte " + k.getVerboseLabel() + "\n");
+						writer.write("konvertierte " + k.getVerboseLabel() + StringTool.lf);
 					}
 					i++;
 				}

--- a/bundles/ch.elexis.core.ui/src/com/tiff/common/ui/datepicker/DatePicker.java
+++ b/bundles/ch.elexis.core.ui/src/com/tiff/common/ui/datepicker/DatePicker.java
@@ -59,6 +59,7 @@ import org.eclipse.swt.widgets.TypedListener;
  * @author <a href="mailto:andy@tiff.ru">Andrey Onistchuk</a>
  * @version $Revision: 1.2 $
  */
+import ch.rgw.tools.StringTool;
 public class DatePicker extends Composite {
 	
 	// ~ Inner Classes ----------------------------------------------------------
@@ -337,7 +338,7 @@ public class DatePicker extends Composite {
 							: SWT.COLOR_BLACK));
 				}
 				
-				drawTextImage(gc, "" + day, p.x, p.y, colSize, rowSize);
+				drawTextImage(gc, StringTool.leer + day, p.x, p.y, colSize, rowSize);
 				day++;
 			}
 			

--- a/bundles/ch.elexis.core.ui/src/com/tiff/common/ui/datepicker/DatePickerCombo.java
+++ b/bundles/ch.elexis.core.ui/src/com/tiff/common/ui/datepicker/DatePickerCombo.java
@@ -57,6 +57,7 @@ import org.eclipse.swt.widgets.TypedListener;
  * @author <a href="mailto:andy@tiff.ru">Andrey Onistchuk</a>
  * @version $Revision: 1.1 $
  */
+import ch.rgw.tools.StringTool;
 public class DatePickerCombo extends Composite {
 	// ~ Static methods ---------------------------------------------------------
 	
@@ -437,7 +438,7 @@ public class DatePickerCombo extends Composite {
 			Date date = dp.getDate();
 			
 			if (date == null) {
-				text.setText("");
+				text.setText(StringTool.leer);
 			} else {
 				text.setText(getFormat().format(date));
 				text.selectAll();
@@ -830,7 +831,7 @@ public class DatePickerCombo extends Composite {
 			text.selectAll();
 			dp.setDate(date);
 		} else {
-			text.setText("");
+			text.setText(StringTool.leer);
 		}
 		
 		dp.setDate(date);

--- a/bundles/ch.elexis.core/src-gen/ch/elexis/core/types/PathologicDescription.java
+++ b/bundles/ch.elexis.core/src-gen/ch/elexis/core/types/PathologicDescription.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author thomas
  *
  */
+import ch.rgw.tools.StringTool;
 public class PathologicDescription {
 	
 	public enum Description {
@@ -52,23 +53,23 @@ public class PathologicDescription {
 			ret.reference = parts[1];
 		} else if (parts.length == 1 && !parts[0].isEmpty()) {
 			ret.description = Description.valueOf(parts[0]);
-			ret.reference = "";
+			ret.reference = StringTool.leer;
 		}
 		return ret;
 	}
 	
 	public PathologicDescription(Description description){
-		this(description, "");
+		this(description, StringTool.leer);
 	}
 	
 	public PathologicDescription(Description description, String reference){
 		this.description = description;
-		this.reference = (reference != null) ? StringUtils.abbreviate(reference, 90) : "";
+		this.reference = (reference != null) ? StringUtils.abbreviate(reference, 90) : StringTool.leer;
 	}
 	
 	private PathologicDescription(){
 		description = Description.UNKNOWN;
-		reference = "";
+		reference = StringTool.leer;
 	}
 	
 	@Override

--- a/bundles/ch.elexis.core/src/ch/elexis/core/ac/ACE.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/ac/ACE.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import ch.rgw.tools.StringTool;
 public class ACE {
 	
 	public static final String ACE_ROOT_LITERAL = "root";//$NON-NLS-1$	
@@ -113,7 +114,7 @@ public class ACE {
 		sp.append(getName());
 		ACE parent = getParent();
 		while ((parent != null) && (!parent.equals(ACE.ACE_ROOT))) {
-			sp.insert(0, parent.getName() + "/"); //$NON-NLS-1$
+			sp.insert(0, parent.getName() + StringTool.slash); //$NON-NLS-1$
 			parent = parent.getParent();
 		}
 		return sp.toString();
@@ -124,7 +125,7 @@ public class ACE {
 			return ACE_ROOT_LITERAL;
 		int valCan = Math.abs(getCanonicalName().hashCode());
 		int valNam = Math.abs(getName().hashCode());
-		BigInteger valI = new BigInteger(valCan + "" + valNam);
+		BigInteger valI = new BigInteger(valCan + StringTool.leer + valNam);
 		return valI.toString(16);
 	}
 }

--- a/bundles/ch.elexis.core/src/ch/elexis/core/common/DBConnection.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/common/DBConnection.java
@@ -29,6 +29,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
+import ch.rgw.tools.StringTool;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
@@ -50,7 +51,7 @@ public class DBConnection implements Serializable {
 		@XmlEnumValue("MYSQL")
 		MySQL(JdbcLink.MYSQL_DRIVER_CLASS_NAME, "mySQl", "3306"), @XmlEnumValue("PostgreSQL")
 		PostgreSQL(JdbcLink.POSTGRESQL_DRIVER_CLASS_NAME, "PostgreSQL", "5432"), @XmlEnumValue("H2")
-		H2(JdbcLink.H2_DRIVER_CLASS_NAME, "H2", "");
+		H2(JdbcLink.H2_DRIVER_CLASS_NAME, "H2", StringTool.leer);
 
 		public final String driverName;
 		public final String dbType;
@@ -158,7 +159,7 @@ public class DBConnection implements Serializable {
 			m.marshal(this, sw);
 			return sw.toString();
 		} catch (JAXBException | IOException e) {
-			return "";
+			return StringTool.leer;
 		}
 	}
 
@@ -196,11 +197,11 @@ public class DBConnection implements Serializable {
 		URI uri = URI.create(url);
 		String path = uri.getPath();
 		if (!StringUtils.isBlank(path)) {
-			if (path.startsWith("/")) {
+			if (path.startsWith(StringTool.slash)) {
 				path = path.substring(1);
 			}
-			if (path.contains("/")) {
-				path = path.substring(0, path.indexOf("/"));
+			if (path.contains(StringTool.slash)) {
+				path = path.substring(0, path.indexOf(StringTool.slash));
 			}
 			return Optional.of(path);
 		}

--- a/bundles/ch.elexis.core/src/ch/elexis/core/common/InstanceStatus.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/common/InstanceStatus.java
@@ -2,6 +2,7 @@ package ch.elexis.core.common;
 
 import java.util.Date;
 
+import ch.rgw.tools.StringTool;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
@@ -96,7 +97,7 @@ public class InstanceStatus {
 
 	@Override
 	public String toString() {
-		String identifier = getIdentifier() != null ? " @ " + getIdentifier() : "";
+		String identifier = getIdentifier() != null ? " @ " + getIdentifier() : StringTool.leer;
 		String ret = "[" + getUuid() + "] " + getActiveUser() + identifier + " (Version " + getVersion() + " @ "
 				+ getOperatingSystem() + ") ";
 		if (getState() != STATE.ACTIVE) {

--- a/bundles/ch.elexis.core/src/ch/elexis/core/console/AbstractConsoleCommandProvider.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/console/AbstractConsoleCommandProvider.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  * method. And every sub-method to sub-method (separated with a single underscore) is treated same.
  * 
  */
+import ch.rgw.tools.StringTool;
 public abstract class AbstractConsoleCommandProvider implements CommandProvider {
 	
 	public final Logger logger = LoggerFactory.getLogger(getClass());
@@ -49,7 +50,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 				methods.put(method.getName(), method);
 			} else if (method.getName().startsWith("_")) {
 				CmdAdvisor advisor = method.getDeclaredAnnotation(CmdAdvisor.class);
-				String description = (advisor != null) ? advisor.description() : "";
+				String description = (advisor != null) ? advisor.description() : StringTool.leer;
 				commandsHelp.put(method.getName().substring(1), description);
 			}
 			
@@ -90,7 +91,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 		
 		subArguments = Arrays.copyOfRange(arguments, i, arguments.length);
 		
-		String joinedArguments = String.join(" ", arguments);
+		String joinedArguments = String.join(StringTool.space, arguments);
 		ci.println("--( " + new Date() + " )---[cmd: " + joinedArguments + "]"
 			+ getRelativeFixedLengthSeparator(joinedArguments, 100, "-"));
 		
@@ -106,7 +107,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 				} else if (clazz.equals(List.class)) {
 					result = method.invoke(this, Arrays.asList(subArguments));
 				} else if (clazz.equals(String.class)) {
-					result = method.invoke(this, subArguments.length > 0 ? subArguments[0] : "");
+					result = method.invoke(this, subArguments.length > 0 ? subArguments[0] : StringTool.leer);
 				} else {
 					ci.println("invalid parameter type " + clazz);
 				}
@@ -143,12 +144,12 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 	public String getRelativeFixedLengthSeparator(String value, int determinedLength,
 		String separator){
 		if (value == null) {
-			return "";
+			return StringTool.leer;
 		}
 		if (value.length() > determinedLength) {
 			determinedLength = value.length() + 1;
 		}
-		return String.join("", Collections.nCopies(determinedLength - value.length(), separator));
+		return String.join(StringTool.leer, Collections.nCopies(determinedLength - value.length(), separator));
 	}
 	
 	public void fail(String message){
@@ -169,7 +170,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 	
 	@Override
 	public String getHelp(){
-		return getHelp("");
+		return getHelp(StringTool.leer);
 	}
 	
 	public void printHelp(String... sub){
@@ -181,7 +182,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 		help.append("---"); //$NON-NLS-1$
 		help.append(header);
 		help.append("---"); //$NON-NLS-1$
-		help.append("\n");
+		help.append(StringTool.lf);
 	}
 	
 	/** Private helper method for getHelp. Formats the command descriptions. */
@@ -190,7 +191,7 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 		help.append(command);
 		help.append(" - "); //$NON-NLS-1$
 		help.append(description);
-		help.append("\n");
+		help.append(StringTool.lf);
 	}
 	
 	public String getHelp(String... sub){
@@ -199,12 +200,12 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 			return printOverviewHelp();
 		}
 		if (StringUtils.isBlank(sub[0])) {
-			return "";
+			return StringTool.leer;
 		}
 		String[] methodSignatures = methods.keySet().toArray(new String[] {});
 		
-		sb.append(StringUtils.join(sub, " "));
-		sb.append(" ");
+		sb.append(StringUtils.join(sub, StringTool.space));
+		sb.append(StringTool.space);
 		
 		Set<String> relevant = new HashSet<>();
 		for (int i = 0; i < methodSignatures.length; i++) {
@@ -221,20 +222,20 @@ public abstract class AbstractConsoleCommandProvider implements CommandProvider 
 		}
 		
 		if (relevant.isEmpty()) {
-			return "Sub/Command not found: " + StringUtils.join(sub, " ");
+			return "Sub/Command not found: " + StringUtils.join(sub, StringTool.space);
 		}
 		
 		// flatten the set (prevents mulitple entries) to a list
 		List<String> helpList = new ArrayList<>(relevant);
 		Collections.sort(helpList, Comparator.naturalOrder());
 		
-		sb.append("(" + helpList.stream().reduce((u, t) -> u + " | " + t).orElse("") + ")\n");
+		sb.append("(" + helpList.stream().reduce((u, t) -> u + " | " + t).orElse(StringTool.leer) + ")\n");
 		for (String string : helpList) {
 			String methodKey = "__"+StringUtils.join(sub, "_")+"_"+string;
 			Method method = methods.get(methodKey);
 			if(method!=null) {
 				CmdAdvisor declaredAnnotation = method.getDeclaredAnnotation(CmdAdvisor.class);
-				addCommand(string, (declaredAnnotation!=null) ? declaredAnnotation.description(): "", sb);
+				addCommand(string, (declaredAnnotation!=null) ? declaredAnnotation.description(): StringTool.leer, sb);
 			} else {
 				sb.append("\t"+string+" - [see subcommand]\n");
 			}

--- a/bundles/ch.elexis.core/src/ch/elexis/core/console/ConsoleProgressMonitor.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/console/ConsoleProgressMonitor.java
@@ -3,6 +3,7 @@ package ch.elexis.core.console;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.osgi.framework.console.CommandInterpreter;
 
+import ch.rgw.tools.StringTool;
 public class ConsoleProgressMonitor implements IProgressMonitor {
 
 	private CommandInterpreter ci;
@@ -27,7 +28,7 @@ public class ConsoleProgressMonitor implements IProgressMonitor {
 	}
 
 	private void printStatus() {
-		String msg = name + " [" + worked + "/" + totalWork + "]";
+		String msg = name + " [" + worked + StringTool.slash + totalWork + "]";
 		if (cancelled) {
 			msg = "-CNCLD- " + msg;
 		}

--- a/bundles/ch.elexis.core/src/ch/elexis/core/constants/StringConstants.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/constants/StringConstants.java
@@ -19,18 +19,19 @@ package ch.elexis.core.constants;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class StringConstants {
-	public static final String SLASH = "/"; //$NON-NLS-1$
+	public static final String SLASH = StringTool.slash; //$NON-NLS-1$
 	public static final String BACKSLASH = "\\"; //$NON-NLS-1$
-	public static final String SPACE = " "; //$NON-NLS-1$
-	public static final String EMPTY = ""; //$NON-NLS-1$
+	public static final String SPACE = StringTool.space; //$NON-NLS-1$
+	public static final String EMPTY = StringTool.leer; //$NON-NLS-1$
 	public static final String COMMA = ","; //$NON-NLS-1$
 	public static final String COLON = ":"; //$NON-NLS-1$
 	public static final String DASH = "-";
 	public static final String DOUBLECOLON = "::"; //$NON-NLS-1$
 	public static final String SEMICOLON = ";";
-	public static final String CRLF = "\r\n";
-	public static final String LF = "\n";
+	public static final String CRLF = StringTool.crlf;
+	public static final String LF = StringTool.lf;
 	
 	public static final String VERSION_LITERAL = "VERSION"; //$NON-NLS-1$
 	

--- a/bundles/ch.elexis.core/src/ch/elexis/core/exceptions/ElexisException.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/exceptions/ElexisException.java
@@ -13,6 +13,7 @@ package ch.elexis.core.exceptions;
 
 import java.util.logging.Logger;
 
+import ch.rgw.tools.StringTool;
 public class ElexisException extends Exception {
 	private static final long serialVersionUID = -4535064606049686854L;
 	private static Logger log = Logger.getLogger(ElexisException.class.getName());
@@ -35,7 +36,7 @@ public class ElexisException extends Exception {
 		super(errmsg);
 		this.clazz = clazz;
 		this.errcode = errcode;
-		log.severe(clazz.getName() + ": " + errmsg + " " + Integer.toString(errcode));
+		log.severe(clazz.getName() + ": " + errmsg + StringTool.space + Integer.toString(errcode));
 	}
 	
 	public ElexisException(String errmsg, Throwable throwable){

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/format/AddressFormatUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/format/AddressFormatUtil.java
@@ -45,7 +45,7 @@ public class AddressFormatUtil {
 		} else if (person.getGender().equals(Gender.FEMALE)) {
 			salutation = Messages.KontakteView_SalutationF;
 		} else {
-			salutation = ""; //$NON-NLS-1$
+			salutation = StringTool.leer; //$NON-NLS-1$
 		}
 		ret.append(salutation);
 		ret.append(StringTool.space);

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/format/MandatorFormatUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/format/MandatorFormatUtil.java
@@ -2,10 +2,11 @@ package ch.elexis.core.model.format;
 
 import ch.elexis.core.model.IMandator;
 
+import ch.rgw.tools.StringTool;
 public class MandatorFormatUtil {
 	
 	public static String getMandatorLabel(IMandator mandator){
-		return mandator.getDescription1() + " " + mandator.getDescription2() + " ("
+		return mandator.getDescription1() + StringTool.space + mandator.getDescription2() + " ("
 			+ mandator.getDescription3() + ")";
 	}
 	

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PatientFormatUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PatientFormatUtil.java
@@ -2,11 +2,12 @@ package ch.elexis.core.model.format;
 
 import ch.elexis.core.model.IPatient;
 
+import ch.rgw.tools.StringTool;
 public class PatientFormatUtil {
 	
 	public static String getNarrativeText(IPatient patient){
-		return ((patient.getTitel() != null) ? patient.getTitel() + " " : "")
-			+ patient.getFirstName() + " " + patient.getLastName() + " ("
+		return ((patient.getTitel() != null) ? patient.getTitel() + StringTool.space : StringTool.leer)
+			+ patient.getFirstName() + StringTool.space + patient.getLastName() + " ("
 			+ PersonFormatUtil.getGenderCharLocalized(patient) + "), "
 			+ PersonFormatUtil.getDateOfBirth(patient) + " (" + patient.getAgeInYears()
 			+ ") - [" + patient.getPatientNr() + "]";

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PersonFormatUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PersonFormatUtil.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import ch.elexis.core.model.IPerson;
 import ch.elexis.core.types.Gender;
 
+import ch.rgw.tools.StringTool;
 public class PersonFormatUtil {
 	
 	private static DateTimeFormatter defaultDateFormatter =
@@ -24,7 +25,7 @@ public class PersonFormatUtil {
 		if (dob != null) {
 			return dob.format(defaultDateFormatter);
 		}
-		return "";
+		return StringTool.leer;
 	}
 	
 	/**
@@ -60,7 +61,7 @@ public class PersonFormatUtil {
 			sb.append(person.getLastName());
 		}
 		if (StringUtils.isNotBlank(sb.toString())) {
-			sb.append(" ");
+			sb.append(StringTool.space);
 		}
 		if (StringUtils.isNoneEmpty(person.getFirstName())) {
 			sb.append(person.getFirstName());

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PostalAddress.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/format/PostalAddress.java
@@ -111,8 +111,8 @@ public class PostalAddress {
 			zeileList.add(tokenizer.nextToken());
 		}
 		// Zeilen interpretieren (so gut es geht)
-		String plzOrt = ""; //$NON-NLS-1$
-		String nameVorname = ""; //$NON-NLS-1$
+		String plzOrt = StringTool.leer; //$NON-NLS-1$
+		String nameVorname = StringTool.leer; //$NON-NLS-1$
 		final int len = zeileList.size();
 		switch (len) {
 		case 0: // Kann gar nicht sein, aber man weiss ja nie!
@@ -126,7 +126,7 @@ public class PostalAddress {
 			break;
 		case 3: // NameVorname, Adr1, Ortsangaben ODER Anrede, NameVorname,
 			// Ortsangaben
-			if (zeileList.get(0).indexOf(" ") < 0) { //$NON-NLS-1$
+			if (zeileList.get(0).indexOf(StringTool.space) < 0) { //$NON-NLS-1$
 				// Erste Zeile Anrede
 				salutation = zeileList.get(0);
 				nameVorname = zeileList.get(1);
@@ -141,7 +141,7 @@ public class PostalAddress {
 		case 4: // NameVorname, Adr1, Adr2, Ortsangaben ODER Anrede,
 			// NameVorname, Adr1,
 			// Ortsangaben
-			if (zeileList.get(0).indexOf(" ") < 0) { //$NON-NLS-1$
+			if (zeileList.get(0).indexOf(StringTool.space) < 0) { //$NON-NLS-1$
 				// Erste Zeile Anrede
 				salutation = zeileList.get(0);
 				nameVorname = zeileList.get(1);
@@ -169,7 +169,7 @@ public class PostalAddress {
 		// NameVorname aufteilen. Z.B. Von Allmen Christoph
 		if (!StringTool.isNothing(nameVorname)) {
 			nameVorname = nameVorname.trim();
-			int index = nameVorname.lastIndexOf(" "); // Z.B. Von Allmen Christoph //$NON-NLS-1$
+			int index = nameVorname.lastIndexOf(StringTool.space); // Z.B. Von Allmen Christoph //$NON-NLS-1$
 			if (index > 0) {
 				lastName = nameVorname.substring(0, index);
 				firstName = nameVorname.substring(index + 1);
@@ -186,7 +186,7 @@ public class PostalAddress {
 			plzOrt = plzOrt.substring(index + 1);
 			city = plzOrt;
 		}
-		if (plzOrt.indexOf(" ") > 0) { //$NON-NLS-1$
+		if (plzOrt.indexOf(StringTool.space) > 0) { //$NON-NLS-1$
 			// Read zip code
 			int index = plzOrt.indexOf(StringConstants.SPACE);
 			zip = plzOrt.substring(0, index);

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/prescription/Methods.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/prescription/Methods.java
@@ -4,18 +4,19 @@ import java.util.Arrays;
 
 import ch.elexis.core.services.IMedicationService;
 
+import ch.rgw.tools.StringTool;
 public class Methods {
 	/**
 	 * 
 	 * @return the signature split into a string array with 4 elements; will always return an array
-	 *         of 4 elements, where empty entries are of type String ""
+	 *         of 4 elements, where empty entries are of type String StringTool.leer
 	 * @since 3.1.0
 	 * @since 3.2.0 relocated from Prescription
 	 * @deprecated use {@link IMedicationService} method instead.
 	 */
 	public static String[] getSignatureAsStringArray(String signature){
 		String[] daytimeSignature = new String[4];
-		Arrays.fill(daytimeSignature, "");
+		Arrays.fill(daytimeSignature, StringTool.leer);
 		if (signature != null) {
 			// Match stuff like '1/2', '7/8'
 			//			if (signature.matches("^[0-9]/[0-9]$")) {
@@ -31,7 +32,7 @@ public class Methods {
 					System.arraycopy(split, 0, daytimeSignature, 0, split.length);
 					return getDayTimeOrFreetextSignatureArray(daytimeSignature);
 				}
-			} else if (signature.indexOf("/") != -1) {
+			} else if (signature.indexOf(StringTool.slash) != -1) {
 				String[] split = signature.split("[/]"); //$NON-NLS-1$
 				if (split.length > 0 && split.length < 5) {
 					System.arraycopy(split, 0, daytimeSignature, 0, split.length);
@@ -61,7 +62,7 @@ public class Methods {
 	 */
 	private static String[] getDayTimeOrFreetextSignatureArray(String[] signature){
 		String[] values = new String[4];
-		Arrays.fill(values, "");
+		Arrays.fill(values, StringTool.leer);
 		
 		String morn = signature[0];
 		String noon = signature[1];

--- a/bundles/ch.elexis.core/src/ch/elexis/core/model/tasks/TaskException.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/model/tasks/TaskException.java
@@ -2,6 +2,7 @@ package ch.elexis.core.model.tasks;
 
 import ch.rgw.tools.Result;
 
+import ch.rgw.tools.StringTool;
 public class TaskException extends Exception {
 	/**
 	 * The task service was rejecting the execution of this task
@@ -48,7 +49,7 @@ public class TaskException extends Exception {
 	}
 	
 	public TaskException(int exceptionCode, @SuppressWarnings("rawtypes") Result result) {
-		this(exceptionCode, (result != null) ? result.toString() : "");
+		this(exceptionCode, (result != null) ? result.toString() : StringTool.leer);
 	}
 	
 	public int getExceptionCode(){

--- a/bundles/ch.elexis.core/src/ch/elexis/core/services/IMedicationService.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/services/IMedicationService.java
@@ -11,6 +11,7 @@ import ch.elexis.core.model.IPrescription;
 import ch.elexis.core.model.IRecipe;
 import ch.elexis.core.model.prescription.EntryType;
 
+import ch.rgw.tools.StringTool;
 public interface IMedicationService {
 	
 	/**
@@ -93,7 +94,7 @@ public interface IMedicationService {
 	/**
 	 * 
 	 * @return the signature split into a string array with 4 elements; will always return an array
-	 *         of 4 elements, where empty entries are of type String ""
+	 *         of 4 elements, where empty entries are of type String StringTool.leer
 	 */
 	public String[] getSignatureAsStringArray(String signature);
 }

--- a/bundles/ch.elexis.core/src/ch/elexis/core/status/StatusUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/status/StatusUtil.java
@@ -13,9 +13,10 @@ import org.slf4j.Logger;
 import ch.elexis.core.jdt.NonNull;
 
 // TODO refactor ...
+import ch.rgw.tools.StringTool;
 public class StatusUtil {
 	public static void printStatus(Logger log, IStatus status) {
-		print(log, "", status);
+		print(log, StringTool.leer, status);
 	}
 
 	public static void print(Logger log, String indent, IStatus status) {
@@ -31,7 +32,7 @@ public class StatusUtil {
 	}
 
 	public static void printStatus(PrintStream out, IStatus status) {
-		print(out, "", status);
+		print(out, StringTool.leer, status);
 	}
 
 	public static String printStatus(IStatus status) {
@@ -109,7 +110,7 @@ public class StatusUtil {
 			sb.append("[MULTISTATUS] ");
 		}
 		if (prependMessage != null) {
-			sb.append(prependMessage + " ");
+			sb.append(prependMessage + StringTool.space);
 		}
 		sb.append("(c" + status.getCode() + "/s" + status.getSeverity() + ") ");
 		sb.append(status.getMessage());

--- a/bundles/ch.elexis.core/src/ch/elexis/core/text/model/Macro.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/text/model/Macro.java
@@ -10,9 +10,10 @@
  ******************************************************************************/
 package ch.elexis.core.text.model;
 
+import ch.rgw.tools.StringTool;
 public class Macro {
 	
 	public static String resolve(String key){
-		return "";
+		return StringTool.leer;
 	}
 }

--- a/bundles/ch.elexis.core/src/ch/elexis/core/text/model/SSDRange.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/text/model/SSDRange.java
@@ -22,6 +22,7 @@ import org.jdom.Element;
  * @author gerry
  * 
  */
+import ch.rgw.tools.StringTool;
 public class SSDRange {
 	public static final String TYPE_MARKUP = "markup";
 	public static final String TYPE_XREF = "xref";
@@ -72,7 +73,7 @@ public class SSDRange {
 		typename = el.getAttributeValue(ATTR_TYPENAME);
 		position = Integer.parseInt(el.getAttributeValue(ATTR_START_OFFSET));
 		length = Integer.parseInt(el.getAttributeValue(ATTR_LENGTH));
-		// length=Integer.parseInt(el.getAttributeValue(""));
+		// length=Integer.parseInt(el.getAttributeValue(StringTool.leer));
 		hint = el.getAttributeValue(ATTR_HINT);
 		String v = el.getAttributeValue(ATTR_VIEWPORT);
 		if (v != null && v.matches("\\d+,\\d+,\\d+,\\d+")) {

--- a/bundles/ch.elexis.core/src/ch/elexis/core/text/model/Samdas.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/text/model/Samdas.java
@@ -32,6 +32,7 @@ import ch.rgw.tools.TimeTool;
  * XML-Schema, das die Übertragung medizinischer Krankengeschichten (Elecronic medical record, EMR)
  * zwischen verschiedenen Endanwendungen ermöglicht. Diese Klasse ist ein API dafür
  */
+import ch.rgw.tools.StringTool;
 public class Samdas {
 	public static final String ELEM_ROOT = "EMR"; //$NON-NLS-1$
 	public static final String ELEM_TEXT = "text"; //$NON-NLS-1$
@@ -111,7 +112,7 @@ public class Samdas {
 	public String getRecordText(){
 		Element rec = getRecordElement();
 		String ret = rec.getChildText(ELEM_TEXT, ns);
-		return ret == null ? "" : ret; //$NON-NLS-1$
+		return ret == null ? StringTool.leer : ret; //$NON-NLS-1$
 	}
 	
 	public Element getRecordElement(){

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/CoreUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/CoreUtil.java
@@ -68,7 +68,7 @@ public class CoreUtil {
 			}
 			ret.rdbmsType = DBType.H2;
 			ret.username = "sa";
-			ret.password = "";
+			ret.password = StringTool.leer;
 			return Optional.of(ret);
 		}
 		
@@ -77,11 +77,11 @@ public class CoreUtil {
 			dbConnection.username =
 				System.getProperty(ElexisSystemPropertyConstants.CONN_DB_USERNAME) != null
 						? System.getProperty(ElexisSystemPropertyConstants.CONN_DB_USERNAME)
-						: "";
+						: StringTool.leer;
 			dbConnection.password =
 				System.getProperty(ElexisSystemPropertyConstants.CONN_DB_PASSWORD) != null
 						? System.getProperty(ElexisSystemPropertyConstants.CONN_DB_PASSWORD)
-						: "";
+						: StringTool.leer;
 			
 			if (System.getProperty(ElexisSystemPropertyConstants.CONN_DB_FLAVOR) != null) {
 				String flavorString =
@@ -93,7 +93,7 @@ public class CoreUtil {
 			dbConnection.connectionString =
 				System.getProperty(ElexisSystemPropertyConstants.CONN_DB_SPEC) != null
 						? System.getProperty(ElexisSystemPropertyConstants.CONN_DB_SPEC)
-						: "";
+						: StringTool.leer;
 			return Optional.of(dbConnection);
 		}
 		
@@ -126,7 +126,7 @@ public class CoreUtil {
 				StringBuilder sb = new StringBuilder();
 				for (Object object : hConn.keySet()) {
 					if (object instanceof String) {
-						sb.append("\n").append(object).append("->").append(hConn.get(object));
+						sb.append(StringTool.lf).append(object).append("->").append(hConn.get(object));
 					}
 				}
 				logger.error(

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/FileUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/FileUtil.java
@@ -15,6 +15,7 @@ import ch.rgw.tools.TimeTool;
  * @author med1
  *
  */
+import ch.rgw.tools.StringTool;
 public class FileUtil {
 	
 	/**
@@ -25,7 +26,7 @@ public class FileUtil {
 	 */
 	public static String removeInvalidChars(String filename){
 		if (filename != null) {
-			return filename.replaceAll("[\\\\/:*?\"<>|]", "");
+			return filename.replaceAll("[\\\\/:*?\"<>|]", StringTool.leer);
 		}
 		return filename;
 	}

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/KontaktMatcher.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/KontaktMatcher.java
@@ -93,13 +93,13 @@ public class KontaktMatcher {
 	 * 
 	 * @param str
 	 *            a string containing possibly zip and possibly place
-	 * @return always a two element array, [0] is zip or "", [1] is place or ""
+	 * @return always a two element array, [0] is zip or StringTool.leer, [1] is place or StringTool.leer
 	 */
 	public static String[] normalizeAddress(String str){
 		String[] ret = str.split("\\s+", 2); //$NON-NLS-1$
 		if (ret.length < 2) {
 			String[] rx = new String[2];
-			rx[0] = "";
+			rx[0] = StringTool.leer;
 			rx[1] = ret[0];
 			return rx;
 		}

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/PlatformHelper.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/PlatformHelper.java
@@ -18,17 +18,18 @@ import java.net.URL;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 
+import ch.rgw.tools.StringTool;
 public class PlatformHelper {
 	public static String getBasePath(String pluginID){
 		try {
-			URL url = Platform.getBundle(pluginID).getEntry("/");
+			URL url = Platform.getBundle(pluginID).getEntry(StringTool.slash);
 			url = FileLocator.toFileURL(url);
 			String bundleLocation = url.getPath();
 			File file = new File(bundleLocation);
 			bundleLocation = file.getAbsolutePath();
 			return bundleLocation;
 		} catch (Throwable throwable) {
-			return "";
+			return StringTool.leer;
 		}
 	}
 }

--- a/bundles/org.iatrix.help.wiki/src/org/iatrix/help/wiki/views/WikiView.java
+++ b/bundles/org.iatrix.help.wiki/src/org/iatrix/help/wiki/views/WikiView.java
@@ -81,7 +81,7 @@ public class WikiView extends ViewPart implements ISaveablePart2 {
 			tokens[i] = tokens[i].substring(0, 1).toUpperCase() + tokens[i].substring(1);
 		}
 		
-		String wikiName = StringTool.join(tokens, "");
+		String wikiName = StringTool.join(tokens, StringTool.leer);
 		return wikiName;
 	}
 	

--- a/ch.elexis.core.releng/use_stringtool.rb
+++ b/ch.elexis.core.releng/use_stringtool.rb
@@ -1,0 +1,151 @@
+#!/usr/bin/env ruby
+require 'bundler/inline'
+puts "It may take some time for bundler/inline to install the dependencies"
+gemfile do
+  source 'https://rubygems.org'
+  gem 'optimist'
+  gem 'pry-byebug'
+  gem 'test-unit'
+end
+
+begin
+require 'pry'
+rescue
+end
+require 'optimist'
+
+StringToolConstants = 
+    {
+      '\1StringTool.backslash' => /(\s|\()"\\""/,
+      '\1StringTool.leer' => /(\s|\()""/,
+      'StringTool.space' => '" "',
+      'StringTool.equals' => '"="',
+      'StringTool.crlf' => /"\\r\\n"/,
+      'StringTool.lf' => /"\\n"/,
+      'StringTool.slash' => '"/"',
+    }
+@options = Optimist::options do
+  version "#{File.basename(__FILE__)} (c) 2019 by Niklaus Giger <niklaus.giger@member.fsf.org>"
+  banner <<-EOS
+Useage: #{File.basename(__FILE__)} directory
+  Converts simple strings like '', ' ', '=' to it ch.rgw.tools.StringTool equivalent, eg StringTool.empty
+  in all java files in the directory and all its subdirectories
+  Without any parameters it just runs some unit tests
+  #{version}
+EOS
+end
+
+def fix_line(line)
+  found = false
+  # return found, line if /"\\"/.match(line)
+  StringToolConstants.each do |constant, string|
+    found = true if m = line.match(string)
+    line = line.gsub(string, constant)
+  end
+  return found, line
+end
+
+STRINGTOOL_IMPORT = "import ch.rgw.tools.StringTool;\n"
+
+def fix_header(filename, lines)
+  lines.each_with_index do |line, pos| 
+     # puts "#{pos}: #{line}"
+     if line.index(STRINGTOOL_IMPORT)
+       puts "Found #{STRINGTOOL_IMPORT} in #{filename}" if $VERBOSE
+       return
+     end
+     if /^@Suppress|^@Deprecated|^@Componen|XmlRootElement|^public|^class/.match(line)
+       puts "Found public class at line #{pos} in #{filename}" if $VERBOSE
+       lines.insert(pos, STRINGTOOL_IMPORT)
+       return
+     end
+     
+  end
+end
+
+def fix_file(filename)
+  return if /ch.rgw.utility/.match(filename)
+  # Some bundles do not depend on ch.rgw.utility
+  return if /ch.elexis.core.logback.rocketchat|ch.elexis.core.jpa.datasource|ch.elexis.core.findings\/|ch.elexis.core.ui.icons|ch.elexis.core.document|ch.elexis.core.jpa.entities/.match(filename)
+  return if /ch.elexis.core.ui.perspective|ch.elexis.core.ui.chromium/.match(filename)
+  lines = IO.readlines(filename)
+  new_lines = []
+  hasChanges = false
+  lines.each do |line|
+    found, newLine = fix_line(line)
+    if found
+      hasChanges = found 
+    end
+    new_lines << newLine 
+  end
+  fix_header(filename, new_lines) if hasChanges
+  File.open(filename, 'w+') { |f| f.write(new_lines.join("")) }
+  puts "Update #{filename}" if hasChanges
+end
+
+if ARGV.size > 0
+  @main_dir = File.expand_path(ARGV.first)
+  raise "We expected #{ARGV.first} to be the name of an existing directory" unless File.directory?(@main_dir)
+  @scriptStarted = Time.now
+
+  @allJavaFile = Dir.glob("#{@main_dir}/**/*.java")
+  puts "Handling #{@allJavaFile.size} java files" 
+
+  @allJavaFile.each do |javafile|
+    puts "Javafile #{javafile}" if $VERBOSE
+    fix_file(javafile)
+  end
+
+  @scriptStopped = Time.now
+  @diffSeconds = (@scriptStopped-@scriptStarted).to_i
+  puts "#{Time.now}: Script finished after #{sprintf('%i:%02i', @diffSeconds/60, @diffSeconds%60)}. Reloaded #{@nr_loaded} redmine tickets"
+else # built in unit test
+  require 'test/unit'
+  require 'test/unit/ui/console/testrunner'
+
+  class MyTest < Test::Unit::TestCase  
+    def test_leer
+      assert_equal([true, '  String txt1 = p1.getText().orElse(StringTool.leer);'], fix_line(
+                   '  String txt1 = p1.getText().orElse("");'));
+    end
+    
+    def test_space
+      assert_equal([true, 'int index = text.indexOf(StringTool.space);'], fix_line(
+                   'int index = text.indexOf(" ");'));
+    end
+    def test_nothing
+      assert_equal([false, 'int index = text.indexOf("Dummy");'], fix_line(
+                   'int index = text.indexOf("Dummy");'));
+    end
+    def test_lf
+      assert_equal([true, 'Collectors.joining(StringTool.lf)'], fix_line(
+                   'Collectors.joining("\n")'));
+    end    
+    def test_backslash
+      assert_equal([true, 'String repl = StringTool.backslash'], fix_line(
+                   'String repl = "\""'));
+    end
+    def test_crlf
+      assert_equal([true, 'actPat.setDiagnosen(oldDiag + StringTool.crlf + newDiag.toString());'], fix_line(
+                   'actPat.setDiagnosen(oldDiag + "\r\n" + newDiag.toString());'));
+    end
+    def test_escacped
+      assert_equal([false, 'matcher.appendReplacement(sb, "\"\"");'], fix_line(
+                   'matcher.appendReplacement(sb, "\"\"");'));
+    end
+  end
+
+  my_tests = Test::Unit::TestSuite.new
+  my_tests << MyTest.new('test_space')
+  my_tests << MyTest.new('test_leer')
+  my_tests << MyTest.new('test_nothing')
+  my_tests << MyTest.new('test_crlf')
+  my_tests << MyTest.new('test_lf')
+  my_tests << MyTest.new('test_backslash')
+  my_tests << MyTest.new('test_escacped')
+
+  #run the suite
+  res = Test::Unit::UI::Console::TestRunner.run(my_tests)
+  exit (res.faults.size == 0) ? 0 : 3
+end
+


### PR DESCRIPTION
Hilfescript erstellt, um in allen Java-Dateien die Ausdrücke wie " ", "=" oder "" durch die entsprechenden Konstanten aus dem StringTool zu ersetzen.

Script so angepasst, dass die Bundles aus dem elexis-3-core, welche ch.rgw.utility nicht schon brauchen, weggelassen werden.

Kompiliert. Die RCPTT-Tests zeigen die gleichen Fehler wie ohne diesen Patch.