### PR TITLE
[26531] do not display mediorder sticker

### DIFF
--- a/bundles/ch.elexis.core.jpa/db/v3.12/elexisdb_update.xml
+++ b/bundles/ch.elexis.core.jpa/db/v3.12/elexisdb_update.xml
@@ -157,4 +157,19 @@ SET KEYWORDS = CONCAT(COALESCE(KEYWORDS, ''), COALESCE((SELECT D.KEYWORDS FROM c
 	</insert>
 </changeSet>
 
+<changeSet author="pdenzler" id="mediorder_sticker_update_name">
+        <update tableName="ETIKETTEN">
+            <column name="NAME" value="Patientenbestellung über PEA aktiviert" />
+            <where>ID='activate_mediorder'</where>
+        </update>
+    </changeSet>
+
+<changeSet author="pdenzler" id="mediorder_sticker_objclass">
+	<insert tableName="ETIKETTEN_OBJCLASS_LINK">
+		<column name="OBJCLASS" value="ch.elexis.data.Patient" />
+		<column name="STICKER" value="activate_mediorder" />
+		<column name="LASTUPDATE" valueComputed="${timestamp}" />
+	</insert>
+</changeSet>
+
 </databaseChangeLog>

--- a/bundles/ch.elexis.core.services/src/ch/elexis/core/services/StickerService.java
+++ b/bundles/ch.elexis.core.services/src/ch/elexis/core/services/StickerService.java
@@ -113,7 +113,7 @@ public class StickerService implements IStickerService {
 		List<ISticker> loadedStickers = new ArrayList<>();
 		for (StickerObjectLink link : stickerObjectLinks) {
 			ISticker sticker = loadStickerForStickerObjectLink(link, identifiable);
-			if (sticker != null) {
+			if (sticker != null && !sticker.getId().equals("activate_mediorder")) {
 				loadedStickers.add(sticker);
 			}
 		}


### PR DESCRIPTION
Der Eintrag in die Tabelle ETIKETTEN_OBJCLASS_LINK wird benötigt, damit in der Patienten View nach diesem Sticker gefiltert werden kann.