### PR TITLE
VerrechnungsDisplay_doNotCharge taucht beim Starten auf als nicht

### DIFF
--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
@@ -5393,8 +5393,6 @@ VerrechnungsDisplay_confirmChangeTextCaption = really change description
 
 VerrechnungsDisplay_doBill = billing
 
-VerrechnungsDisplay_doNotCharge = Anz
-
 VerrechnungsDisplay_enterNewPrice = enter the new price for this service (x.xx oder -x%)
 
 VerrechnungsDisplay_error = error

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
@@ -5375,8 +5375,6 @@ VerrechnungsDisplay_confirmChangeTextCaption = Wirklich Text \u00E4ndern?
 
 VerrechnungsDisplay_doBill = Verrechnen
 
-VerrechnungsDisplay_doNotCharge = Anz
-
 VerrechnungsDisplay_enterNewPrice = Geben Sie bitte den neuen Preis f\u00FCr die Leistung ein (x.xx oder -x%).
 
 VerrechnungsDisplay_error = Fehler

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
@@ -5301,8 +5301,6 @@ VerrechnungsDisplay_confirmChangeTextCaption = Really change text?
 
 VerrechnungsDisplay_doBill = offset
 
-VerrechnungsDisplay_doNotCharge = Anz
-
 VerrechnungsDisplay_enterNewPrice = Please enter the new price for the service (x.xx or -x%).
 
 VerrechnungsDisplay_error = error

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
@@ -5281,8 +5281,6 @@ VerrechnungsDisplay_confirmChangeTextCaption = Vraiment changer le texte?
 
 VerrechnungsDisplay_doBill = Facturation
 
-VerrechnungsDisplay_doNotCharge = Anz
-
 VerrechnungsDisplay_enterNewPrice = S'il vous pla\u00EEt entrer le nouveau prix pour la performance d'un (ou x.xx -x%).
 
 VerrechnungsDisplay_error = Erreur

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
@@ -5281,8 +5281,6 @@ VerrechnungsDisplay_confirmChangeTextCaption = Davvero cambiare il testo?
 
 VerrechnungsDisplay_doBill = Fatturazione
 
-VerrechnungsDisplay_doNotCharge = Anz
-
 VerrechnungsDisplay_enterNewPrice = Si prega di inserire il nuovo prezzo per l'esecuzione di uno (o x.xx -x%).
 
 VerrechnungsDisplay_error = Errore


### PR DESCRIPTION
verwendet

Commit löscht VerrechnungsDisplay_doNotCharge in allen
Uebersetztungsfiles