### PR TITLE
[24368] Wrong preferences for italian broke tarmed importer

### DIFF
--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/Messages.java
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/Messages.java
@@ -1724,7 +1724,6 @@ public class Messages extends NLS {
 	public static String Ablauf_19;
 	public static String Ablauf_21;
 	public static String Ablauf_23;
-	public static String Ablauf_24;
 	public static String Ablauf_31;
 	public static String Ablauf_3;
 	public static String Ablauf_4;

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
@@ -51,8 +51,6 @@ Ablauf_21 = &3: In case of Warnings show the Alertbox
 
 Ablauf_23 = Tablename for Trace or 'none' for close Trace 
 
-Ablauf_24 = i
-
 Ablauf_3 = Log-&Grade
 
 Ablauf_31 = &maximum Size (leave Blank for infinite)

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
@@ -51,8 +51,6 @@ Ablauf_21 = &3: Bei Warnungen Alertbox zeigen
 
 Ablauf_23 = Tabellenname f\u00FCr Trace oder 'none' f\u00FCr Trace aus
 
-Ablauf_24 = i
-
 Ablauf_3 = Log-&Stufe
 
 Ablauf_31 = &Maximale Gr\u00F6sse (leer lassen f\u00FCr unbeschr\u00E4nkt)

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
@@ -51,8 +51,6 @@ Ablauf_21 = &3: Show Alertbox on alerts
 
 Ablauf_23 = Table name for Trace or 'none' for Trace off
 
-Ablauf_24 = i
-
 Ablauf_3 = Log-&Stage
 
 Ablauf_31 = &Maximum size (leave blank for unlimited)

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
@@ -51,8 +51,6 @@ Ablauf_21 = &3: Afficher cas d'avertissements Alertbox
 
 Ablauf_23 = Nom de la table pour la trace ou \u00AB aucun \u00BB pour Trace de
 
-Ablauf_24 = Je
-
 Ablauf_3 = Log &niveau
 
 Ablauf_31 = &Taille maximale (Laissez le champ vide pour un nombre illimit\u00E9)

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
@@ -51,8 +51,6 @@ Ablauf_21 = &3: Mostra il caso di avvertimenti Alertbox
 
 Ablauf_23 = Nome tabella per la traccia o 'none' per Trace da
 
-Ablauf_24 = io
-
 Ablauf_3 = Log &level
 
 Ablauf_31 = &Dimensione massima (Lascia in bianco per illimitato)

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/Messages.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/preferences/Messages.java
@@ -20,7 +20,6 @@ public class Messages {
 	public static String Ablauf_19 = ch.elexis.core.l10n.Messages.Ablauf_19;
 	public static String Ablauf_21 = ch.elexis.core.l10n.Messages.Ablauf_21;
 	public static String Ablauf_23 = ch.elexis.core.l10n.Messages.Ablauf_23;
-	public static String Ablauf_24 = ch.elexis.core.l10n.Messages.Ablauf_24;
 	public static String Ablauf_3 = ch.elexis.core.l10n.Messages.Ablauf_3;
 	public static String Ablauf_31 = ch.elexis.core.l10n.Messages.Ablauf_31;
 	public static String Ablauf_4 = ch.elexis.core.l10n.Messages.Ablauf_4;

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Ablauf.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Ablauf.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package ch.elexis.core.ui.preferences;
 
-import java.io.File;
-import java.nio.file.Paths;
-
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -23,8 +19,6 @@ import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ch.elexis.core.constants.Preferences;
 import ch.elexis.core.data.activator.CoreHub;
@@ -44,7 +38,7 @@ public class Ablauf extends FieldEditorPreferencePage implements IWorkbenchPrefe
 		addField(new RadioGroupFieldEditor(Preferences.ABL_LANGUAGE, Messages.Ablauf_preferredLang, 1,
 				new String[][] { { Messages.Ablauf_german, "d" //$NON-NLS-1$
 				}, { Messages.Ablauf_french, "f" //$NON-NLS-1$
-				}, { Messages.Ablauf_italian, Messages.Ablauf_24 } }, getFieldEditorParent()));
+				}, { Messages.Ablauf_italian, "i" } }, getFieldEditorParent())); //$NON-NLS-1$
 
 		addField(new IntegerFieldEditor(Preferences.ABL_CACHELIFETIME, Messages.Ablauf_cachelifetime,
 				getFieldEditorParent()));

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Messages.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/Messages.java
@@ -13,7 +13,6 @@ public class Messages {
 
 	public static String Ablauf_0 = ch.elexis.core.l10n.Messages.Ablauf_0;
 	public static String Ablauf_3 = ch.elexis.core.l10n.Messages.Ablauf_3;
-	public static String Ablauf_24 = ch.elexis.core.l10n.Messages.Ablauf_24;
 	public static String Ablauf_31 = ch.elexis.core.l10n.Messages.Ablauf_31;
 	public static String Ablauf_4 = ch.elexis.core.l10n.Messages.Ablauf_4;
 	public static String Ablauf_6 = ch.elexis.core.l10n.Messages.Ablauf_6;

--- a/bundles/ch.elexis.core/src/ch/elexis/core/preferences/Messages.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/preferences/Messages.java
@@ -24,7 +24,6 @@ public class Messages {
 	public static String Ablauf_19 = ch.elexis.core.l10n.Messages.Ablauf_19;
 	public static String Ablauf_21 = ch.elexis.core.l10n.Messages.Ablauf_21;
 	public static String Ablauf_23 = ch.elexis.core.l10n.Messages.Ablauf_23;
-	public static String Ablauf_24 = ch.elexis.core.l10n.Messages.Ablauf_24;
 	public static String Ablauf_3 = ch.elexis.core.l10n.Messages.Ablauf_3;
 	public static String Ablauf_31 = ch.elexis.core.l10n.Messages.Ablauf_31;
 	public static String Ablauf_4 = ch.elexis.core.l10n.Messages.Ablauf_4;


### PR DESCRIPTION
In Ablauf.java there was a translation for "i" which must be marked as NON-NLS. With this change the tarmed importer works fine for the italian language, too.