### PR TITLE
FHIR write-path: Encounter.account, ChargeItem.context, Condition.encounter, TARDOC/ICD-10

### DIFF
--- a/bundles/ch.elexis.core.findings.util/OSGI-INF/ch.elexis.core.findings.util.fhir.transformer.ChargeItemIBilledTransformer.xml
+++ b/bundles/ch.elexis.core.findings.util/OSGI-INF/ch.elexis.core.findings.util.fhir.transformer.ChargeItemIBilledTransformer.xml
@@ -7,5 +7,6 @@
    <reference cardinality="1..1" field="codeElementService" interface="ch.elexis.core.services.ICodeElementService" name="codeElementService"/>
    <reference cardinality="1..1" field="contextService" interface="ch.elexis.core.services.IContextService" name="contextService"/>
    <reference cardinality="1..1" field="coreModelService" interface="ch.elexis.core.services.IModelService" name="coreModelService" target="(service.model.name=ch.elexis.core.model)"/>
+   <reference cardinality="1..1" field="findingsService" interface="ch.elexis.core.findings.IFindingsService" name="findingsService"/>
    <implementation class="ch.elexis.core.findings.util.fhir.transformer.ChargeItemIBilledTransformer"/>
 </scr:component>

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/accessor/EncounterAccessor.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/accessor/EncounterAccessor.java
@@ -12,6 +12,7 @@ import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Encounter.DiagnosisComponent;
 import org.hl7.fhir.r4.model.Encounter.EncounterParticipantComponent;
+import org.hl7.fhir.r4.model.Encounter.EncounterStatus;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Reference;
@@ -21,6 +22,7 @@ import ch.elexis.core.findings.ICoding;
 import ch.elexis.core.findings.ICondition;
 import ch.elexis.core.findings.IdentifierSystem;
 import ch.elexis.core.findings.util.ModelUtil;
+import ch.elexis.core.findings.util.fhir.transformer.helper.FhirUtil;
 import ch.elexis.core.model.IContact;
 import ch.elexis.core.model.IMandator;
 
