### PR TITLE
Ersetzen der dirty / ISaveablePart2 Lösung durch MPart.setClosable

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallListeView.java
@@ -25,7 +25,10 @@ import static ch.elexis.core.ui.actions.GlobalActions.reopenFallAction;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.GroupMarker;
 import org.eclipse.jface.action.IAction;
@@ -88,7 +91,7 @@ import ch.rgw.tools.IFilter;
  * @author gerry
  * 
  */
-public class FallListeView extends ViewPart implements IActivationListener, ISaveablePart2 {
+public class FallListeView extends ViewPart implements IActivationListener {
 	private static boolean noPatientHandled = true;
 	public static final String ID = "ch.elexis.FallListeView"; //$NON-NLS-1$
 	CommonViewer fallViewer;
@@ -470,31 +473,8 @@ public class FallListeView extends ViewPart implements IActivationListener, ISav
 		
 	}
 	
-	/***********************************************************************************************
-	 * Die folgenden 6 Methoden implementieren das Interface ISaveablePart2 Wir benötigen das
-	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
-	 * Gibt es da keine einfachere Methode?
-	 */
-	public int promptToSaveOnClose(){
-		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
-				: ISaveablePart2.NO;
-	}
-	
-	public void doSave(IProgressMonitor monitor){ /* leer */
-	}
-	
-	public void doSaveAs(){ /* leer */
-	}
-	
-	public boolean isDirty(){
-		return true;
-	}
-	
-	public boolean isSaveAsAllowed(){
-		return false;
-	}
-	
-	public boolean isSaveOnCloseNeeded(){
-		return true;
+	@Inject
+	public void setClosable(MPart part) {
+		part.setCloseable(GlobalActions.fixLayoutAction.isChecked());	
 	}
 }

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
@@ -15,8 +15,10 @@ package ch.elexis.core.ui.views;
 import javax.inject.Inject;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.dialogs.Dialog;
@@ -163,8 +165,18 @@ public class KonsListe extends ViewPart implements IRefreshable {
 	}
 
 	@Inject
-	public void setClosable(MPart part) {
-		part.setCloseable(GlobalActions.fixLayoutAction.isChecked());	
+	public void setClosable(MPart part, MApplication application) {
+		
+		part.setCloseable(!GlobalActions.fixLayoutAction.isChecked());
+		if (GlobalActions.fixLayoutAction.isChecked()) {
+			 // works as of 2020-03 (4.16)
+//			application.getTags().add("DisableDnDAddon");
+			// before 2020-03 you have to set this on each part separately
+			part.getTags().add("NoMove");
+		} else {
+			part.getTags().add("NoMove");
+		}
+		
 	}
 	
 	/**

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/KonsListe.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.layout.GridLayout;
@@ -39,7 +40,7 @@ import ch.elexis.core.ui.util.ViewMenus;
 import ch.elexis.data.Konsultation;
 
 
-public class KonsListe extends ViewPart implements IRefreshable, ISaveablePart2 {
+public class KonsListe extends ViewPart implements IRefreshable {
 	public static final String ID = "ch.elexis.HistoryView"; //$NON-NLS-1$
 	HistoryDisplay liste;
 	IPatient actPatient;
@@ -160,33 +161,10 @@ public class KonsListe extends ViewPart implements IRefreshable, ISaveablePart2 
 				}
 			};
 	}
-	
-	/*
-	 * Die folgenden 6 Methoden implementieren das Interface ISaveablePart2 Wir benötigen das
-	 * Interface nur, um das Schliessen einer View zu verhindern, wenn die Perspektive fixiert ist.
-	 * Gibt es da keine einfachere Methode?
-	 */
-	public int promptToSaveOnClose(){
-		return GlobalActions.fixLayoutAction.isChecked() ? ISaveablePart2.CANCEL
-				: ISaveablePart2.NO;
-	}
-	
-	public void doSave(final IProgressMonitor monitor){ /* leer */
-	}
-	
-	public void doSaveAs(){ /* leer */
-	}
-	
-	public boolean isDirty(){
-		return true;
-	}
-	
-	public boolean isSaveAsAllowed(){
-		return false;
-	}
-	
-	public boolean isSaveOnCloseNeeded(){
-		return true;
+
+	@Inject
+	public void setClosable(MPart part) {
+		part.setCloseable(GlobalActions.fixLayoutAction.isChecked());	
 	}
 	
 	/**


### PR DESCRIPTION
Analog zur ISaveablePart2 wird hier auf
GlobalActions.fixLayoutAction.isChecked() überprüft und der closable
Status entsprechend auf MPart gesetzt.

Beispiel für zwei Views FallListeView und KonListe.