### PR TITLE
[21760] Force AUTO_SERVER for h2 (jpa and PO)

### DIFF
--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/DBConnection.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ch.elexis.core.constants.ElexisSystemPropertyConstants;
 import ch.elexis.core.constants.Preferences;
 import ch.elexis.core.data.activator.CoreHub;
 import ch.elexis.core.data.cache.IPersistentObjectCache;
@@ -132,6 +133,11 @@ public class DBConnection {
 		else
 			dbDriver = "invalid";
 		if (!dbDriver.equalsIgnoreCase("invalid")) {
+			if (dbConnectString.startsWith("jdbc:h2:")
+					&& System.getProperty(ElexisSystemPropertyConstants.CONN_DB_H2_AUTO_SERVER) != null
+					&& !dbConnectString.contains(";AUTO_SERVER")) {
+				dbConnectString = dbConnectString + ";AUTO_SERVER=TRUE";
+			}
 			jdbcLink = new JdbcLink(dbDriver, dbConnectString, dbFlavor);
 			boolean ret = jdbcLink.connect(dbUser, dbPw);
 			if (ret) {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObject.java
@@ -256,7 +256,6 @@ public abstract class PersistentObject implements IPersistentObject {
 				if (password == null) {
 					dbConnection.setDBPassword(StringTool.leer);
 				}
-				
 				return dbConnection.connect() && connect(dbConnection);
 			} catch (JdbcLinkException je) {
 				ElexisStatus status = translateJdbcException(je);
@@ -266,6 +265,12 @@ public abstract class PersistentObject implements IPersistentObject {
 			}
 		} else if (dbConnection.isDirectConnectConfigured()) {
 			// open direct database connection according to system properties
+			if ( dbConnection.getDBConnectString().startsWith("jdbc:h2:") &&
+					System.getProperty(ElexisSystemPropertyConstants.CONN_DB_H2_AUTO_SERVER) != null) {
+				log.info("Adding AUTO_SERVER to " + dbConnection.getDBConnectString());
+				String h2_with = dbConnection.getDBConnectString() + ";AUTO_SERVER=TRUE";
+				dbConnection.setDBConnectString(h2_with);
+			}
 			return (PersistentObject.connect(dbConnection, true) && connect(dbConnection));
 		} else if (dbConnection.isRunningFromScratch()) {
 			// run from scratch configuration with a temporary database

--- a/bundles/ch.elexis.core/src/ch/elexis/core/constants/ElexisSystemPropertyConstants.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/constants/ElexisSystemPropertyConstants.java
@@ -14,6 +14,7 @@ public class ElexisSystemPropertyConstants {
 	public static final String CONN_DB_USERNAME = "ch.elexis.dbUser";
 	public static final String CONN_DB_PASSWORD = "ch.elexis.dbPw";
 	public static final String CONN_DB_FLAVOR = "ch.elexis.dbFlavor";
+	public static final String CONN_DB_H2_AUTO_SERVER = "ch.elexis.dbH2AutoServer";
 	public static final String CONN_DB_SPEC = "ch.elexis.dbSpec";
 	
 	// Demo database related properties

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/CoreUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/CoreUtil.java
@@ -121,6 +121,13 @@ public class CoreUtil {
 				System.getProperty(ElexisSystemPropertyConstants.CONN_DB_SPEC) != null
 						? System.getProperty(ElexisSystemPropertyConstants.CONN_DB_SPEC)
 						: "";
+			if (dbConnection.connectionString.startsWith("jdbc:h2:") &&
+					System.getProperty(ElexisSystemPropertyConstants.CONN_DB_H2_AUTO_SERVER) != null) {
+				logger.info("Adding AUTO_SERVER to "+ dbConnection.connectionString );
+				dbConnection.connectionString  = dbConnection.connectionString  + ";AUTO_SERVER=TRUE";
+
+			}
+
 			return Optional.of(dbConnection);
 		}
 		


### PR DESCRIPTION
Enables H2 databases to be open while Elexis is running. Use cases:
* Inspect running Elexis-DB via Webbrowser
* Create DB-Dump while running RCPTT-GUI tests
* for the project elexis-uitest I did not find a way on howto pass a ";" to via setting to the startup parameter of elexis, as the semicolon is considered a separator of item