### PR TITLE
Fuege fehlende @Override und @Deprecated annatationen für Views hinzu

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUF2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUF2.java
@@ -63,6 +63,7 @@ public class AUF2 extends ViewPart implements IActivationListener {
 	private Action newAUF, delAUF, modAUF, printAUF;
 	private ElexisEventListener eli_auf = new ElexisUiEventListenerImpl(AUF.class) {
 		
+		@Override
 		public void runInUi(ElexisEvent ev){
 			boolean bSelect = (ev.getType() == ElexisEvent.EVENT_SELECTED);
 			modAUF.setEnabled(bSelect);
@@ -80,6 +81,7 @@ public class AUF2 extends ViewPart implements IActivationListener {
 	};
 	private ElexisEventListener eli_pat = new ElexisUiEventListenerImpl(Patient.class) {
 		
+		@Override
 		public void runInUi(ElexisEvent ev){
 			if (ev.getType() == ElexisEvent.EVENT_SELECTED) {
 				tv.refresh();
@@ -113,6 +115,7 @@ public class AUF2 extends ViewPart implements IActivationListener {
 		GlobalEventDispatcher.addActivationListener(this, this);
 		tv.addSelectionChangedListener(GlobalEventDispatcher.getInstance().getDefaultListener());
 		tv.addDoubleClickListener(new IDoubleClickListener() {
+			@Override
 			public void doubleClick(DoubleClickEvent event){
 				modAUF.run();
 			}
@@ -232,6 +235,7 @@ public class AUF2 extends ViewPart implements IActivationListener {
 	
 	class AUFContentProvider implements IStructuredContentProvider {
 		
+		@Override
 		public Object[] getElements(Object inputElement){
 			Patient pat = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
 			if (pat == null) {
@@ -244,18 +248,22 @@ public class AUF2 extends ViewPart implements IActivationListener {
 			return list.toArray();
 		}
 		
+		@Override
 		public void dispose(){ /* leer */
 		}
 		
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput){
 			/* leer */
 		}
 		
 	}
 	
+	@Override
 	public void activation(boolean mode){ /* egal */
 	}
 	
+	@Override
 	public void visible(boolean mode){
 		if (mode) {
 			ElexisEventDispatcher.getInstance().addListeners(eli_auf, eli_pat);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUFZeugnis.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/AUFZeugnis.java
@@ -88,22 +88,26 @@ public class AUFZeugnis extends ViewPart implements ICallback, IActivationListen
 		return text;
 	}
 	
+	@Override
 	public void save(){
 		if (actBrief != null) {
 			actBrief.save(text.getPlugin().storeToByteArray(), text.getPlugin().getMimeType());
 		}
 	}
 	
+	@Override
 	public boolean saveAs(){
 		return true;
 	}
 	
+	@Override
 	public void activation(boolean mode){
 		if (mode == false) {
 			save();
 		}
 	}
 	
+	@Override
 	public void visible(boolean mode){}
 	
 }

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BBSView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BBSView.java
@@ -168,6 +168,7 @@ public class BBSView extends ViewPart implements ISelectionChangedListener, ISav
 	
 	class NewThread implements ViewerConfigurer.ButtonProvider {
 		
+		@Override
 		public Button createButton(Composite parent){
 			Button ret = new Button(parent, SWT.PUSH);
 			ret.setText(Messages.BBSView_21); //$NON-NLS-1$
@@ -187,12 +188,14 @@ public class BBSView extends ViewPart implements ISelectionChangedListener, ISav
 			return ret;
 		}
 		
+		@Override
 		public boolean isAlwaysEnabled(){
 			return false;
 		}
 		
 	}
 	
+	@Override
 	public void selectionChanged(SelectionChangedEvent event){
 		setDisplay();
 	}
@@ -202,23 +205,29 @@ public class BBSView extends ViewPart implements ISelectionChangedListener, ISav
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */}
 	
+	@Override
 	public void doSaveAs(){ /* leer */}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellBlatt.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellBlatt.java
@@ -140,12 +140,14 @@ public class BestellBlatt extends ViewPart implements ICallback {
 		
 	}
 	
+	@Override
 	public void save(){
 		if (actBest != null) {
 			actBest.save(text.getPlugin().storeToByteArray(), text.getPlugin().getMimeType());
 		}
 	}
 	
+	@Override
 	public boolean saveAs(){
 		// TODO Automatisch erstellter Methoden-Stub
 		return false;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BestellView.java
@@ -334,10 +334,12 @@ public class BestellView extends ViewPart implements ISaveablePart2 {
 	
 	private class BestellungLabelProvider extends LabelProvider implements ITableLabelProvider {
 		
+		@Override
 		public Image getColumnImage(final Object element, final int columnIndex){
 			return null;
 		}
 		
+		@Override
 		public String getColumnText(final Object element, final int columnIndex){
 			IOrderEntry entry = (IOrderEntry) element;
 			switch (columnIndex) {
@@ -685,25 +687,31 @@ public class BestellView extends ViewPart implements ISaveablePart2 {
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(final IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BriefAuswahl.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BriefAuswahl.java
@@ -202,6 +202,7 @@ public class BriefAuswahl extends ViewPart implements
 	
 	public void relabel(){
 		UiDesk.asyncExec(new Runnable() {
+			@Override
 			public void run(){
 				Patient pat = (Patient) ElexisEventDispatcher.getSelected(Patient.class);
 				if (form != null && !form.isDisposed()) {
@@ -664,11 +665,13 @@ public class BriefAuswahl extends ViewPart implements
 		}
 	}
 	
+	@Override
 	public void activation(final boolean mode){
 		// TODO Auto-generated method stub
 		
 	}
 	
+	@Override
 	public void visible(final boolean mode){
 		if (mode == true) {
 			ElexisEventDispatcher.getInstance().addListeners(this);
@@ -685,29 +688,36 @@ public class BriefAuswahl extends ViewPart implements
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(final IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}
 	
+	@Override
 	public void catchElexisEvent(ElexisEvent ev){
 		relabel();
 	}
@@ -715,6 +725,7 @@ public class BriefAuswahl extends ViewPart implements
 	private static ElexisEvent template = new ElexisEvent(null, Patient.class,
 		ElexisEvent.EVENT_SELECTED | ElexisEvent.EVENT_DESELECTED);
 	
+	@Override
 	public ElexisEvent getElexisEventFilter(){
 		return template;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/DiagnosenDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/DiagnosenDisplay.java
@@ -95,6 +95,7 @@ public class DiagnosenDisplay extends Composite implements IUnlockable {
 	private ToolBar toolBar;
 	private TableColumnLayout tableLayout;
 	
+	@Override
 	public void setEnabled(boolean enabled) {
 		toolBar.setEnabled(enabled);
 		super.setEnabled(enabled);
@@ -182,6 +183,7 @@ public class DiagnosenDisplay extends Composite implements IUnlockable {
 		
 		// connect double click on column to actions
 		table.addMouseListener(new MouseAdapter() {
+			@Override
 			public void mouseDoubleClick(MouseEvent e){
 				int clickedIndex = -1;
 				// calculate column of click
@@ -373,19 +375,23 @@ public class DiagnosenDisplay extends Composite implements IUnlockable {
 		MenuManager contextMenuManager = new MenuManager();
 		contextMenuManager.setRemoveAllWhenShown(true);
 		contextMenuManager.addMenuListener(new IMenuListener() {
+			@Override
 			public void menuAboutToShow(IMenuManager manager){
 				IStructuredSelection selection = viewer.getStructuredSelection();
 				if (!selection.isEmpty()) {
 					manager.add(new Action() {
 						
+						@Override
 						public ImageDescriptor getImageDescriptor(){
 							return Images.IMG_DELETE.getImageDescriptor();
 						};
 						
+						@Override
 						public String getText(){
 							return Messages.DiagnosenDisplay_RemoveDiagnoses;
 						};
 						
+						@Override
 						public void run(){
 							for (Object object : selection.toList()) {
 								if (object instanceof IDiagnosis) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FaelleView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FaelleView.java
@@ -300,30 +300,36 @@ public class FaelleView extends ViewPart implements IRefreshable {
 				IEncounter.class);
 		}
 		
+		@Override
 		public void activate(){
 			bDaempfung = true;
 			konsFilterAction.setChecked(true);
 			bDaempfung = false;
 		}
 		
+		@Override
 		public void changed(){
 			// don't mind
 		}
 		
+		@Override
 		public void deactivate(){
 			bDaempfung = true;
 			konsFilterAction.setChecked(false);
 			bDaempfung = false;
 		}
 		
+		@Override
 		public IFilter getFilter(){
 			return this;
 		}
 		
+		@Override
 		public String getId(){
 			return "ch.elexis.FallFilter"; //$NON-NLS-1$
 		}
 		
+		@Override
 		public boolean select(final Object toTest){
 			if (mine == null) {
 				return true;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
@@ -400,6 +400,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 		btnCopyForPatient = new Button(top, SWT.CHECK);
 		btnCopyForPatient.setText(Messages.FallDetailBlatt2_CopyToPatient);
 		btnCopyForPatient.addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent e){
 				boolean b = btnCopyForPatient.getSelection();
 				getSelectedFall().setCopyForPatient(b);
@@ -506,9 +507,11 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 			this.control = control;
 		}
 		
+		@Override
 		public void focusGained(final FocusEvent e){ /* nichts */
 		}
 		
+		@Override
 		public void focusLost(final FocusEvent e){
 			save();
 		}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailView.java
@@ -47,6 +47,7 @@ public class FallDetailView extends ViewPart implements ISaveablePart2 {
 	};
 	
 	private final ElexisEventListener eeli_fall = new ElexisUiEventListenerImpl(Fall.class) {
+		@Override
 		public void runInUi(final ElexisEvent ev){
 			Fall fall = (Fall) ev.getObject();
 			Fall deselectedFall = null;
@@ -112,25 +113,31 @@ public class FallDetailView extends ViewPart implements ISaveablePart2 {
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
@@ -101,6 +101,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 	private Konsultation actBehandlung;
 	private ElexisEventListener eeli_pat = new ElexisUiEventListenerImpl(Patient.class) {
 		
+		@Override
 		public void runInUi(final ElexisEvent ev){
 			actPatient = (Patient) ev.getObject();
 			form.setText(actPatient.getPersonalia());
@@ -109,6 +110,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 	};
 	private ElexisEventListener eeli_fall = new ElexisUiEventListenerImpl(Fall.class) {
 		
+		@Override
 		public void runInUi(final ElexisEvent ev){
 			Fall f = (Fall) ev.getObject();
 			setFall(f, null);
@@ -155,6 +157,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 		sash.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 		ButtonProvider fallButton = new ButtonProvider() {
 			
+			@Override
 			public Button createButton(Composite parent1){
 				Button ret = tk.createButton(parent1, Messages.FallListeView_NewCase, SWT.PUSH); //$NON-NLS-1$
 				ret.addSelectionListener(new SelectionAdapter() {
@@ -175,6 +178,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 				return ret;
 			}
 			
+			@Override
 			public boolean isAlwaysEnabled(){
 				return false;
 			}
@@ -236,6 +240,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 			GlobalEventDispatcher.getInstance().getDefaultListener());
 		behandlViewer = new CommonViewer();
 		ButtonProvider behandlButton = new ButtonProvider() {
+			@Override
 			public Button createButton(Composite parent1){
 				Button ret = tk.createButton(parent1, Messages.FallListeView_NewKons, SWT.PUSH); //$NON-NLS-1$
 				ret.addSelectionListener(new SelectionAdapter() {
@@ -256,6 +261,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 				return ret;
 			}
 			
+			@Override
 			public boolean isAlwaysEnabled(){
 				return true;
 			}
@@ -324,6 +330,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 		MenuManager fallMenuMgr = new MenuManager();
 		fallMenuMgr.setRemoveAllWhenShown(true);
 		fallMenuMgr.addMenuListener(new IMenuListener() {
+			@Override
 			public void menuAboutToShow(IMenuManager manager){
 				manager.add(openFallaction);
 				manager.add(reopenFallAction);
@@ -342,6 +349,7 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 		MenuManager behdlMenuMgr = new MenuManager();
 		behdlMenuMgr.setRemoveAllWhenShown(true);
 		behdlMenuMgr.addMenuListener(new IMenuListener() {
+			@Override
 			public void menuAboutToShow(IMenuManager manager){
 				manager.add(new GroupMarker(IWorkbenchActionConstants.MB_ADDITIONS));
 				manager.add(delKonsAction);
@@ -422,10 +430,12 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 		super.dispose();
 	}
 	
+	@Override
 	public void activation(boolean mode){
 		// TODO Auto-generated method stub
 	}
 	
+	@Override
 	public void visible(boolean mode){
 		if (mode == true) {
 			ElexisEventDispatcher.getInstance().addListeners(eeli_fall, eeli_pat);
@@ -475,25 +485,31 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FavoritenComposite.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FavoritenComposite.java
@@ -107,6 +107,7 @@ public class FavoritenComposite extends Composite {
 		});
 		
 		table.addListener(SWT.PaintItem, new Listener() {
+			@Override
 			public void handleEvent(Event event){
 				TableItem item = (TableItem) event.item;
 				
@@ -247,6 +248,7 @@ public class FavoritenComposite extends Composite {
 				}
 			}
 			
+			@Override
 			public void dragStart(final DragSourceEvent event){
 				// TODO ...
 				//				StructuredSelection ss = (StructuredSelection) tv.getSelection();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FieldDisplayView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FieldDisplayView.java
@@ -92,11 +92,13 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 			
 		});
 		text.addKeyListener(new KeyListener() {
+			@Override
 			public void keyPressed(KeyEvent arg0){
 				arg0.doit = bCanEdit;
 				
 			}
 			
+			@Override
 			public void keyReleased(KeyEvent arg0){}
 		});
 		makeActions();
@@ -125,10 +127,12 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 		text.setFocus();
 	}
 	
+	@Override
 	public void activation(boolean mode){
 		
 	}
 	
+	@Override
 	public void visible(boolean mode){
 		if (mode) {
 			ElexisEventDispatcher.getInstance().addListeners(this);
@@ -141,10 +145,12 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 		
 	}
 	
+	@Override
 	public void catchElexisEvent(final ElexisEvent ev){
 		final PersistentObject po = ev.getObject();
 		if (po != null && ev.getObjectClass().equals(myClass)) {
 			UiDesk.asyncExec(new Runnable() {
+				@Override
 				public void run(){
 					if (ev.getType() == ElexisEvent.EVENT_SELECTED) {
 						String val = po.get(myField);
@@ -175,10 +181,12 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 	final private ElexisEvent template = new ElexisEvent(null, myClass, ElexisEvent.EVENT_SELECTED
 		| ElexisEvent.EVENT_DESELECTED);
 	
+	@Override
 	public ElexisEvent getElexisEventFilter(){
 		return template;
 	}
 	
+	@Override
 	public void heartbeat(){
 		IPersistentObject mine = ElexisEventDispatcher.getSelected(myClass);
 		if (mine == null) {
@@ -266,6 +274,7 @@ public class FieldDisplayView extends ViewPart implements IActivationListener, E
 					setToolTipText(Messages.FieldDisplayView_DataTypeToolTip); //$NON-NLS-1$
 				}
 				
+				@Override
 				public void run(){
 					SelectDataDialog sdd = new SelectDataDialog();
 					if (sdd.open() == Dialog.OK) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
@@ -182,6 +182,7 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 		}
 		if (showLoadingScreen) {
 			UiDesk.getDisplay().syncExec(new Runnable() {
+				@Override
 				public void run(){
 					if (!isDisposed()) {
 						scrolledComposite.setOrigin(0, 0);
@@ -206,8 +207,10 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 		actPatient = pat;
 	}
 	
+	@Override
 	public void jobFinished(BackgroundJob j){
 		UiDesk.getDisplay().asyncExec(new Runnable() {
+			@Override
 			public void run(){
 				String s = (String) loader.getData();
 				
@@ -252,9 +255,11 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 	
 	
 
+	@Override
 	public void catchElexisEvent(ElexisEvent ev){
 		UiDesk.asyncExec(new Runnable() {
 			
+			@Override
 			public void run(){
 				if (text != null && (!text.isDisposed())) {
 					text.setFont(UiDesk.getFont(Preferences.USR_DEFAULTFONT));
@@ -266,6 +271,7 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener,
 	private final ElexisEvent eetemplate = new ElexisEvent(null, null,
 		ElexisEvent.EVENT_USER_CHANGED);
 	
+	@Override
 	public ElexisEvent getElexisEventFilter(){
 		return eetemplate;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KGPrintView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KGPrintView.java
@@ -51,8 +51,10 @@ public class KGPrintView extends ViewPart {
 		CTabItem ret = new CTabItem(ctab, SWT.NONE);
 		text = new TextContainer(getViewSite());
 		ret.setControl(text.getPlugin().createContainer(ctab, new ICallback() {
+			@Override
 			public void save(){}
 			
+			@Override
 			public boolean saveAs(){
 				return false;
 			}
@@ -132,6 +134,7 @@ public class KGPrintView extends ViewPart {
 		
 		text.getPlugin().setFont("Serif", SWT.NORMAL, 9); //$NON-NLS-1$
 		text.replace("\\[Elexis\\]", new ReplaceCallback() { //$NON-NLS-1$
+				@Override
 				public String replace(String in){
 					return "ELEXIS"; //$NON-NLS-1$
 				}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KompendiumView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KompendiumView.java
@@ -61,23 +61,29 @@ public class KompendiumView extends ViewPart implements ISaveablePart2 {
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */}
 	
+	@Override
 	public void doSaveAs(){ /* leer */}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
@@ -166,25 +166,31 @@ public class KonsListe extends ViewPart implements IRefreshable, ISaveablePart2 
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(final IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/MediVerlaufView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/MediVerlaufView.java
@@ -68,6 +68,7 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 	
 	private ElexisUiEventListenerImpl eeli_pat = new ElexisUiEventListenerImpl(Patient.class) {
 		
+		@Override
 		public void runInUi(ElexisEvent ev){
 			reload();
 		}
@@ -130,15 +131,18 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 	
 	class MediVerlaufContentProvider implements IStructuredContentProvider {
 		
+		@Override
 		public Object[] getElements(final Object inputElement){
 			return mListe.toArray();
 		}
 		
+		@Override
 		public void dispose(){
 			// TODO Auto-generated method stub
 			
 		}
 		
+		@Override
 		public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput){
 			// TODO Auto-generated method stub
 			
@@ -148,11 +152,13 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 	
 	static class MediVerlaufLabelProvider extends LabelProvider implements ITableLabelProvider {
 		
+		@Override
 		public Image getColumnImage(final Object element, final int columnIndex){
 			// TODO Auto-generated method stub
 			return null;
 		}
 		
+		@Override
 		public String getColumnText(final Object element, final int columnIndex){
 			if (element instanceof MediAbgabe) {
 				MediAbgabe ma = (MediAbgabe) element;
@@ -184,6 +190,7 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 		try {
 			progressService.runInUI(PlatformUI.getWorkbench().getProgressService(),
 				new IRunnableWithProgress() {
+					@Override
 					public void run(final IProgressMonitor monitor)
 						throws InvocationTargetException, InterruptedException{
 						Patient sp = ElexisEventDispatcher.getSelectedPatient();
@@ -250,6 +257,7 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 			dosis = p.getDosis();
 		}
 		
+		@Override
 		public int compareTo(final MediAbgabe o){
 			int ret = 0;
 			switch (sortCol) {
@@ -299,11 +307,13 @@ public class MediVerlaufView extends ViewPart implements IActivationListener {
 		}
 	}
 	
+	@Override
 	public void activation(final boolean mode){
 		// TODO Auto-generated method stub
 		
 	}
 	
+	@Override
 	public void visible(final boolean mode){
 		if (mode) {
 			ElexisEventDispatcher.getInstance().addListeners(eeli_pat);

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ODDBView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ODDBView.java
@@ -88,23 +88,29 @@ public class ODDBView extends ViewPart implements ISaveablePart2 {
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */}
 	
+	@Override
 	public void doSaveAs(){ /* leer */}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatFilterImpl.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatFilterImpl.java
@@ -37,6 +37,7 @@ import ch.rgw.tools.ExHandler;
  */
 public class PatFilterImpl implements IPatFilter {
 	
+	@Override
 	public int accept(Patient p, PersistentObject o){
 		if (o instanceof Kontakt) {
 			Query<BezugsKontakt> qbe = new Query<BezugsKontakt>(BezugsKontakt.class);
@@ -115,6 +116,7 @@ public class PatFilterImpl implements IPatFilter {
 		return DONT_HANDLE;
 	}
 	
+	@Override
 	public boolean aboutToStart(PersistentObject filter){
 		if (filter instanceof Script) {
 			try {
@@ -129,6 +131,7 @@ public class PatFilterImpl implements IPatFilter {
 		
 	}
 	
+	@Override
 	public boolean finished(PersistentObject filter){
 		if (filter instanceof Script) {
 			try {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/PatHeuteView.java
@@ -140,6 +140,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 	private final ElexisEventListener eeli_kons =
 		new ElexisUiEventListenerImpl(Konsultation.class) {
 			
+			@Override
 			public void runInUi(ElexisEvent ev){
 				selection((Konsultation) ev.getObject());
 				
@@ -162,10 +163,12 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 		makeActions();
 		ldFilter = new ListDisplay<IBillable>(parent, SWT.NONE, new ListDisplay.LDListener() {
 			
+			@Override
 			public String getLabel(final Object o){
 				return ((IBillable) o).getCode();
 			}
 			
+			@Override
 			public void hyperlinkActivated(final String l){
 				if (l.equals(LEISTUNG_HINZU)) {
 					try {
@@ -390,9 +393,11 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			.filter(b -> b instanceof IService).mapToInt(b -> ((IService) b).getMinutes()).sum();
 	}
 	
+	@Override
 	public void activation(final boolean mode){ /* leer */
 	}
 	
+	@Override
 	public void visible(final boolean mode){
 		if (mode == true) {
 			ElexisEventDispatcher.getInstance().addListeners(eeli_kons);
@@ -407,25 +412,31 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(final IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}
@@ -471,6 +482,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			monitor.worked(20);
 			monitor.done();
 			UiDesk.asyncExec(new Runnable() {
+				@Override
 				public void run(){
 					FileDialog fd = new FileDialog(getSite().getShell(), SWT.SAVE);
 					fd.setFilterExtensions(new String[] {
@@ -571,6 +583,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			qbe.orderBy(false, Konsultation.DATE, Konsultation.FLD_TIME);
 			
 			qbe.addPostQueryFilter(new IFilter() {
+				@Override
 				public boolean select(final Object toTest){
 					if (filterAction.isChecked()) {
 						IEncounter encounter = NoPoUtil
@@ -696,6 +709,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 		
 	}
 	
+	@Override
 	public void jobFinished(final BackgroundJob j){
 		if (j.isValid()) {
 			kons = (Konsultation[]) j.getData();
@@ -737,6 +751,7 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			this.cost.addMoney(totalCost);
 		}
 		
+		@Override
 		public int compareTo(StatCounter o){
 			String v1 = null, v2 = null;
 			String vc1 = null, vc2 = null;
@@ -929,11 +944,13 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 			super.okPressed();
 		}
 		
+		@Override
 		public void save(){
 			// TODO Auto-generated method stub
 			
 		}
 		
+		@Override
 		public boolean saveAs(){
 			// TODO Auto-generated method stub
 			return false;
@@ -941,12 +958,14 @@ public class PatHeuteView extends ViewPart implements IActivationListener, ISave
 	}
 	
 	private final class DropReceiver implements PersistentObjectDropTarget.IReceiver {
+		@Override
 		public void dropped(final PersistentObject o, final DropTargetEvent ev){
 			if (o instanceof IBillable) {
 				ldFilter.add((IBillable) o);
 			}
 		}
 		
+		@Override
 		public boolean accept(final PersistentObject o){
 			if (o instanceof IBillable) {
 				return true;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
@@ -132,6 +132,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 	
 	private ElexisEventListener eeli_reminder = new ElexisUiEventListenerImpl(Reminder.class,
 		ElexisEvent.EVENT_RELOAD | ElexisEvent.EVENT_CREATE | ElexisEvent.EVENT_UPDATE) {
+		@Override
 		public void catchElexisEvent(ElexisEvent ev){
 			cv.notify(CommonViewer.Message.update);
 		}
@@ -140,6 +141,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 	// 1079 - nur wenn der View offen ist werden bei Patienten-Wechsel die Reminders abgefragt!
 	private ElexisEventListener eeli_pat = new ElexisUiEventListenerImpl(Patient.class) {
 		
+		@Override
 		public void runInUi(final ElexisEvent ev){
 			if (((Patient) ev.getObject()).equals(actPatient)) {
 				return;
@@ -159,6 +161,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 			if (!ConfigServiceHolder.getUser(Preferences.USR_SHOWPATCHGREMINDER, true)) {
 				UiDesk.asyncExec(new Runnable() {
 					
+					@Override
 					public void run(){
 						List<Reminder> list = Reminder.findOpenRemindersResponsibleFor(
 							CoreHub.getLoggedInContact(), false, (Patient) ev.getObject(), true);
@@ -180,6 +183,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 	private ElexisEventListener eeli_user =
 		new ElexisUiEventListenerImpl(Anwender.class, ElexisEvent.EVENT_USER_CHANGED) {
 			
+			@Override
 			public void runInUi(ElexisEvent ev){
 				refreshUserConfiguration();
 				
@@ -254,6 +258,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 		}
 		cv.create(vc, content, SWT.NONE, getViewSite());
 		cv.addDoubleClickListener(new CommonViewer.PoDoubleClickListener() {
+			@Override
 			public void doubleClicked(final PersistentObject obj, final CommonViewer cv){
 				Reminder reminder = (Reminder) obj;
 				AcquireLockBlockingUi.aquireAndRun(reminder, new ILockHandler() {
@@ -532,6 +537,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 				setToolTipText(Messages.ReminderView_activatePatientTooltip);
 			}
 			
+			@Override
 			public void doRun(){
 				Object[] sel = cv.getSelection();
 				if (sel != null && sel.length > 1) {
@@ -607,10 +613,12 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 		}
 	}
 	
+	@Override
 	public void activation(final boolean mode){
 		/* egal */
 	}
 	
+	@Override
 	public void visible(final boolean mode){
 		if (mode) {
 			cv.notify(CommonViewer.Message.update);
@@ -622,6 +630,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 		}
 	}
 	
+	@Override
 	public void heartbeat(){
 		long highestLastUpdate = PersistentObject.getHighestLastUpdate(Reminder.TABLENAME);
 		if (highestLastUpdate > cvHighestLastUpdate) {
@@ -639,6 +648,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 		private Color colorOverdue;
 		private Color colorOpen;
 		
+		@Override
 		public Color getBackground(final Object element){
 			if (element instanceof Reminder) {
 				Reminder reminder = (Reminder) element;
@@ -675,6 +685,7 @@ public class ReminderView extends ViewPart implements IActivationListener, Heart
 					Preferences.USR_REMINDERCOLORS + "/" + ProcessStatus.OPEN.name(), "00FF00")); //$NON-NLS-1$
 		}
 		
+		@Override
 		public Color getForeground(final Object element){
 			if (element instanceof Reminder) {
 				Reminder reminder = (Reminder) element;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezeptBlatt.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezeptBlatt.java
@@ -237,17 +237,20 @@ public class RezeptBlatt extends ViewPart implements ICallback, IActivationListe
 		return createList(pres, TT_INTAKE_LIST, Messages.RezeptBlatt_6); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 	
+	@Override
 	public void save(){
 		if (actBrief != null) {
 			actBrief.save(text.getPlugin().storeToByteArray(), text.getPlugin().getMimeType());
 		}
 	}
 	
+	@Override
 	public boolean saveAs(){
 		// TODO Automatisch erstellter Methoden-Stub
 		return false;
 	}
 	
+	@Override
 	public void activation(boolean mode){
 		if (mode == false) {
 			save();
@@ -255,18 +258,22 @@ public class RezeptBlatt extends ViewPart implements ICallback, IActivationListe
 		
 	}
 	
+	@Override
 	public void visible(boolean mode){
 		
 	}
 	
+	@Override
 	public String getOutputterDescription(){
 		return "Druckerausgabe erstellt";
 	}
 	
+	@Override
 	public String getOutputterID(){
 		return "ch.elexis.RezeptBlatt";
 	}
 	
+	@Override
 	public Image getSymbol(){
 		return Images.IMG_PRINTER.getImage();
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezepteView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/RezepteView.java
@@ -110,6 +110,7 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 	private GenericObjectDropTarget dropTarget;
 	private final ElexisEventListener eeli_pat = new ElexisUiEventListenerImpl(Patient.class) {
 		
+		@Override
 		public void runInUi(ElexisEvent ev){
 			if (tv != null && tv.getControl() != null && !tv.getControl().isDisposed()) {
 				if (ev.getType() == ElexisEvent.EVENT_SELECTED) {
@@ -138,6 +139,7 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 	private final ElexisEventListener eeli_rp = new ElexisUiEventListenerImpl(Rezept.class,
 		ElexisEvent.EVENT_SELECTED | ElexisEvent.EVENT_UPDATE) {
 		
+		@Override
 		public void runInUi(ElexisEvent ev){
 			if (tv != null && tv.getControl() != null && !tv.getControl().isDisposed()) {
 				if (ev.getType() == ElexisEvent.EVENT_SELECTED) {
@@ -162,6 +164,7 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 		tv = new TableViewer(sash, SWT.V_SCROLL | SWT.FULL_SELECTION);
 		tv.setContentProvider(new IStructuredContentProvider() {
 			
+			@Override
 			public Object[] getElements(final Object inputElement){
 				Query<Rezept> qbe = new Query<Rezept>(Rezept.class);
 				/*
@@ -179,9 +182,11 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 				}
 			}
 			
+			@Override
 			public void dispose(){ /* leer */
 			}
 			
+			@Override
 			public void inputChanged(final Viewer viewer, final Object oldInput,
 				final Object newInput){ /* leer */
 			}
@@ -488,6 +493,7 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 				setToolTipText(Messages.RezepteView_ChangeTooltip); //$NON-NLS-1$
 			}
 			
+			@Override
 			public void doRun(){
 				Rezept rp = (Rezept) ElexisEventDispatcher.getSelected(Rezept.class);
 				IStructuredSelection sel = (IStructuredSelection) lvRpLines.getSelection();
@@ -527,11 +533,13 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 		}
 	}
 	
+	@Override
 	public void activation(final boolean mode){
 		// TODO Auto-generated method stub
 		
 	}
 	
+	@Override
 	public void visible(final boolean mode){
 		if (mode == true) {
 			ElexisEventDispatcher.getInstance().addListeners(eeli_pat, eeli_rp);
@@ -555,6 +563,7 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 	
 	private static class RezeptContentProvider implements IStructuredContentProvider {
 		
+		@Override
 		@SuppressWarnings("unchecked")
 		public Object[] getElements(final Object inputElement){
 			Rezept rp = (Rezept) ElexisEventDispatcher.getSelected(Rezept.class);
@@ -566,9 +575,11 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 			return list.toArray();
 		}
 		
+		@Override
 		public void dispose(){ /* leer */
 		}
 		
+		@Override
 		public void inputChanged(final Viewer viewer, final Object oldInput,
 			final Object newInput){ /* leer */
 		}
@@ -596,25 +607,31 @@ public class RezepteView extends ViewPart implements IActivationListener, ISavea
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(final IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ScriptView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ScriptView.java
@@ -81,6 +81,7 @@ public class ScriptView extends ViewPart {
 		tv = new TableViewer(form.getBody(), SWT.SINGLE | SWT.FULL_SELECTION);
 		tv.setContentProvider(new IStructuredContentProvider() {
 			
+			@Override
 			public Object[] getElements(Object inputElement){
 				SortedList<Script> sortedScripts = new SortedList<Script>(new ScriptComparator());
 				List<Script> scripts = Script.getScripts();
@@ -91,8 +92,10 @@ public class ScriptView extends ViewPart {
 				return sortedScripts.toArray();
 			}
 			
+			@Override
 			public void dispose(){}
 			
+			@Override
 			public void inputChanged(Viewer viewer, Object oldInput, Object newInput){}
 		});
 		tv.setLabelProvider(new LabelProvider() {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/SearchView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/SearchView.java
@@ -121,10 +121,12 @@ public class SearchView extends ViewPart implements ISaveablePart2 {
 		searchButton.setLayoutData(gd);
 		
 		searchButton.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetSelected(SelectionEvent e){
 				viewer.refresh();
 			}
 			
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e){
 				widgetSelected(e);
 			}
@@ -135,14 +137,17 @@ public class SearchView extends ViewPart implements ISaveablePart2 {
 		table.setLayoutData(SWTHelper.getFillGridData(1, true, 1, true));
 		
 		viewer.setContentProvider(new IStructuredContentProvider() {
+			@Override
 			public void dispose(){
 				// nothing to do
 			}
 			
+			@Override
 			public void inputChanged(Viewer viewer, Object oldInput, Object newInput){
 				// nothing to do
 			}
 			
+			@Override
 			public Object[] getElements(Object inputElement){
 				return mainSearch();
 			}
@@ -150,6 +155,7 @@ public class SearchView extends ViewPart implements ISaveablePart2 {
 		
 		// simple default label provider
 		viewer.setLabelProvider(new LabelProvider() {
+			@Override
 			public String getText(Object element){
 				if (element instanceof PersistentObject) {
 					PersistentObject po = (PersistentObject) element;
@@ -190,23 +196,29 @@ public class SearchView extends ViewPart implements ISaveablePart2 {
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */}
 	
+	@Override
 	public void doSaveAs(){ /* leer */}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/StockView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/StockView.java
@@ -156,6 +156,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 		filterText.setMessage("Filter");
 		filterText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		filterText.addKeyListener(new KeyAdapter() {
+			@Override
 			public void keyReleased(KeyEvent e){
 				if (!refreshUseFilter()) {
 					// reload all if empty
@@ -210,6 +211,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 				poes = new ReflectiveEditingSupport(viewer,
 					ModelPackage.Literals.ISTOCK_ENTRY__CURRENT_STOCK.getName(),
 					new NumericCellEditorValidator(), true) {
+					@Override
 					protected boolean canEdit(Object element){
 						boolean canEdit = super.canEdit(element);
 						if (canEdit) {
@@ -297,6 +299,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 		
 		contextMenu.addMenuListener(new IMenuListener() {
 			
+			@Override
 			public void menuAboutToShow(IMenuManager manager){
 				manager.add(new CheckInOrderedAction(viewer));
 				manager.add(new DeleteStockEntryAction(viewer));
@@ -510,6 +513,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 			return Messages.StockView_PerformFullInventoryOnCommSystem;
 		}
 		
+		@Override
 		public void run(){
 			IStockEntry stockEntry = fetchSelection();
 			IStatus status = StockCommissioningServiceHolder.get()
@@ -554,6 +558,7 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 			return Messages.StockView_OutlayArticle;
 		}
 		
+		@Override
 		public void run(){
 			IStockEntry stockEntry = fetchSelection();
 			IStatus status =
@@ -753,31 +758,39 @@ public class StockView extends ViewPart implements ISaveablePart2, IActivationLi
 	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
 	 * Gibt es da keine einfachere Methode?
 	 */
+	@Override
 	public int promptToSaveOnClose(){
 		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
 				: ISaveablePart2.NO;
 	}
 	
+	@Override
 	public void doSave(IProgressMonitor monitor){ /* leer */
 	}
 	
+	@Override
 	public void doSaveAs(){ /* leer */
 	}
 	
+	@Override
 	public boolean isDirty(){
 		return true;
 	}
 	
+	@Override
 	public boolean isSaveAsAllowed(){
 		return false;
 	}
 	
+	@Override
 	public boolean isSaveOnCloseNeeded(){
 		return true;
 	}
 	
+	@Override
 	public void activation(boolean mode){}
 	
+	@Override
 	public void visible(boolean mode){
 		List<IStockEntry> allEntries =
 			CoreModelServiceHolder.get().getQuery(IStockEntry.class).execute();

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TemplatePrintView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TemplatePrintView.java
@@ -52,8 +52,10 @@ public class TemplatePrintView extends ViewPart {
 		CTabItem ret = new CTabItem(ctab, SWT.NONE);
 		text = new TextContainer(getViewSite());
 		ret.setControl(text.getPlugin().createContainer(ctab, new ICallback() {
+			@Override
 			public void save(){}
 			
+			@Override
 			public boolean saveAs(){
 				return false;
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TextView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/TextView.java
@@ -284,12 +284,14 @@ public class TextView extends ViewPart implements IActivationListener {
 			};
 		
 		showMenuAction = new Action(Messages.TextView_showMenu, Action.AS_CHECK_BOX) { //$NON-NLS-1$			
+				@Override
 				public void run(){
 					txt.getPlugin().showMenu(isChecked());
 				}
 			};
 		
 		showToolbarAction = new Action(Messages.TextView_Toolbar, Action.AS_CHECK_BOX) { //$NON-NLS-1$
+				@Override
 				public void run(){
 					txt.getPlugin().showToolbar(isChecked());
 				}
@@ -358,6 +360,7 @@ public class TextView extends ViewPart implements IActivationListener {
 					setImageDescriptor(Images.IMG_NEW.getImageDescriptor());
 				}
 				
+				@Override
 				public void run(){
 					Patient pat = ElexisEventDispatcher.getSelectedPatient();
 					if (pat != null) {
@@ -411,6 +414,7 @@ public class TextView extends ViewPart implements IActivationListener {
 	
 	class SaveHandler implements ITextPlugin.ICallback {
 		
+		@Override
 		public void save(){
 			log.debug("TextView.save"); //$NON-NLS-1$
 			if (actBrief != null) {
@@ -418,6 +422,7 @@ public class TextView extends ViewPart implements IActivationListener {
 			}
 		}
 		
+		@Override
 		public boolean saveAs(){
 			log.debug("TextView.saveAs"); //$NON-NLS-1$
 			InputDialog il =
@@ -433,6 +438,7 @@ public class TextView extends ViewPart implements IActivationListener {
 		
 	}
 	
+	@Override
 	public void activation(boolean mode){
 		if (mode == false) {
 			if (actBrief != null) {
@@ -447,6 +453,7 @@ public class TextView extends ViewPart implements IActivationListener {
 		}
 	}
 	
+	@Override
 	public void visible(boolean mode){
 		
 	}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/VerrechnungsDisplay.java
@@ -515,6 +515,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 	 * @deprecated for {@link ch.elexis.core.model.ICodeElement} instances direct use of
 	 *             {@link IBillingService} is recommended
 	 */
+	@Deprecated
 	public void addPersistentObject(PersistentObject o){
 		if (actEncounter != null) {
 			if (o instanceof Leistungsblock) {
@@ -746,6 +747,7 @@ public class VerrechnungsDisplay extends Composite implements IUnlockable {
 		
 		contextMenuManager.setRemoveAllWhenShown(true);
 		contextMenuManager.addMenuListener(new IMenuListener() {
+			@Override
 			public void menuAboutToShow(IMenuManager manager){
 				IStructuredSelection selection = viewer.getStructuredSelection();
 				if (selection.size() > 1) {


### PR DESCRIPTION
Mit der JDT clean-up action, wurden @Deprecated und @Override für das
ch.elexis.core.ui.views durchgeführt. Macht die Weiterentwicklung der
Views leichter, da klar ist, welche Methoden überschrieben wurden.