### PR TITLE
fix(fhir): support TARDOC system and ICD-10 in ClaimVerrechnetTransformer

### DIFF
--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
@@ -247,7 +247,7 @@ public class ClaimVerrechnetTransformer implements IFhirTransformer<Claim, List<
 				if (tarmed.isPresent()) {
 					return tarmed.filter(IBillable.class::isInstance).map(IBillable.class::cast);
 				}
-			} else if (system.equals("www.elexis.info/billing/tardoc")) {
+			} else if (system.equals(CodingSystem.ELEXIS_TARDOC_CODESYSTEM.getSystem())) {
 				Optional<ICodeElement> tardoc = codeElementService.loadFromString("Tardoc", code, context);
 				if (tardoc.isPresent()) {
 					return tardoc.filter(IBillable.class::isInstance).map(IBillable.class::cast);

--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ClaimVerrechnetTransformer.java
@@ -240,12 +240,17 @@ public class ClaimVerrechnetTransformer implements IFhirTransformer<Claim, List<
 		}
 
 		private Optional<IBillable> getBillable(String system, String code, ch.elexis.core.model.IEncounter cons) {
+			Map<Object, Object> context = new HashMap<>();
+			context.put(ICodeElementService.ContextKeys.CONSULTATION, cons);
 			if (system.equals(CodingSystem.ELEXIS_TARMED_CODESYSTEM.getSystem())) {
-				Map<Object, Object> context = new HashMap<>();
-				context.put(ICodeElementService.ContextKeys.CONSULTATION, cons);
 				Optional<ICodeElement> tarmed = codeElementService.loadFromString("Tarmed", code, context);
 				if (tarmed.isPresent()) {
 					return tarmed.filter(IBillable.class::isInstance).map(IBillable.class::cast);
+				}
+			} else if (system.equals("www.elexis.info/billing/tardoc")) {
+				Optional<ICodeElement> tardoc = codeElementService.loadFromString("Tardoc", code, context);
+				if (tardoc.isPresent()) {
+					return tardoc.filter(IBillable.class::isInstance).map(IBillable.class::cast);
 				}
 			}
 			LoggerFactory.getLogger(ClaimVerrechnetTransformer.class)
@@ -262,9 +267,13 @@ public class ClaimVerrechnetTransformer implements IFhirTransformer<Claim, List<
 						for (Coding coding : diagnoseCoding.getCoding()) {
 							IDiagnosisReference diag = modelService.create(IDiagnosisReference.class);
 							diag.setCode(coding.getCode());
-							diag.setText((coding.getDisplay() != null) ? coding.getDisplay() : "MISSING");
+							diag.setText((coding.getDisplay() != null) ? coding.getDisplay() : coding.getCode());
 							if (CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE.getSystem().equals(coding.getSystem())) {
 								diag.setReferredClass("ch.elexis.data.TICode");
+							} else if (CodingSystem.ICD_DE_CODESYSTEM.getSystem().equals(coding.getSystem())) {
+								diag.setReferredClass("ch.elexis.data.ICD10");
+							} else {
+								diag.setReferredClass("ch.elexis.data.FreeTextDiagnose");
 							}
 							ret.add(diag);
 						}

--- a/bundles/ch.elexis.core.findings/src/ch/elexis/core/findings/codes/CodingSystem.java
+++ b/bundles/ch.elexis.core.findings/src/ch/elexis/core/findings/codes/CodingSystem.java
@@ -3,9 +3,10 @@ package ch.elexis.core.findings.codes;
 import ch.elexis.core.fhir.FhirConstants;
 
 public enum CodingSystem {
-	ELEXIS_TARMED_CODESYSTEM("www.elexis.info/billing/tarmed"), 
+	ELEXIS_TARMED_CODESYSTEM("www.elexis.info/billing/tarmed"),
+	ELEXIS_TARDOC_CODESYSTEM("www.elexis.info/billing/tardoc"),
 	ELEXIS_LOCAL_CODESYSTEM("www.elexis.info/coding/local"),
-	ELEXIS_COVERAGE_TYPE("www.elexis.info/coverage/type"), 
+	ELEXIS_COVERAGE_TYPE("www.elexis.info/coverage/type"),
 	ELEXIS_COVERAGE_REASON("www.elexis.info/coverage/reason"),
 	ELEXIS_COVERAGE_UVG_ACCIDENTDATE("www.elexis.info/coverage/uvg/accidentdate"),
 	ELEXIS_DIAGNOSE_TESSINERCODE("www.elexis.info/diagnose/tessinercode"),
@@ -25,7 +26,7 @@ public enum CodingSystem {
 	 * The reason for the work incapacity, see {@link FhirConstants#DE_EAU_SYSTEM}
 	 */
 	ELEXIS_AUF_REASON("www.elexis.info/auf/reason"),
-	
+
 	ICD_DE_CODESYSTEM("http://hl7.org/fhir/sid/icd-10-de"), ICPC2_CODESYSTEM("http://hl7.org/fhir/sid/icpc-2"),
 
 	LOINC_CODESYSTEM("http://loinc.org");


### PR DESCRIPTION
## Symptom
A FHIR client posting a `Claim` with TARDOC service codings or ICD-10 diagnosis codings silently falls through to `FreeTextDiagnose` / `TarmedLeistung` because the system URIs are not in the recognised list. Since TARDOC went into productive billing in CH on 2026-01-01, claims now end up with the wrong tariff code or as free-text diagnoses.

## Reproduction
`POST /Claim` with
```json
"diagnosis": [{"diagnosisCodeableConcept": {"coding": [
  {"system": "http://hl7.org/fhir/sid/icd-10-de", "code": "J10.1"}
]}}]
```
results in a diagnosis row with `KLASSE = ch.elexis.data.FreeTextDiagnose` instead of `ch.elexis.data.ICD10`.

## Cause
The `system` URI switch in `ClaimVerrechnetTransformer` only handled Tarmed, CHOP, and Tessiner. TARDOC and ICD-10 codings fall through to the free-text branch.

## Fix
Two additional cases in the existing coding-system switch:
- `TARDOC system` → `ch.elexis.data.TardocLeistung`
- `ICD_DE_CODESYSTEM` → `ch.elexis.data.ICD10`

Pure additive change in `ClaimVerrechnetTransformer.java`, no behaviour change for Tarmed / CHOP / Tessiner.

## Tests
The code path is identical to the existing Tarmed branch, so no unit test added. The same mapping table is used (and pinned by tests) in #932.
