### PR TITLE
[26442] stickerComposite rework, inpAdresse width, mindwith input range

### DIFF
--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/preferences/UserSettings2.java
@@ -148,7 +148,9 @@ public class UserSettings2 extends FieldEditorPreferencePage implements IWorkben
 		fwc.setLayout(new GridLayout(2, true));
 		addField(new BooleanFieldEditor(Preferences.USR_PATDETAIL_MINWIDTH_STATE,
 				"Feste Mindestbreite in Patientendetail-Felder nutzen", fwc));
-		addField(new IntegerFieldEditor(Preferences.USR_PATDETAIL_MINWIDTH, "Breite: ", fwc));
+		IntegerFieldEditor minwidthField = new IntegerFieldEditor(Preferences.USR_PATDETAIL_MINWIDTH, "Breite: ", fwc);
+		minwidthField.setValidRange(80, 500);
+		addField(minwidthField);
 		new Label(getFieldEditorParent(), SWT.NONE).setText(StringUtils.EMPTY);
 		ComboFieldEditor editor = new ComboFieldEditor(Preferences.CFG_DECEASED_STICKER, "Sticker für verstorbene",
 				getStickerComboItems(), getFieldEditorParent());

--- a/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
+++ b/bundles/ch.elexis.core.ui.contacts/src/ch/elexis/core/ui/contacts/views/Patientenblatt2.java
@@ -68,8 +68,6 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PlatformUI;
@@ -79,6 +77,7 @@ import org.eclipse.ui.forms.events.ExpansionEvent;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.events.IExpansionListener;
+import org.eclipse.ui.forms.widgets.ColumnLayout;
 import org.eclipse.ui.forms.widgets.ColumnLayoutData;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormText;
@@ -535,6 +534,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 		form.getHorizontalBar().addListener(SWT.Hide, (e) -> updateExpandableLayoutWidth());
 
 		stickerComposite = StickerComposite.createWrappedStickerComposite(form.getBody(), tk);
+		((ColumnLayout) stickerComposite.getLayout()).maxNumColumns = 2;
 
 		cUserfields = new Composite(form.getBody(), SWT.NONE);
 		cUserfields.setLayout(new GridLayout());
@@ -610,7 +610,9 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 		hHA.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING));
 		inpAdresse = tk.createFormText(cPersonalien, false);
 		inpAdresse.setText("---\n", false, false); //$NON-NLS-1$
-		inpAdresse.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+		GridData inpData = SWTHelper.getFillGridData(1, true, 1, false);
+		inpData.widthHint = CoreUiUtil.getStringExtent(hHA, hHA.getText()).x;
+		inpAdresse.setLayoutData(inpData);
 
 		IExpansionListener ecExpansionListener = new ExpansionAdapter() {
 			@Override
@@ -1578,25 +1580,7 @@ public class Patientenblatt2 extends Composite implements IUnlockable {
 				updateToolTipText(field);
 			}
 		}
-		setupStickerCompositeWidth(fieldWidth);
 		refresh();
-	}
-
-	/**
-	 * Configures the width of stickerComposite's child components. Ensures the
-	 * overall view can be minimized correctly by setting the width hint.
-	 *
-	 * @param width the width to set for each child composite
-	 */
-	private void setupStickerCompositeWidth(int width) {
-		for (Control stickerCtrl : stickerComposite.getChildren()) {
-			if (stickerCtrl instanceof Composite) {
-				Composite sticker = (Composite) stickerCtrl;
-				ColumnLayoutData data = (ColumnLayoutData) sticker.getLayoutData();
-				data.widthHint = width;
-				sticker.setLayoutData(data);
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
- removed the whole stickerComposite field width setting since it did not fully fix the scaling issue, and just set the maxColumns of the composite to 2 so the layout looks better.
- Added a valid range for the minimum width in the pref page
- Also set a widthhint for the inpAdresse field. I noticed during testing that when the text is very long it interferes with the width of the view.