### PR TITLE
[26513] fix updating of fall in falldetail

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/FallDetailBlatt2.java
@@ -481,6 +481,7 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 			public void widgetSelected(SelectionEvent e) {
 				boolean b = btnNoElectronicDelivery.getSelection();
 				getSelectedFall().setInfoString(FallConstants.FLD_EXT_NO_ELECTRONIC_DELIVERY, b ? "1" : "0"); //$NON-NLS-1$ //$NON-NLS-2$
+				fireSelectedFallUpdateEvent();
 			};
 		});
 		btnNoElectronicDelivery.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
@@ -699,9 +700,6 @@ public class FallDetailBlatt2 extends Composite implements IUnlockable {
 	 */
 	@SuppressWarnings("unchecked")
 	public void setFall(final IFall f) {
-		if (actFall != null) {
-			save();
-		}
 		// *** dispose of currently displayed fields
 		actFall = f;
 		for (Control c : lReqs) {


### PR DESCRIPTION
Beim Testen ist aufgefallen, dass beim Öffnen des Falldetails von einem Fall das Lastupdate aktualisiert wird, oder auch beim Auswählen der Checkbox "Keine elektronische Zustellung" wird der Fall erst aktualisiert, wenn man das Falldetail View erneut öffnet.
Die Änderungen sollten die zwei Probleme lösen.