### PR TITLE
[24027] Make convertDocx2Pdf to enable docx textplug to use it

### DIFF
--- a/bundles/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/core/data/activator/CoreHub.java
@@ -106,7 +106,7 @@ public class CoreHub implements BundleActivator {
 
 	/**
 	 * Globale Einstellungen (Werden in der Datenbank gespeichert)
-	 * 
+	 *
 	 * @deprecated use {@link IConfigService}
 	 */
 	public static Settings globalCfg;
@@ -114,7 +114,7 @@ public class CoreHub implements BundleActivator {
 	/**
 	 * Lokale Einstellungen (Werden in userhome/localCfg_xxx.xml gespeichert) </br>
 	 * <b>WARNING: can not handle more than one / in config name!</b>
-	 * 
+	 *
 	 * @deprecated use {@link IConfigService}
 	 */
 	public static Settings localCfg;
@@ -192,7 +192,7 @@ public class CoreHub implements BundleActivator {
 
 	/**
 	 * Initialize the user dir on startup
-	 * 
+	 *
 	 * @since 3.10 extracted from {@link #getWritableUserDir()}
 	 */
 	private static void initUserDir() {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectDataSourceActivator.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/PersistentObjectDataSourceActivator.java
@@ -26,13 +26,13 @@ import ch.rgw.tools.ExHandler;
 /**
  * Connect PersistentObject after NoPo was properly initialized and liquibase
  * was executed (visible due to injection of coreModelService)
- * 
+ *
  * The unused references assert that we have all pre-conditions met to start
  * PersistentObject
- * 
+ *
  * If a specific service has to wait for PersistentObjec to become ready, add a
  * reference to this class
- * 
+ *
  * @since 3.10
  */
 @Component(immediate = true, service = PersistentObjectDataSourceActivator.class)
@@ -80,7 +80,7 @@ public class PersistentObjectDataSourceActivator {
 
 	/**
 	 * Extracted from PersistentObject
-	 * 
+	 *
 	 * @param coreOperationAdvisor
 	 * @return
 	 */

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Rechnung.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Rechnung.java
@@ -845,7 +845,7 @@ public class Rechnung extends PersistentObject {
 
 	/**
 	 * Die nächste Rechnungsnummer holen.
-	 * 
+	 *
 	 * @deprecated InvoiceEntityListener
 	 */
 	@Deprecated

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/User.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/User.java
@@ -101,7 +101,7 @@ public class User extends PersistentObject {
 	 * assigned to the role {@link Role#SYSTEMROLE_LITERAL_EXECUTIVE_DOCTOR}.
 	 *
 	 * @see https://redmine.medelexis.ch/issues/771
-	 * 
+	 *
 	 */
 	@Deprecated(forRemoval = true)
 	private static void migrateToNewStructure() {

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/XML2Database.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/XML2Database.java
@@ -42,7 +42,7 @@ import ch.rgw.tools.Log;
  * <EAN>7680573770024</EAN> <br>
  * ... other field values <br>
  * </ARTIKEL> <br>
- * 
+ *
  * @deprecated is this used at all?
  */
 @Deprecated(forRemoval = true)

--- a/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/internal/DataSourceConnectionParser.java
+++ b/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/internal/DataSourceConnectionParser.java
@@ -35,7 +35,7 @@ public class DataSourceConnectionParser {
 	 * Try to find a valid existing database configuration, according to the given
 	 * surrounding parameters. If none found (which is a valid scenario e.g. for
 	 * Elexis RCP which reads from CoreHub.localCfg) return Optional empty
-	 * 
+	 *
 	 * @return
 	 */
 	public Optional<DBConnection> parseAvailableParameters() {

--- a/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/test/TestDatabaseConnection.java
+++ b/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/test/TestDatabaseConnection.java
@@ -14,7 +14,7 @@ import ch.elexis.core.common.DBConnection;
 
 /**
  * an h2 based test database connection
- * 
+ *
  * @deprecated
  */
 @Deprecated(forRemoval = true)

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/StartEditLocalDocumentHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/StartEditLocalDocumentHandler.java
@@ -154,7 +154,7 @@ public class StartEditLocalDocumentHandler extends AbstractHandler implements IH
 	}
 
 	/**
-	 *  <b>TEST ONLY:</b> If the extension is a docx, then we check the property
+	 * <b>TEST ONLY:</b> If the extension is a docx, then we check the property
 	 * ch.elexis.convertDocx2PDF to see whether we need additional treatment when
 	 * running GUI-tests.
 	 *

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/StartEditLocalDocumentHandler.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/commands/StartEditLocalDocumentHandler.java
@@ -16,6 +16,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.elexis.core.constants.Preferences;
@@ -41,6 +42,7 @@ import ch.elexis.data.Brief;
 public class StartEditLocalDocumentHandler extends AbstractHandler implements IHandler {
 
 	public static final String CONVERT_DOCX_2_PDF = "ch.elexis.test.convertDocx2PDF"; //$NON-NLS-1$
+	private static Logger logger = LoggerFactory.getLogger(StartEditLocalDocumentHandler.class);
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
@@ -123,18 +125,18 @@ public class StartEditLocalDocumentHandler extends AbstractHandler implements IH
 	}
 
 	/**
-	 * Convert docx file to pdf and txt for test purposes
+	 * <b>TEST ONLY:</b> Convert docx file to pdf and txt for test purposes
 	 *
 	 * @param file
 	 */
-	private void convertDocx2Pdf(Optional<File> file) {
+	public static void convertDocx2Pdf(Optional<File> file) {
 		for (String format : List.of("pdf", "txt")) { //$NON-NLS-1$ //$NON-NLS-2$
 			String filePath = file.get().getAbsolutePath();
 			String storage = DocumentLetterUtil.getOperatingSystemSpecificExternalStoragePath();
 			String fullCmd = String.format("libreoffice --headless --convert-to %s --outdir %s %s", format, storage, //$NON-NLS-1$
 					filePath);
-			LoggerFactory.getLogger(getClass()).info("Convert external file using"); //$NON-NLS-1$
-			LoggerFactory.getLogger(getClass()).info(fullCmd);
+			logger.info("Convert external file using"); //$NON-NLS-1$
+			logger.info(fullCmd);
 			try {
 				// Running the above command
 				Runtime run = Runtime.getRuntime();
@@ -142,24 +144,24 @@ public class StartEditLocalDocumentHandler extends AbstractHandler implements IH
 				while (runner.isAlive()) {
 					Thread.sleep(200);
 				}
-				LoggerFactory.getLogger(getClass()).info(" created: " + storage + File.separator //$NON-NLS-1$
+				logger.info(" created: " + storage + File.separator //$NON-NLS-1$
 						+ file.get().getName().replace("docx", format)); //$NON-NLS-1$
 			} catch (IOException | InterruptedException e) {
-				LoggerFactory.getLogger(getClass()).error("Unable to produce pdf. Error was {}", //$NON-NLS-1$
+				logger.error("Unable to produce pdf. Error was {}", //$NON-NLS-1$
 						e.getMessage());
 			}
 		}
 	}
 
 	/**
-	 * If the extension is a docx, then we check the property
+	 *  <b>TEST ONLY:</b> If the extension is a docx, then we check the property
 	 * ch.elexis.convertDocx2PDF to see whether we need additional treatment when
 	 * running GUI-tests.
 	 *
 	 * @param extension
 	 * @return whether we should convert the docx to pdf and txt using libreoffice
 	 */
-	private boolean isConvertDocx2Pdf(String extension) {
+	public static boolean isConvertDocx2Pdf(String extension) {
 		String convert2pdf = System.getProperty(CONVERT_DOCX_2_PDF, StringUtils.EMPTY);
 		return (extension.equalsIgnoreCase("docx") && //$NON-NLS-1$
 				!convert2pdf.equals(StringUtils.EMPTY));
@@ -182,17 +184,17 @@ public class StartEditLocalDocumentHandler extends AbstractHandler implements IH
 			} else if (lockObject instanceof IDocumentLetter) {
 				document = (IDocumentLetter) lockObject;
 			} else {
-				LoggerFactory.getLogger(getClass()).error("Invalid argument [{}]", lockObject.getClass()); //$NON-NLS-1$
+				logger.error("Invalid argument [{}]", lockObject.getClass()); //$NON-NLS-1$
 				return false;
 			}
 
 			IVirtualFilesystemHandle handle = DocumentLetterUtil.getExternalHandleIfApplicable(document);
 			Optional<File> file = handle.toFile();
 			if (file.isPresent()) {
-				if (isConvertDocx2Pdf(handle.getExtension())) { // $NON-NLS-1$
+				if (isConvertDocx2Pdf(handle.getExtension())) {
 					convertDocx2Pdf(file);
 				} else {
-					LoggerFactory.getLogger(getClass()).info("Open external file {}", file.get().getAbsolutePath()); //$NON-NLS-1$
+					logger.info("Open external file {}", file.get().getAbsolutePath()); //$NON-NLS-1$
 					Program.launch(file.get().getAbsolutePath());
 				}
 			} else {

--- a/bundles/ch.elexis.core/src/ch/elexis/core/services/IAppointmentService.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/services/IAppointmentService.java
@@ -132,7 +132,7 @@ public interface IAppointmentService {
 	/**
 	 * Get the appointment type color configured for the given userContact. Default
 	 * is #3a87ad.
-	 * 
+	 *
 	 * @param userContact     if <code>null</code>, take user from context
 	 * @param appointmentType the value of {@link IAppointment#getType()}
 	 * @return
@@ -143,7 +143,7 @@ public interface IAppointmentService {
 	/**
 	 * Get the appointment state color configured for the given userContact. Default
 	 * is #ffffff.
-	 * 
+	 *
 	 * @param userContact      if <code>null</code>, take user from context
 	 * @param appointmentState the value of {@link IAppointment#getState()}
 	 * @return

--- a/bundles/ch.elexis.core/src/ch/elexis/core/utils/OsgiServiceUtil.java
+++ b/bundles/ch.elexis.core/src/ch/elexis/core/utils/OsgiServiceUtil.java
@@ -100,7 +100,7 @@ public class OsgiServiceUtil {
 	 * Get a service from the OSGi service registry. Wait for it, it it's not
 	 * available yet. <b>Always</b> release the service using the
 	 * {@link OsgiServiceUtil#ungetService(Object)} method after usage.
-	 * 
+	 *
 	 * @param clazz
 	 * @param timeout milliseconds to wait for the service to become available
 	 * @return

--- a/bundles/ch.rgw.utility/src/ch/rgw/tools/JdbcLink.java
+++ b/bundles/ch.rgw.utility/src/ch/rgw/tools/JdbcLink.java
@@ -241,7 +241,7 @@ public class JdbcLink {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param dataSource
 	 * @throws SQLException
 	 * @since 3.10


### PR DESCRIPTION
I want to make the openCurrentDocument method in the DocxTextPlugin to be public. Then I can use it in Kassenbuch (and possibly other) plugin(s) to create directly a PDF document, when I run the RCPTT GUI-Tests. 