### PR TITLE
[24207] Add AUTO_SERVER for h2

### DIFF
--- a/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/internal/DataSourceConnectionParser.java
+++ b/bundles/ch.elexis.core.jpa.datasource/src/ch/elexis/core/jpa/datasource/internal/DataSourceConnectionParser.java
@@ -101,6 +101,14 @@ public class DataSourceConnectionParser {
 			if (isRunFromScratch) {
 				// TODO checkIfEmpty throw IllegalState
 				// PersistentObject#deleteAllTables
+			} else {
+				// When running the RCPTT-GUI Tests via maven in a settings.xml, it is impossible to add
+				// ;AUTO_SERVER=TRUE as a jdbc connection string, maven interprets it as an end of line
+				if (dbType.dbType.equalsIgnoreCase("h2") && !prop_dbConnSpec.contains("AUTO_SERVER=TRUE"))
+				{
+					prop_dbConnSpec = prop_dbConnSpec+";AUTO_SERVER=TRUE";
+					logger.info("Added AUTO_SERVER [" + prop_dbConnSpec + "]");
+				}
 			}
 			configSourceCode = 2;
 			return Optional.of(new DBConnection(dbType, prop_dbConnSpec, prop_dbUser, prop_dbPassword.toCharArray()));


### PR DESCRIPTION
This is needed for the RCPTT GUI tests to dump a h2 while running