### PR TITLE
[26738] reminders beta fixes and improvements

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderListsView.java
@@ -946,7 +946,7 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 		createResponsibleColumn(tableViewer, 80, 2);
 		createPatientColumn(tableViewer, 150, 3);
 		createDescriptionColumn(tableViewer, 400, columnIndex);
-		TableViewerResizer.enableResizing(tableViewer);
+		TableViewerResizer.enableResizing(tableViewer, viewersScrolledComposite);
 		addModifiedScrollListener(tableViewer.getTable());
 		tableViewer.getTable().addFocusListener(new FocusAdapter() {
 			@Override
@@ -2591,7 +2591,7 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 		private static int tolerance = 15;
 		private static int minHeight = 25;
 
-		public static void enableResizing(TableViewer tableViewer) {
+		public static void enableResizing(TableViewer tableViewer, ScrolledComposite scrolledComposite) {
 			Table table = tableViewer.getTable();
 			Composite parent = table.getParent();
 
@@ -2628,14 +2628,10 @@ public class ReminderListsView extends ViewPart implements HeartListener, IRefre
 								table.setLayoutData(gd);
 								lastY += deltaY;
 								table.getParent().layout(true, true);
-								if (table.getParent().getParent() instanceof ScrolledComposite) {
-									ScrolledComposite scrolledComposite = (ScrolledComposite) table.getParent()
-											.getParent();
 									Point newSize = table.getParent().computeSize(SWT.DEFAULT, SWT.DEFAULT);
 									scrolledComposite.setMinSize(newSize.x,
 											Math.max(newSize.y, scrolledComposite.getClientArea().height));
 									scrolledComposite.layout(true, true);
-								}
 							}
 						}
 					}


### PR DESCRIPTION
- deleteReminderAction and ReminderStatus SubMenu both use the getSelection to check if an element is selected.
they both should check only the selection of the viewer the menu is assigned to.
I achieved this by adding a method getViewerForId(String id), which returns the viewer with the given id from a HashMap which has all viewers.

- fix patient change reminder query
before, the query gets the patient related reminders which are assigned to the active mandator.
after, the query should *also* get patient related reminders which are assigned to ALL
- adjusted the custom time action dialog for improved experience
can only select dates from *today*
show a text as the title of the dialog

- fix duedate filter query
before, only add comparator less or equal filter to reminder
after, it should query between now() and the set filter days.
this way, older due filters will not show up.

- fix when resizing a table with the mouse (drag on bottom of table to resize), the overall view vertical scrollbar doesnt update correctly.
recalculate the MinSize of the scrolledComposite when the table is being resized manually

- fix table column sorting always only sorted by dueDate
with the new changes it should now sort after the selected column, either by reminderType, Date, or String.