### PR TITLE
Tycho pomless extension updated to 1.7.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.0.0</version>
+    <version>1.7.0</version>
   </extension>
 </extensions>


### PR DESCRIPTION
While not strictly necessary it is recommended to keep the pomless
extension in sync with the the used Tycho version to avoid strange build
issues.