### PR TITLE
[26738] add drag and drop support for general patients

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
@@ -878,7 +878,13 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 			// do nothing, it should not be possible to change the patient of a reminder.
 			break;
 		case GENERAL_PATIENT:
-			// dont remove patient
+			if (!reminder.getResponsible().isEmpty()) {
+				for (IContact contact : reminder.getResponsible()) {
+					reminder.removeResponsible(contact);
+				}
+				reminder.addResponsible(patient);
+			}
+			reminder.setResponsibleAll(true);
 			break;
 		case GROUP:
 			IUserGroup targetGroup = findGroupForViewer(viewer);
@@ -895,9 +901,8 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 			}
 			break;
 		case MYREMINDERS:
-			List<IContact> currentResponsibles = reminder.getResponsible();
-			if (!currentResponsibles.isEmpty()) {
-				for (IContact contact : currentResponsibles) {
+			if (!reminder.getResponsible().isEmpty()) {
+				for (IContact contact : reminder.getResponsible()) {
 					reminder.removeResponsible(contact);
 				}
 			}

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
@@ -882,7 +882,6 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 				for (IContact contact : reminder.getResponsible()) {
 					reminder.removeResponsible(contact);
 				}
-				reminder.addResponsible(patient);
 			}
 			reminder.setResponsibleAll(true);
 			break;


### PR DESCRIPTION
Noticed while testing that you cannot assign a reminder back to all via drag and dropping into the all reminders area.
this should add the ability.