@@ -114,6 +116,71 @@ public class EncounterAccessor extends AbstractFindingsAccessor {
 	public void setPatientId(DomainResource resource, String patientId) {
 		org.hl7.fhir.r4.model.Encounter fhirEncounter = (org.hl7.fhir.r4.model.Encounter) resource;
 		fhirEncounter.setSubject(new Reference(new IdDt("Patient", patientId)));
+	}
+
+	/**
+	 * Patch: read Coverage (Elexis Fall) reference from Encounter.account[*].
+	 * Allows FHIR clients to explicitly assign a consultation to a specific
+	 * Fall instead of being forced into the auto-created "online" default fall.
+	 */
+	public Optional<String> getCoverageId(DomainResource resource) {
+		org.hl7.fhir.r4.model.Encounter fhirEncounter = (org.hl7.fhir.r4.model.Encounter) resource;
+		if (fhirEncounter.hasAccount()) {
+			for (Reference account : fhirEncounter.getAccount()) {
+				if (account != null && FhirUtil.isReferenceType(account, "Coverage")) {
+					return FhirUtil.getId(account);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Patch: expose the Elexis Fall id as Encounter.account[0] so that FHIR
+	 * clients can see which Fall a consultation belongs to.
+	 */
+	public void setCoverageId(DomainResource resource, String coverageId) {
+		org.hl7.fhir.r4.model.Encounter fhirEncounter = (org.hl7.fhir.r4.model.Encounter) resource;
+		fhirEncounter.getAccount().clear();
+		if (coverageId != null && !coverageId.isEmpty()) {
+			fhirEncounter.addAccount(new Reference(new IdDt("Coverage", coverageId)));
+		}
+	}
+
+	/**
+	 * Patch: map Elexis IEncounter.billable to FHIR Encounter.status. A billable
+	 * (still editable) consultation maps to in-progress, a non-billable
+	 * (closed/billed) one to finished.
+	 */
+	public void setStatus(DomainResource resource, boolean billable) {
+		org.hl7.fhir.r4.model.Encounter fhirEncounter = (org.hl7.fhir.r4.model.Encounter) resource;
+		fhirEncounter.setStatus(billable ? EncounterStatus.INPROGRESS : EncounterStatus.FINISHED);
+	}
+
+	/**
+	 * Patch: derive the billable flag from FHIR Encounter.status, so that clients
+	 * can reopen / close a consultation via PUT.
+	 */
+	public Optional<Boolean> getBillable(DomainResource resource) {
+		org.hl7.fhir.r4.model.Encounter fhirEncounter = (org.hl7.fhir.r4.model.Encounter) resource;
+		if (!fhirEncounter.hasStatus()) {
+			return Optional.empty();
+		}
+		switch (fhirEncounter.getStatus()) {
+		case PLANNED:
+		case ARRIVED:
+		case TRIAGED:
+		case INPROGRESS:
+		case ONLEAVE:
+			return Optional.of(Boolean.TRUE);
+		case FINISHED:
+		case CANCELLED:
+		case ENTEREDINERROR:
+		case UNKNOWN:
+		case NULL:
+		default:
+			return Optional.of(Boolean.FALSE);
+		}
 	}
 
 	public void setConsultationId(DomainResource resource, String consultationId) {

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ChargeItemIBilledTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ChargeItemIBilledTransformer.java
@@ -18,6 +18,7 @@ import org.osgi.service.component.annotations.Reference;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.api.SummaryEnum;
+import ch.elexis.core.findings.IFindingsService;
 import ch.elexis.core.findings.util.fhir.IFhirTransformer;
 import ch.elexis.core.findings.util.fhir.IFhirTransformerException;
 import ch.elexis.core.findings.util.fhir.transformer.helper.CodeSystemUtil;
@@ -49,6 +50,9 @@ public class ChargeItemIBilledTransformer implements IFhirTransformer<ChargeItem
 
 	@Reference
 	private IContextService contextService;
+
+	@Reference
+	private IFindingsService findingsService;
 
 	@Override
 	public Optional<ChargeItem> getFhirObject(IBilled localObject, SummaryEnum summaryEnum, Set<Include> includes) {
@@ -166,7 +170,18 @@ public class ChargeItemIBilledTransformer implements IFhirTransformer<ChargeItem
 			throw new IFhirTransformerException("WARNING", "Missing encounter parameter", 412);
 		}
 
-		IEncounter encounter = coreModelService.load(encounterId, IEncounter.class).orElse(null);
+		// Patch: a FHIR Encounter id refers to a findings-store IEncounter,
+		// whose consultationId points at the actual Elexis Behandlung
+		// (ch.elexis.core.model.IEncounter). Loading the FHIR id directly as
+		// a Behandlung returns null because the id-spaces are distinct, which
+		// caused ChargeItems to be billed against the wrong / no consultation
+		// and never persisted into the "leistungen" table. Mirror the
+		// two-step lookup used by ClaimVerrechnetTransformer.
+		Optional<ch.elexis.core.findings.IEncounter> finding = findingsService.findById(encounterId,
+				ch.elexis.core.findings.IEncounter.class);
+		IEncounter encounter = finding
+				.flatMap(f -> coreModelService.load(f.getConsultationId(), IEncounter.class))
+				.orElse(null);
 		if (encounter == null) {
 			throw new IFhirTransformerException("WARNING", "Invalid encounter", 412);
 		}

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
@@ -233,12 +233,17 @@ public class ClaimVerrechnetTransformer implements IFhirTransformer<Claim, List<
 		}
 
 		private Optional<IBillable> getBillable(String system, String code, ch.elexis.core.model.IEncounter cons) {
+			Map<Object, Object> context = new HashMap<>();
+			context.put(ICodeElementService.ContextKeys.CONSULTATION, cons);
 			if (system.equals(CodingSystem.ELEXIS_TARMED_CODESYSTEM.getSystem())) {
-				Map<Object, Object> context = new HashMap<>();
-				context.put(ICodeElementService.ContextKeys.CONSULTATION, cons);
 				Optional<ICodeElement> tarmed = codeElementService.loadFromString("Tarmed", code, context);
 				if (tarmed.isPresent()) {
 					return tarmed.filter(IBillable.class::isInstance).map(IBillable.class::cast);
+				}
+			} else if (system.equals("www.elexis.info/billing/tardoc")) {
+				Optional<ICodeElement> tardoc = codeElementService.loadFromString("Tardoc", code, context);
+				if (tardoc.isPresent()) {
+					return tardoc.filter(IBillable.class::isInstance).map(IBillable.class::cast);
 				}
 			}
 			LoggerFactory.getLogger(ClaimVerrechnetTransformer.class)
@@ -255,9 +260,13 @@ public class ClaimVerrechnetTransformer implements IFhirTransformer<Claim, List<
 						for (Coding coding : diagnoseCoding.getCoding()) {
 							IDiagnosisReference diag = modelService.create(IDiagnosisReference.class);
 							diag.setCode(coding.getCode());
-							diag.setText((coding.getDisplay() != null) ? coding.getDisplay() : "MISSING");
+							diag.setText((coding.getDisplay() != null) ? coding.getDisplay() : coding.getCode());
 							if (CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE.getSystem().equals(coding.getSystem())) {
 								diag.setReferredClass("ch.elexis.data.TICode");
+							} else if (CodingSystem.ICD_DE_CODESYSTEM.getSystem().equals(coding.getSystem())) {
+								diag.setReferredClass("ch.elexis.data.ICD10");
+							} else {
+								diag.setReferredClass("ch.elexis.data.FreeTextDiagnose");
 							}
 							ret.add(diag);
 						}

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformer.java
@@ -5,19 +5,26 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SummaryEnum;
 import ch.elexis.core.findings.ICondition;
 import ch.elexis.core.findings.IFindingsService;
+import ch.elexis.core.findings.codes.CodingSystem;
 import ch.elexis.core.findings.util.ModelUtil;
 import ch.elexis.core.findings.util.fhir.IFhirTransformer;
 import ch.elexis.core.findings.util.fhir.accessor.ConditionAccessor;
+import ch.elexis.core.findings.util.fhir.transformer.helper.AbstractHelper;
 import ch.elexis.core.findings.util.fhir.transformer.helper.FhirUtil;
 import ch.elexis.core.findings.util.fhir.transformer.helper.FindingsContentHelper;
+import ch.elexis.core.lock.types.LockResponse;
+import ch.elexis.core.model.IDiagnosisReference;
 import ch.elexis.core.model.IPatient;
 import ch.elexis.core.services.IModelService;
 
@@ -83,7 +90,118 @@ public class ConditionIConditionTransformer implements IFhirTransformer<Conditio
 			patient.ifPresent(k -> iCondition.setPatientId(id));
 		}
 		findingsService.saveFinding(iCondition);
+
+		// Additionally bridge into the Elexis client world if an Encounter context
+		// is referenced: the FHIR `Condition.encounter` is interpreted as a write
+		// anchor that should produce a row in the `behdl_dg_joint` junction table
+		// so that the desktop client, TARDOC billing, history view etc. actually
+		// see this diagnosis. The mapping mirrors the established pattern used by
+		// ClaimVerrechnetTransformer for `Claim.diagnosis[]`.
+		persistAsClientDiagnosis(fhirObject);
+
 		return Optional.of(iCondition);
+	}
+
+	/**
+	 * Bridge a FHIR Condition into the Elexis client diagnosis world
+	 * (`diagnosen` master + `behdl_dg_joint` junction).
+	 *
+	 * <p>
+	 * The Findings world (`ch_elexis_core_findings_condition`) is kept as the
+	 * canonical store for the FHIR roundtrip; this method only adds the
+	 * additional junction link expected by the desktop client. If any of the
+	 * required inputs (encounter reference, coding) is missing, the method is a
+	 * no-op so that other Condition use-cases (problem list, family history,
+	 * etc.) remain unaffected.
+	 * </p>
+	 */
+	private void persistAsClientDiagnosis(Condition fhirObject) {
+		if (fhirObject == null || !fhirObject.hasEncounter() || !fhirObject.hasCode()) {
+			return;
+		}
+		String fhirEncounterId = fhirObject.getEncounter().getReferenceElement().getIdPart();
+		if (StringUtils.isBlank(fhirEncounterId)) {
+			return;
+		}
+		// Two-step lookup identical to ChargeItemIBilledTransformer.assertEncounter:
+		//   FHIR-Encounter id -> ch_elexis_core_findings_encounter.CONSULTATIONID -> behandlungen.ID
+		Optional<ch.elexis.core.findings.IEncounter> findingsEncounter = findingsService.findById(fhirEncounterId,
+				ch.elexis.core.findings.IEncounter.class);
+		Optional<ch.elexis.core.model.IEncounter> consultation = findingsEncounter
+				.flatMap(f -> modelService.load(f.getConsultationId(), ch.elexis.core.model.IEncounter.class));
+		if (!consultation.isPresent()) {
+			LoggerFactory.getLogger(ConditionIConditionTransformer.class).warn(
+					"Condition.encounter='{}' could not be resolved to an Elexis Behandlung; skipping junction write.",
+					fhirEncounterId);
+			return;
+		}
+
+		if (!fhirObject.getCode().hasCoding() || fhirObject.getCode().getCoding().isEmpty()) {
+			return;
+		}
+
+		Logger log = LoggerFactory.getLogger(ConditionIConditionTransformer.class);
+		ch.elexis.core.model.IEncounter cons = consultation.get();
+		LockResponse lockResponse = AbstractHelper.acquireLock(cons);
+		try {
+			for (Coding coding : fhirObject.getCode().getCoding()) {
+				if (coding == null || StringUtils.isBlank(coding.getCode())) {
+					continue;
+				}
+				IDiagnosisReference diag = modelService.create(IDiagnosisReference.class);
+				diag.setCode(coding.getCode());
+				diag.setText(StringUtils.isNotBlank(coding.getDisplay()) ? coding.getDisplay() : coding.getCode());
+				diag.setReferredClass(mapCodingSystemToReferredClass(coding.getSystem()));
+				// Saving the diagnosis reference + the encounter triggers
+				// AbstractModelService.save -> ContextService.postEvent, which is not
+				// implemented on the headless server (UnsupportedOperationException).
+				// The JPA write itself succeeds (junction row is committed); swallow
+				// the post-save event failure so the HTTP request still returns 201.
+				safeSave(diag, log);
+				cons.addDiagnosis(diag);
+				log.debug("Linked Condition coding system='{}' code='{}' to Behandlung '{}'.",
+						coding.getSystem(), coding.getCode(), cons.getId());
+			}
+			safeSave(cons, log);
+		} finally {
+			if (lockResponse != null && lockResponse.isOk()) {
+				AbstractHelper.releaseLock(lockResponse.getLockInfo());
+			}
+		}
+	}
+
+	/**
+	 * Wrap modelService.save() so that the headless server's missing event-bus
+	 * (ContextService.postEvent throws UnsupportedOperationException) does not
+	 * surface as an HTTP 500 to the FHIR client. The actual JPA write has
+	 * already happened at that point and the row is persisted.
+	 */
+	private void safeSave(Object entity, Logger log) {
+		try {
+			modelService.save((ch.elexis.core.model.Identifiable) entity);
+		} catch (UnsupportedOperationException uoe) {
+			log.debug("modelService.save post-event raised UnsupportedOperationException; "
+					+ "persistence row is already committed, ignoring. entity={}", entity, uoe);
+		}
+	}
+
+	/**
+	 * Map a FHIR Coding.system URI to the Elexis `ReferredClass` value used in
+	 * the `diagnosen.KLASSE` column. Identical to the resolution used by
+	 * ClaimVerrechnetTransformer; additionally accepts the HAPI-default
+	 * "http://hl7.org/fhir/sid/icd-10" URI (without the German `-de` suffix) so
+	 * that off-the-shelf FHIR clients also produce ICD-10 mappings instead of
+	 * silently falling through to FreeTextDiagnose.
+	 */
+	static String mapCodingSystemToReferredClass(String system) {
+		if (system != null && CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE.getSystem().equals(system)) {
+			return "ch.elexis.data.TICode"; //$NON-NLS-1$
+		}
+		if (system != null && (CodingSystem.ICD_DE_CODESYSTEM.getSystem().equals(system)
+				|| "http://hl7.org/fhir/sid/icd-10".equals(system))) { //$NON-NLS-1$
+			return "ch.elexis.data.ICD10"; //$NON-NLS-1$
+		}
+		return "ch.elexis.data.FreeTextDiagnose"; //$NON-NLS-1$
 	}
 
 	@Override

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/EncounterIEncounterTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/EncounterIEncounterTransformer.java
@@ -55,6 +55,12 @@ public class EncounterIEncounterTransformer implements IFhirTransformer<Encounte
 	public Optional<Encounter> getFhirObject(IEncounter localObject, SummaryEnum summaryEnum, Set<Include> includes) {
 		Optional<IBaseResource> resource = contentHelper.getResource(localObject);
 		if (resource.isPresent()) {
+			// Patch: re-sync FHIR Encounter from the underlying Elexis Behandlung,
+			// so that account (Fall) and status reflect the current DB state and
+			// not just the cached findings-store copy.
+			Optional<ch.elexis.core.model.IEncounter> behandlung = coreModelService.load(localObject.getConsultationId(),
+					ch.elexis.core.model.IEncounter.class);
+			behandlung.ifPresent(cons -> attributeMapper.elexisToFhir(cons, (Encounter) resource.get(), summaryEnum, includes));
 			return Optional.of((Encounter) resource.get());
 		}
 		return Optional.empty();
@@ -94,7 +100,9 @@ public class EncounterIEncounterTransformer implements IFhirTransformer<Encounte
 			contentHelper.setResource(fhirObject, iEncounter);
 			patientKontakt.ifPresent(k -> iEncounter.setPatientId(k.getId()));
 			performerKontakt.ifPresent(k -> iEncounter.setMandatorId(k.getId()));
-			encounterHelper.createIEncounter(iEncounter).ifPresent(cons -> {
+			// Patch: pass an explicit Coverage id from Encounter.account through so
+			// the consultation gets assigned to the caller-chosen Fall.
+			encounterHelper.createIEncounter(iEncounter, attributeMapper.getCoverageId(fhirObject)).ifPresent(cons -> {
 				iEncounter.setConsultationId(cons.getId());
 				attributeMapper.fhirToElexis(fhirObject, cons);
 				coreModelService.save(cons);

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/helper/IEncounterHelper.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/helper/IEncounterHelper.java
@@ -29,12 +29,23 @@ public class IEncounterHelper extends AbstractHelper {
 	}
 
 	public Optional<ch.elexis.core.model.IEncounter> createIEncounter(IEncounter iEncounter) {
+		return createIEncounter(iEncounter, Optional.empty());
+	}
+
+	/**
+	 * Patch: variant that honours an explicit Coverage (Fall) id supplied via
+	 * FHIR Encounter.account. If the requested Fall exists and belongs to the
+	 * same patient, it is used. Otherwise the legacy default-fall behaviour
+	 * applies.
+	 */
+	public Optional<ch.elexis.core.model.IEncounter> createIEncounter(IEncounter iEncounter,
+			Optional<String> coverageId) {
 		Optional<ch.elexis.core.model.IEncounter> ret = getIEncounter(iEncounter);
 		if (!ret.isPresent()) {
 			Optional<IPatient> patient = getPatient(iEncounter);
 			Optional<IMandator> serviceProvider = getPerformer(iEncounter);
 			if (patient.isPresent() && serviceProvider.isPresent()) {
-				ICoverage fall = getOrCreateDefaultFall(patient.get());
+				ICoverage fall = getCoverageOrDefaultFall(patient.get(), coverageId);
 				ch.elexis.core.model.IEncounter encounter = new IEncounterBuilder(coreModelService, fall,
 						serviceProvider.get()).buildAndSave();
 				findingsModelService.save(encounter);
@@ -42,6 +53,24 @@ public class IEncounterHelper extends AbstractHelper {
 			}
 		}
 		return ret;
+	}
+
+	public Optional<ICoverage> getCoverage(String coverageId) {
+		if (coverageId != null && !coverageId.isEmpty()) {
+			return coreModelService.load(coverageId, ICoverage.class);
+		}
+		return Optional.empty();
+	}
+
+	private ICoverage getCoverageOrDefaultFall(IPatient patient, Optional<String> coverageId) {
+		if (coverageId.isPresent()) {
+			Optional<ICoverage> requestedCoverage = getCoverage(coverageId.get());
+			if (requestedCoverage.isPresent() && requestedCoverage.get().getPatient() != null
+					&& patient.getId().equals(requestedCoverage.get().getPatient().getId())) {
+				return requestedCoverage.get();
+			}
+		}
+		return getOrCreateDefaultFall(patient);
 	}
 
 	public ICoverage getOrCreateDefaultFall(IPatient patient) {

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/mapper/IEncounterEncounterAttributeMapper.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/mapper/IEncounterEncounterAttributeMapper.java
@@ -29,6 +29,14 @@ public class IEncounterEncounterAttributeMapper
 
 	private EncounterAccessor accessor = new EncounterAccessor();
 
+	/**
+	 * Patch: expose the Coverage id extracted from FHIR Encounter.account so the
+	 * transformer can pass it on to IEncounterHelper.
+	 */
+	public Optional<String> getCoverageId(Encounter source) {
+		return accessor.getCoverageId(source);
+	}
+
 	@Override
 	public void elexisToFhir(IEncounter source, Encounter target, SummaryEnum summaryEnum, Set<Include> includes) {
 
@@ -40,11 +48,16 @@ public class IEncounterEncounterAttributeMapper
 		}
 		ICoverage coverage = source.getCoverage();
 		if (coverage != null) {
+			// Patch: surface Elexis Fall as Encounter.account[0]
+			accessor.setCoverageId(target, coverage.getId());
 			IPatient patient = coverage.getPatient();
 			if (patient != null) {
 				accessor.setPatientId(target, patient.getId());
 			}
 		}
+
+		// Patch: map IEncounter.billable to FHIR Encounter.status
+		accessor.setStatus(target, source.isBillable());
 
 		if (source.getMandator() != null) {
 			accessor.setPrimaryPerformer(target, source.getMandator());
@@ -80,6 +93,9 @@ public class IEncounterEncounterAttributeMapper
 		if (source.hasText()) {
 			updateConsText(source, target);
 		}
+
+		// Patch: derive billable flag from FHIR Encounter.status (PUT may flip it)
+		accessor.getBillable(source).ifPresent(billable -> target.setBillable(billable.booleanValue()));
 	}
 
 	private void updateConsText(Encounter fhirObject, ch.elexis.core.model.IEncounter cons) {

--- a/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/accessor/EncounterAccessorTest.java
+++ b/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/accessor/EncounterAccessorTest.java
@@ -1,0 +1,106 @@
+package ch.elexis.core.findings.util.fhir.accessor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pure-POJO tests for the Coverage round-trip helpers added to
+ * {@link EncounterAccessor}. The mapping is the source of truth for the
+ * Encounter.account &lt;-&gt; IEncounter.coverage round-trip used by
+ * {@link ch.elexis.core.findings.util.fhir.transformer.mapper.IEncounterEncounterAttributeMapper}.
+ *
+ * <p>The tests deliberately stay free of OSGi / DS so they can be executed
+ * with plain {@code mvn -pl tests/ch.elexis.core.findings.util.test test}.
+ */
+public class EncounterAccessorTest {
+
+	private EncounterAccessor accessor;
+	private Encounter fhirEncounter;
+
+	@Before
+	public void setUp() {
+		accessor = new EncounterAccessor();
+		fhirEncounter = new Encounter();
+	}
+
+	// ------------------------------------------------------------------
+	//  setCoverageId
+	// ------------------------------------------------------------------
+
+	@Test
+	public void setCoverageId_addsAccountReference() {
+		accessor.setCoverageId(fhirEncounter, "fall-42");
+
+		assertEquals("exactly one account entry", 1, fhirEncounter.getAccount().size());
+		assertEquals("Coverage/fall-42", fhirEncounter.getAccountFirstRep().getReference());
+	}
+
+	@Test
+	public void setCoverageId_replacesExistingAccountReferences() {
+		fhirEncounter.addAccount(new Reference("Coverage/old-1"));
+		fhirEncounter.addAccount(new Reference("Coverage/old-2"));
+
+		accessor.setCoverageId(fhirEncounter, "fall-new");
+
+		assertEquals(1, fhirEncounter.getAccount().size());
+		assertEquals("Coverage/fall-new", fhirEncounter.getAccountFirstRep().getReference());
+	}
+
+	@Test
+	public void setCoverageId_nullOrEmpty_clearsAccount() {
+		fhirEncounter.addAccount(new Reference("Coverage/old"));
+
+		accessor.setCoverageId(fhirEncounter, null);
+		assertTrue("null id must clear the account list", fhirEncounter.getAccount().isEmpty());
+
+		fhirEncounter.addAccount(new Reference("Coverage/old"));
+		accessor.setCoverageId(fhirEncounter, "");
+		assertTrue("empty id must clear the account list", fhirEncounter.getAccount().isEmpty());
+	}
+
+	// ------------------------------------------------------------------
+	//  getCoverageId
+	// ------------------------------------------------------------------
+
+	@Test
+	public void getCoverageId_returnsEmptyForFreshEncounter() {
+		Optional<String> id = accessor.getCoverageId(fhirEncounter);
+		assertFalse(id.isPresent());
+	}
+
+	@Test
+	public void getCoverageId_readsBackWhatWasSet() {
+		accessor.setCoverageId(fhirEncounter, "fall-rt");
+
+		Optional<String> id = accessor.getCoverageId(fhirEncounter);
+		assertTrue(id.isPresent());
+		assertEquals("fall-rt", id.get());
+	}
+
+	@Test
+	public void getCoverageId_returnsFirstCoverageReferenceAndIgnoresOtherTypes() {
+		fhirEncounter.addAccount(new Reference("Patient/some-patient"));
+		fhirEncounter.addAccount(new Reference("Coverage/the-fall"));
+		fhirEncounter.addAccount(new Reference("Coverage/another-fall"));
+
+		Optional<String> id = accessor.getCoverageId(fhirEncounter);
+		assertTrue(id.isPresent());
+		assertEquals("must pick the first Coverage reference", "the-fall", id.get());
+	}
+
+	@Test
+	public void getCoverageId_emptyWhenOnlyNonCoverageReferences() {
+		fhirEncounter.addAccount(new Reference("Patient/abc"));
+		fhirEncounter.addAccount(new Reference("Organization/xyz"));
+
+		assertFalse(accessor.getCoverageId(fhirEncounter).isPresent());
+	}
+}

--- a/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ChargeItemIBilledTransformerTest.java
+++ b/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ChargeItemIBilledTransformerTest.java
@@ -1,0 +1,200 @@
+package ch.elexis.core.findings.util.fhir.transformer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hl7.fhir.r4.model.ChargeItem;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.Test;
+
+import ch.elexis.core.findings.IEncounter;
+import ch.elexis.core.findings.IFindingsService;
+import ch.elexis.core.findings.util.fhir.IFhirTransformerException;
+import ch.elexis.core.services.IModelService;
+
+/**
+ * Unit tests for {@link ChargeItemIBilledTransformer#assertEncounter(ChargeItem)},
+ * the patched two-step lookup that was broken before the
+ * {@code fix/fhir-condition-chargeitem-roundtrip} branch and that resulted
+ * in {@code ChargeItem.context} never being persisted as
+ * {@code IBilled.encounter}.
+ *
+ * <p>The transformer's services are injected through DS in production. For
+ * the unit test we install lightweight {@link Proxy} stubs through reflection
+ * — Mockito is not part of the Elexis target platform, so the tests only
+ * depend on JUnit 4 and {@code java.lang.reflect}.
+ *
+ * <p>The point of these tests is the regression sentinel for the patch:
+ * a FHIR Encounter id must be resolved via
+ * {@code IFindingsService.findById(...) -> IModelService.load(consultationId)},
+ * never as a direct {@code modelService.load(fhirEncounterId)} call (which
+ * silently returns empty because the id-spaces differ).
+ */
+public class ChargeItemIBilledTransformerTest {
+
+	private static final String FHIR_ENCOUNTER_ID = "fhir-enc-abc";
+	private static final String CONSULTATION_ID = "behdl-xyz";
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	private static void setPrivateField(Object target, String name, Object value) throws Exception {
+		Field f = target.getClass().getDeclaredField(name);
+		f.setAccessible(true);
+		f.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T newProxy(Class<T> iface, InvocationHandler handler) {
+		return (T) Proxy.newProxyInstance(iface.getClassLoader(), new Class<?>[] { iface }, handler);
+	}
+
+	private static ChargeItem chargeItemWithContext(String encounterId) {
+		ChargeItem ci = new ChargeItem();
+		ci.setContext(new Reference("Encounter/" + encounterId));
+		return ci;
+	}
+
+	private static java.lang.reflect.Method assertEncounterMethod() throws Exception {
+		java.lang.reflect.Method m = ChargeItemIBilledTransformer.class
+				.getDeclaredMethod("assertEncounter", ChargeItem.class);
+		m.setAccessible(true);
+		return m;
+	}
+
+	/** Captures the very first argument of every IFindingsService.findById call. */
+	private static IFindingsService stubFindingsServiceReturning(
+			AtomicReference<String> capturedId,
+			IEncounter result) {
+		return newProxy(IFindingsService.class, (proxy, method, args) -> {
+			if ("findById".equals(method.getName()) && args != null && args.length >= 1) {
+				capturedId.set((String) args[0]);
+				return Optional.ofNullable(result);
+			}
+			return Optional.empty();
+		});
+	}
+
+	/** Captures the consultation-id parameter passed to load(...). */
+	private static IModelService stubModelServiceReturningEncounter(
+			AtomicReference<String> capturedLoadedId,
+			ch.elexis.core.model.IEncounter result) {
+		return newProxy(IModelService.class, (proxy, method, args) -> {
+			if ("load".equals(method.getName()) && args != null && args.length >= 2) {
+				capturedLoadedId.set((String) args[0]);
+				return Optional.ofNullable(result);
+			}
+			return Optional.empty();
+		});
+	}
+
+	private static IEncounter findingsEncounterWithConsultationId(String consultationId) {
+		return newProxy(IEncounter.class, (proxy, method, args) -> {
+			if ("getConsultationId".equals(method.getName())) {
+				return consultationId;
+			}
+			return null;
+		});
+	}
+
+	private static ch.elexis.core.model.IEncounter coreEncounterStub() {
+		return newProxy(ch.elexis.core.model.IEncounter.class, (proxy, method, args) -> null);
+	}
+
+	// ------------------------------------------------------------------
+	// Tests
+	// ------------------------------------------------------------------
+
+	/**
+	 * Happy path: the FHIR Encounter id must be passed to
+	 * {@code findingsService.findById(...)} first, and then the
+	 * {@code consultationId} returned by the findings-store must be the
+	 * argument that {@code modelService.load(...)} sees.
+	 */
+	@Test
+	public void assertEncounter_resolvesViaFindingsServiceTwoStepLookup() throws Exception {
+		ChargeItemIBilledTransformer tx = new ChargeItemIBilledTransformer();
+
+		AtomicReference<String> seenByFindings = new AtomicReference<>();
+		AtomicReference<String> seenByModel = new AtomicReference<>();
+
+		ch.elexis.core.model.IEncounter expected = coreEncounterStub();
+
+		setPrivateField(tx, "findingsService", stubFindingsServiceReturning(
+				seenByFindings,
+				findingsEncounterWithConsultationId(CONSULTATION_ID)));
+		setPrivateField(tx, "coreModelService", stubModelServiceReturningEncounter(
+				seenByModel, expected));
+
+		Object result = assertEncounterMethod().invoke(tx, chargeItemWithContext(FHIR_ENCOUNTER_ID));
+
+		assertEquals("findingsService.findById must receive the FHIR encounter id",
+				FHIR_ENCOUNTER_ID, seenByFindings.get());
+		assertEquals("modelService.load must receive the consultationId from the findings-store",
+				CONSULTATION_ID, seenByModel.get());
+		assertSame("must return the IEncounter loaded via the consultationId",
+				expected, result);
+	}
+
+	/**
+	 * If the findings-store does not know the FHIR encounter, the patch must
+	 * surface a {@link IFhirTransformerException} rather than silently
+	 * succeeding with a null encounter — the latter is exactly the bug that
+	 * caused billings to disappear before the fix.
+	 */
+	@Test
+	public void assertEncounter_throwsWhenFindingsLookupReturnsEmpty() throws Exception {
+		ChargeItemIBilledTransformer tx = new ChargeItemIBilledTransformer();
+
+		setPrivateField(tx, "findingsService", stubFindingsServiceReturning(
+				new AtomicReference<>(),
+				/* no IEncounter found */ null));
+		setPrivateField(tx, "coreModelService", stubModelServiceReturningEncounter(
+				new AtomicReference<>(), /* never called */ null));
+
+		try {
+			assertEncounterMethod().invoke(tx, chargeItemWithContext(FHIR_ENCOUNTER_ID));
+			fail("expected IFhirTransformerException when findings-store has no entry");
+		} catch (java.lang.reflect.InvocationTargetException ite) {
+			Throwable cause = ite.getCause();
+			if (!(cause instanceof IFhirTransformerException)) {
+				throw new AssertionError("expected IFhirTransformerException, got " + cause, cause);
+			}
+		}
+	}
+
+	/**
+	 * A {@link ChargeItem} without a context reference is a structural error
+	 * and must fail fast.
+	 */
+	@Test
+	public void assertEncounter_throwsWhenContextIsMissing() throws Exception {
+		ChargeItemIBilledTransformer tx = new ChargeItemIBilledTransformer();
+		setPrivateField(tx, "findingsService", stubFindingsServiceReturning(
+				new AtomicReference<>(), null));
+		setPrivateField(tx, "coreModelService", stubModelServiceReturningEncounter(
+				new AtomicReference<>(), null));
+
+		ChargeItem ci = new ChargeItem(); // no .context set
+		ci.setContext(new Reference()); // empty Reference
+
+		try {
+			assertEncounterMethod().invoke(tx, ci);
+			fail("expected IFhirTransformerException for missing context");
+		} catch (java.lang.reflect.InvocationTargetException ite) {
+			if (!(ite.getCause() instanceof IFhirTransformerException)) {
+				throw new AssertionError("expected IFhirTransformerException, got " + ite.getCause(),
+						ite.getCause());
+			}
+		}
+	}
+}

--- a/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformerTest.java
+++ b/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformerTest.java
@@ -1,0 +1,73 @@
+package ch.elexis.core.findings.util.fhir.transformer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the static
+ * {@link ConditionIConditionTransformer#mapCodingSystemToReferredClass(String)}
+ * helper that converts FHIR Coding.system URIs to the
+ * {@code diagnosen.KLASSE} string used by the Elexis client.
+ *
+ * <p>
+ * This is a pure-POJO test that does not require an OSGi runtime or
+ * database, so it runs cleanly from {@code mvn test} or the Eclipse JUnit
+ * runner without further setup. The mapping has to stay in lock-step with
+ * the one in {@link ClaimVerrechnetTransformer}; if either drifts, billing
+ * (Claim) and diagnosis (Condition) round-trips will use different
+ * KLASSE values for the same code system, which would silently break
+ * client-side filtering.
+ * </p>
+ */
+public class ConditionIConditionTransformerTest {
+
+	@Test
+	public void icdDeMapsToICD10() {
+		// CodingSystem.ICD_DE_CODESYSTEM is the German ICD-10 URI used by
+		// the Elexis-DE FHIR profile.
+		assertEquals("ch.elexis.data.ICD10", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://hl7.org/fhir/sid/icd-10-de"));
+	}
+
+	@Test
+	public void icdGenericMapsToICD10() {
+		// HAPI-default ICD-10 URI without the German "-de" suffix - used
+		// by most off-the-shelf FHIR clients. Without explicit handling
+		// this would silently fall through to FreeTextDiagnose.
+		assertEquals("ch.elexis.data.ICD10", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://hl7.org/fhir/sid/icd-10"));
+	}
+
+	@Test
+	public void tessinerCodeMapsToTICode() {
+		// CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE - swiss "Tessiner Code"
+		// for TARDOC-internal diagnosis groupings.
+		assertEquals("ch.elexis.data.TICode", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("www.elexis.info/diagnose/tessinercode"));
+	}
+
+	@Test
+	public void unknownSystemFallsBackToFreeText() {
+		// Any other / unknown URI is treated as a free-text diagnosis so
+		// no data is lost; matches the ClaimVerrechnetTransformer
+		// behaviour.
+		assertEquals("ch.elexis.data.FreeTextDiagnose", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://snomed.info/sct"));
+	}
+
+	@Test
+	public void nullSystemFallsBackToFreeText() {
+		// A Coding without an explicit system must not throw a
+		// NullPointerException - defensive callers may strip the system
+		// before invoking the transformer.
+		assertEquals("ch.elexis.data.FreeTextDiagnose",
+				ConditionIConditionTransformer.mapCodingSystemToReferredClass(null));
+	}
+
+	@Test
+	public void emptySystemFallsBackToFreeText() {
+		assertEquals("ch.elexis.data.FreeTextDiagnose",
+				ConditionIConditionTransformer.mapCodingSystemToReferredClass(""));
+	}
+}


### PR DESCRIPTION
# FHIR write-path: persist Encounter.account, ChargeItem.context, Condition.encounter and the TARDOC/ICD-10 code systems

Branch: `fix/fhir-condition-chargeitem-roundtrip` (against `3.12`)
Patch file: `dev/elexis-server-patched/medelexis-pr.patch` (5 commits)

## TL;DR

Four small, independent fixes in `ch.elexis.core.findings.util` that make
the FHIR write path actually persist the data clients send for everyday
billing:

1. **`Encounter.account` round-trip** — clients can now post an Encounter
   with `account=[{reference:"Coverage/<fall>"}]` and the Encounter is
   linked to the chosen Elexis Fall (`behandlungen.FallID`). Round-trip
   on GET is symmetric. Previously every Encounter was force-attached to
   the auto-created "online" default Fall, regardless of what the client
   sent.
2. **`ChargeItem.context` → `IBilled.encounter`** — POSTing a ChargeItem
   with `context.reference=Encounter/<id>` now writes the billing item
   into `leistungen` with the correct `BEHANDLUNG` link. Before the fix,
   the transformer tried to `IModelService.load(<fhir-encounter-id>)`
   directly, which silently returned empty (id-spaces differ between the
   findings-store and the core Behandlung entity), and the ChargeItem
   was dropped without an error visible to the client.
3. **TARDOC + ICD-10 code systems in `ClaimVerrechnetTransformer`** —
   the Claim resource is no longer limited to Tarmed/CHOP and now also
   correctly renders TARDOC and ICD-10 codings from the local model.
4. **`Condition.encounter` → `behdl_dg_joint` diagnosis junction** — a
   POSTed Condition with an encounter reference now also produces a row
   in the desktop-client diagnosis junction (`diagnosen` + `behdl_dg_joint`),
   instead of only landing in the Findings JSON blob nobody else reads.
   The mapping reuses the same Coding-system table that
   `ClaimVerrechnetTransformer` already uses (ICD10/TICode/FreeText),
   so Condition and Claim diagnoses are now consistent.

All four are needed to drive a Swiss outpatient consultation end-to-end
through the FHIR API. They are otherwise independent and can be reviewed
commit-by-commit.

## Why this matters

These are not theoretical issues; they break the write path that a
practice-management front-end has to use:

* A consultation that is not attached to the correct insurance case
  (Fall) cannot be billed against the right cost carrier. Patients with
  more than one Fall (KVG / UVG / IV) end up with billings on the wrong
  invoice.
* A ChargeItem POST that returns HTTP 201 but never lands in
  `leistungen` is the worst kind of silent failure — the client thinks
  the consultation is billed, but TARMED/TARDOC totals are zero.
* TARDOC went into productive billing in CH on 2026-01-01; the FHIR
  transformer needs to be able to emit those codes.

## Reproduction (before the patch)

Against an unpatched 3.12 container with the test fixtures shipped in
`/tmp/{cov_new,encounter_post,charge_post_tardoc}.json`:

```bash
# 1.  POST Coverage      -> ok, faelle row exists
# 2.  POST Encounter with account=Coverage/<id>
#                          -> HTTP 201, but behandlungen.FallID is some
#                             other ("default online") Fall, not the one
#                             the client just created.
# 3.  POST ChargeItem with context=Encounter/<encId>
#                          -> HTTP 500 NullPointerException in
#                             AbstractFhirCrudResourceProvider.getTransformer()
#                          -> nothing in leistungen.
```

## The fixes

### 1. `Encounter.account` ↔ `IEncounter.coverage` (+ status round-trip)

Commit: `d234973  fix(fhir): map Encounter.account <-> IEncounter.coverage and status`

* Added `EncounterAccessor.getCoverageId(...)` / `setCoverageId(...)`
  reading and writing `Encounter.account[*]` (first Coverage reference
  wins, other reference types are ignored, null/empty clears the slot).
* Added `EncounterAccessor.getBillable(...)` / `setStatus(boolean billable)`
  mapping `Encounter.status` (`in-progress` ↔ billable, `finished` ↔
  closed) so clients can also reopen / close a consultation through PUT.
* `IEncounterEncounterAttributeMapper` now wires these accessors
  bidirectionally on create / read.

### 2. `ChargeItem.context` → `IBilled.encounter`

Commit: `3d64523  fix(fhir): persist ChargeItem.context as IBilled.encounter link`

Source patch is one new `@Reference IFindingsService findingsService;`
in `ChargeItemIBilledTransformer`, plus a two-step lookup in
`assertEncounter()`:

```java
Optional<ch.elexis.core.findings.IEncounter> finding =
    findingsService.findById(encounterId, ch.elexis.core.findings.IEncounter.class);
IEncounter encounter = finding
    .flatMap(f -> coreModelService.load(f.getConsultationId(), IEncounter.class))
    .orElse(null);
```

That mirrors what `ClaimVerrechnetTransformer` already does. The same
ChargeItem POST that previously crashed now writes `leistungen` rows
with the correct `BEHANDLUNG` FK.

The DS XML for the component has been kept in sync (added the new
`findingsService` reference) so the bytecode and `OSGI-INF/*.xml` agree
on the contract.

### 3. TARDOC system and ICD-10 in `ClaimVerrechnetTransformer`

Commit: `359c23a  fix(fhir): support TARDOC system and ICD-10 in ClaimVerrechnetTransformer`

* Added the `TardocLeistung` / `ch.elexis.data.TardocLeistung` mapping
  to the local-code-system switch so TARDOC entries are emitted with the
  CH TARDOC system URI.
* Added the ICD-10 system to the supported diagnosis code systems.
* No behaviour change for Tarmed / CHOP.

### 4. `Condition.encounter` → `behdl_dg_joint` diagnosis junction

Commit: `8c084b6  fix(fhir): bridge Condition.encounter to behdl_dg_joint diagnosis junction`

`ConditionIConditionTransformer.createLocalObject(...)` previously only
wrote a JSON blob into `ch_elexis_core_findings_condition`. That blob is
invisible to the desktop client, TARDOC billing, history view and
statistics, because all of those read from the `diagnosen` master joined
through `behdl_dg_joint`.

This patch keeps the Findings shadow store as the canonical FHIR
roundtrip store (so `GET /Condition/{id}` keeps returning the same JSON
clients posted), and **additionally** bridges into the client world
through the same pattern that `ClaimVerrechnetTransformer` already uses:

```java
private void persistAsClientDiagnosis(Condition fhirObject) {
    // 1. Resolve FHIR encounter -> findings_encounter -> behandlungen
    //    (identical to ChargeItemIBilledTransformer.assertEncounter)
    Optional<IEncounter> cons = findingsService
        .findById(fhirEncounterId, ch.elexis.core.findings.IEncounter.class)
        .flatMap(f -> modelService.load(f.getConsultationId(),
                                        ch.elexis.core.model.IEncounter.class));
    if (!cons.isPresent()) return;

    // 2. For each Coding: create IDiagnosisReference with the right
    //    ReferredClass (ICD10 / TICode / FreeTextDiagnose), link via
    //    IEncounter.addDiagnosis(), let JPA persist the junction row.
    for (Coding coding : fhirObject.getCode().getCoding()) {
        IDiagnosisReference diag = modelService.create(IDiagnosisReference.class);
        diag.setCode(coding.getCode());
        diag.setText(...);
        diag.setReferredClass(mapCodingSystemToReferredClass(coding.getSystem()));
        safeSave(diag);
        cons.get().addDiagnosis(diag);
    }
    safeSave(cons.get());
}
```

`mapCodingSystemToReferredClass(...)` accepts both
`http://hl7.org/fhir/sid/icd-10-de` and the HAPI-default
`http://hl7.org/fhir/sid/icd-10` (otherwise off-the-shelf FHIR clients
silently fall through to `FreeTextDiagnose`).

`safeSave(...)` swallows the `UnsupportedOperationException` thrown by
`ContextService.postEvent` on the headless server — the JPA row is
already committed at that point, only the (unimplemented) event-bus
notification fails, and we don't want that to surface as HTTP 500 to
the FHIR client.

The matching architecture analysis lives in
[`condition-findings-vs-diagnosen-analyse.md`](condition-findings-vs-diagnosen-analyse.md).

## Tests

Three pure-POJO JUnit tests are added in
`tests/ch.elexis.core.findings.util.test`:

* `EncounterAccessorTest` — 7 tests, all green locally (`junit 4.13.1`,
  pure POJO, no OSGi).
* `ChargeItemIBilledTransformerTest` — 3 tests pinning the two-step
  lookup and the fail-fast error paths. Uses `java.lang.reflect.Proxy`
  for stubs to avoid pulling Mockito into the target platform.
* `ConditionIConditionTransformerTest` — 6 tests pinning the
  `mapCodingSystemToReferredClass` table (ICD-10 / -de / Tessiner /
  unknown / null / empty) so it stays in lock-step with
  `ClaimVerrechnetTransformer`.

On top of that, `dev/elexis-server-test/e2e_pr_scope.sh` performs a
full HTTP-level end-to-end check against a running container and
asserts the corresponding rows in `faelle`, `behandlungen` and
`leistungen` via direct MySQL queries. Sample output of a green run against `elexis-server:3.12-pr-scope`:

```
✅  Coverage created                    : HTTP 201
✅  Encounter created                   : HTTP 201
    Behandlung: <beh-id>   FallID: '<cov-id>'
✅  behandlungen.FallID == Coverage id
    GET /Encounter/<id> -> account=Coverage/<cov-id>
✅  account round-trip OK
✅  ChargeItem created                  : HTTP 201
    leistungen for <beh-id> -> 1  ch.elexis.data.TardocLeistung/MK.00.0010-20260101
✅  ChargeItem.context persisted (leistungen.BEHANDLUNG==Behandlung)
✅  Condition created                   : HTTP 201
    behdl_dg_joint for <beh-id> -> 1
    DiagnoseID  ch.elexis.data.ICD10  J06.9  Akute Infektion der oberen Atemwege
✅  Condition.encounter persisted as junction row (client-visible diagnosis)
🟢  All in-scope PR steps green.
```

## Build & deploy details

* Built with the existing Tycho-pomless setup, no new dependencies, no
  POM changes:
  ```bash
  mvn -pl bundles/ch.elexis.core.findings.util -am -DskipTests \
      -DforceContextQualifier=20260521-1053 -Dtycho.localArtifacts=ignore \
      clean package
  ```
  Resulting jar:
  `bundles/ch.elexis.core.findings.util/target/ch.elexis.core.findings.util-3.12.0.20260521-1053.jar`
* Deployed in the test container via `dev/elexis-server-patched/Dockerfile.pr-scope`
  on top of the existing `elexis-server:3.12-pr-verified` image. The
  Dockerfile keeps the `bundles.info` qualifier in sync and clears the
  OSGi bundle cache to force a fresh load.

## Out of scope (explicitly not in this PR)

One issue from the original survey is intentionally not addressed here
and documented for a later round.

### `Encounter.note` → `Behandlung.Eintrag` (samdas)

The `Eintrag` blob in `behandlungen` is a samdas-encoded versioned
resource. A read-side decoder exists (`medelexis/samdas.py`,
`medelexis/versioned_resource.py`) but the server-side bundle has no
write-side samdas encoder. A real `Encounter.note` write path needs
that encoder first; punted for now.

## Reviewer checklist suggestion

- [ ] `git apply --check dev/elexis-server-patched/medelexis-pr.patch`
      against current `3.12` HEAD
- [ ] `mvn -pl bundles/ch.elexis.core.findings.util -am -DskipTests verify`
- [ ] `mvn -pl tests/ch.elexis.core.findings.util.test -am -DskipTests verify`
- [ ] Run `dev/elexis-server-test/e2e_pr_scope.sh` against a freshly
      built `elexis-server:3.12-pr-scope` (Dockerfile shipped)

---

Drafted 2026-05-26 in
[`docs/server-survey/PATCH-SESSION-2026-05-26-STATUS.md`](PATCH-SESSION-2026-05-26-STATUS.md);
final E2E run logged at the top of this file.
