### PR TITLE
Add devenv.sh based development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/ch.elexis.sdk/readme.md
+++ b/ch.elexis.sdk/readme.md
@@ -73,6 +73,19 @@ If you want a complete development environment, try
 This is the recommended (and the only supported) setup of an development environment
 for Elexis developers.
 
+### Building using devenv.sh
+
+For details consult [deven.sh](https://devenv.sh/). Resuming [getting started](https://devenv.sh/getting-started/) it should be sufficient to run these steps. Tested the multi-user installation under debian bookworm.
+
+    sh <(curl -L https://nixos.org/nix/install) --daemon
+    nix profile install --accept-flake-config nixpkgs#devenv --extra-experimental-features flakes --extra-experimental-features nix-command
+    # install direnv, eg. debian sudo apt install direnv
+    direnv allow
+
+Now you should be able to use maven e.g via
+
+    mvn -V clean verify  -Dtycho.localArtifacts=ignore -Dmaterialize-products
+
 ### Eclipse IDE-Preferences
 
 We recommend (and if you want to submit patches, you have to respect)

--- a/ch.elexis.sdk/readme.md
+++ b/ch.elexis.sdk/readme.md
@@ -82,9 +82,9 @@ For details consult [deven.sh](https://devenv.sh/). Resuming [getting started](h
     # install direnv, eg. debian sudo apt install direnv
     direnv allow
 
-Now you should be able to use maven e.g via
+Now you can test (build, running unit tests, building products) using the `devenv test` command.
 
-    mvn -V clean verify  -Dtycho.localArtifacts=ignore -Dmaterialize-products
+Or use use any maven command e.g `mvn -V clean verify  -Dtycho.localArtifacts=ignore -DskipTests` to just compile all code.
 
 ### Eclipse IDE-Preferences
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1724251323,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "5340ef87de79a5e23414e6707cc90009e97745d5",
+        "treeHash": "f09dcc233cb82d8ccafebd393e124824a0e25b55",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1724098845,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f1bad50880bae73ff2d82fafc22010b4fc097a9c",
+        "treeHash": "c217afffc0b4aa4caf4533a68d4b8a2f9eff6e07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1724227338,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
+        "treeHash": "698918d3a04360f1dfd19164903511a167368ec1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,13 +7,13 @@
   env.LC_ALL= "de_CH.UTF-8";
 
   # https://devenv.sh/packages/
-  packages = [ pkgs.git pkgs.maven ];
+  packages = [ pkgs.git pkgs.maven pkgs.xvfb-run ];
 
   # https://devenv.sh/tests/
   enterTest = ''
     echo "Running tests"
     git --version | grep --color=auto "${pkgs.git.version}"
-    mvn -V clean verify  -Dtycho.localArtifacts=ignore
+    xvfb-run mvn -V clean verify  -Dtycho.localArtifacts=ignore
   '';
 
   # See full reference at https://devenv.sh/reference/options/

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.LANG= "de_CH.UTF-8";
+  env.LC_MESSAGES= "de_CH.UTF-8";
+  env.LC_ALL= "de_CH.UTF-8";
+
+  # https://devenv.sh/packages/
+  packages = [ pkgs.git pkgs.maven ];
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep --color=auto "${pkgs.git.version}"
+    mvn -V clean verify  -Dtycho.localArtifacts=ignore
+  '';
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
About three years ago I switched from Debian to NixOS and discovered a bit later devenv.sh.
Each time I work on project I try to add a devenv environment to avoid any issues with conflicting libraries, compilers, databases, applications, etc. Devenv allows me to get a reproducible environment (similar as running a docker image). It is handy to define needed background process like a mysql or postgres database with correct username/password combinations. All in a even more compact form than a docker image.

Nobody should feel forced to use it, but it would be nice for me, if it could go into master and last stable branches. This would make it a lot easier for other people to try it.