### PR TITLE
Replaced french Platzhalter names

### DIFF
--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
@@ -7801,13 +7801,13 @@ ResponseAnalyzer_State2 = statut
 
 ResponseAnalyzer_StateRejected = Rejet\u00E9.  N
 
-RezeptBlatt_4 = [Lignes de l'ordonnance]
+RezeptBlatt_4 = [medicament]
 
-RezeptBlatt_4_Extended = [Lignes de recetteExt]
+RezeptBlatt_4_Extended = [medicamentExt]
 
-RezeptBlatt_6 = [Liste des m\u00E9dicaments]
+RezeptBlatt_6 = [medication]
 
-RezeptBlatt_6_Extended = [Liste des m\u00E9dicamentsExt]
+RezeptBlatt_6_Extended = [medicationExt]
 
 RezeptBlatt_TemplateNameList = En prenant la liste
 


### PR DESCRIPTION
Within bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties the following Platzhalter names were not working because they contained whitespaces and apostrophes:

RezeptBlatt_4 = [Lignes de l'ordonnance]
RezeptBlatt_4_Extended = [Lignes de recetteExt]
RezeptBlatt_6 = [Liste des m\u00E9dicaments]
RezeptBlatt_6_Extended = [Liste des m\u00E9dicamentsExt]

The names were replaced by:
RezeptBlatt_4 = [medicament]
RezeptBlatt_4_Extended = [medicamentExt]
RezeptBlatt_6 = [medication]
RezeptBlatt_6_Extended = [medicationExt]