### PR TITLE
Adds build configuration for Github actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,22 @@
+# This workflow will build the Eclipse RCP application with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Build with Maven
+      run: mvn -V clean verify  -Dtycho.localArtifacts=ignore -DskipTests=true


### PR DESCRIPTION
Github offers free build validation on their server for commits and pull
requests.
This configuration file adds this based on the default build command to
avoid any build issue, as this is a free server this validation does not
harm even if Travis is also active.

Additional advantage is that everyone who clones this repo will also
have this action enabled so any PR received will automatically be
validated by the Github action.

Currently the test execution is disabled as the test currently fail in
the Tycho build. Once the test run locally with Tycho it should be
evaluated if the test can be included in the test run.