### PR TITLE
[26635] Patientendetails - global custom fields

### DIFF
--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
@@ -115,7 +115,7 @@ public class UserSettings2 extends FieldEditorPreferencePage implements IWorkben
 		Composite container = new Composite(getFieldEditorParent(), SWT.NONE);
 		container.setLayout(new GridLayout(2, false));
 		new Label(container, SWT.NONE).setText(Messages.UserSettings2_AddidtionalFields);
-		extraBool = globalPrefs.getBoolean(Patientenblatt2.CFG_GLOBALFIELDS);
+		extraBool = prefs.getBoolean(Patientenblatt2.CFG_GLOBALFIELDS);
 		Button checkBox = new Button(container, SWT.CHECK);
 		checkBox.setText("globale Felder"); //$NON-NLS-1$
 		checkBox.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
@@ -128,7 +128,7 @@ public class UserSettings2 extends FieldEditorPreferencePage implements IWorkben
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				extraBool = checkBox.getSelection();
-				globalPrefs.setValue(Patientenblatt2.CFG_GLOBALFIELDS, extraBool);
+				prefs.setValue(Patientenblatt2.CFG_GLOBALFIELDS, extraBool);
 				setZusatzFeldStore(zusatzFeldEditor);
 				if (zusatzFeldEditor.getPreferenceStore().equals(globalPrefs)
 						&& globalPrefs.getString(Patientenblatt2.CFG_EXTRAFIELDS).isEmpty()) {
@@ -211,7 +211,7 @@ public class UserSettings2 extends FieldEditorPreferencePage implements IWorkben
 	}
 
 	private void setZusatzFeldStore(MultilineFieldEditor zusatzFeldEditor) {
-		if (globalPrefs.getBoolean(Patientenblatt2.CFG_GLOBALFIELDS)) {
+		if (prefs.getBoolean(Patientenblatt2.CFG_GLOBALFIELDS)) {
 			zusatzFeldEditor.setPreferenceStore(globalPrefs);
 		} else {
 			zusatzFeldEditor.setPreferenceStore(prefs);

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
@@ -203,11 +203,7 @@ public class UserSettings2 extends FieldEditorPreferencePage implements IWorkben
 		IQuery<IUserConfig> ret = CoreModelServiceHolder.get().getQuery(IUserConfig.class);
 		ret.and("Param", COMPARATOR.EQUALS, Patientenblatt2.CFG_EXTRAFIELDS); //$NON-NLS-1$
 		List<IUserConfig> list = ret.execute();
-		StringBuilder sb = new StringBuilder(list.get(0).getValue());
-		for (int i = 1; i < list.size(); i++) {
-			sb.append("," + list.get(i).getValue()); //$NON-NLS-1$
-		}
-		return sb.toString();
+		return list.stream().map(uc -> uc.getValue()).collect(Collectors.joining(",")); //$NON-NLS-1$
 	}
 
 	private void setZusatzFeldStore(MultilineFieldEditor zusatzFeldEditor) {

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
@@ -153,7 +153,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 	// MenuItem delZA;
 	public final static String CFG_BEZUGSKONTAKTTYPEN = "views/patientenblatt/Bezugskontakttypen"; //$NON-NLS-1$
 	public final static String CFG_EXTRAFIELDS = "views/patientenblatt/extrafelder"; //$NON-NLS-1$
-	public final static String CFG_GLOBALFIELDS = "views/patientenblatt/extrafelder/alle"; //$NON-NLS-1$
+	public final static String CFG_GLOBALFIELDS = "views/patientenblatt/extrafelder/global"; //$NON-NLS-1$
 	public final static String SPLITTER = "#!>"; //$NON-NLS-1$
 
 	@SuppressWarnings("unchecked")

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
@@ -153,6 +153,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 	// MenuItem delZA;
 	public final static String CFG_BEZUGSKONTAKTTYPEN = "views/patientenblatt/Bezugskontakttypen"; //$NON-NLS-1$
 	public final static String CFG_EXTRAFIELDS = "views/patientenblatt/extrafelder"; //$NON-NLS-1$
+	public final static String CFG_GLOBALFIELDS = "views/patientenblatt/extrafelder/alle"; //$NON-NLS-1$
 	public final static String SPLITTER = "#!>"; //$NON-NLS-1$
 
 	@SuppressWarnings("unchecked")
@@ -469,9 +470,14 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 						}
 					}
 				}));
-
-		String[] userfields = ConfigServiceHolder.getUser(CFG_EXTRAFIELDS, StringConstants.EMPTY)
-				.split(StringConstants.COMMA);
+		String[] userfields;
+		if (ConfigServiceHolder.getGlobal(CFG_GLOBALFIELDS, false)) {
+			userfields = ConfigServiceHolder.getGlobal(CFG_EXTRAFIELDS, StringConstants.EMPTY)
+					.split(StringConstants.COMMA);
+		} else {
+			userfields = ConfigServiceHolder.getUser(CFG_EXTRAFIELDS, StringConstants.EMPTY)
+					.split(StringConstants.COMMA);
+		}
 		for (String extfield : userfields) {
 			if (!StringTool.isNothing(extfield)) {
 				fields.add(new InputData(extfield, Patient.FLD_EXTINFO, InputData.Typ.STRING, extfield));


### PR DESCRIPTION
1. Checkbox in PreferencePage
2. Button selection logic
3. Two new params in 'config' will be used (one for boolean and one for custom global fields)
4. Logic: 
- if bool true, show global fields in preference page and use those.
- if bool true, check if global fields param has values / is not empty
- - if no values / empty, get all custom userfields from 'userconfig' and append them all into one global field. save it in 'config' too.
- - global field in 'config' can be changed too.
- user can choose to go back and use their own custom fields set in 'userconfig' by toggling the checkbox