### PR TITLE
jre.bundles/downloaded wird .gitignore hinzugefuegt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ workspace/
 profile.tmp
 .polyglot.build.properties
 bundles/ch.elexis.core.data/rsc/version.properties
+jre.bundles/downloaded/


### PR DESCRIPTION
Nach einem Tycho build tauchen bei mir die zip und tar Einträge des JREs
auf. Wahrscheinlich sollten diese von Git ignoriert werden, von daher
fügt dieser Commit sie dem .gitignore hinzu.