### PR TITLE
fix(fhir): bridge Condition.encounter to behdl_dg_joint diagnosis junction

### DIFF
--- a/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformer.java
+++ b/bundles/ch.elexis.core.findings.util/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformer.java
@@ -5,19 +5,26 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SummaryEnum;
 import ch.elexis.core.findings.ICondition;
 import ch.elexis.core.findings.IFindingsService;
+import ch.elexis.core.findings.codes.CodingSystem;
 import ch.elexis.core.findings.util.ModelUtil;
 import ch.elexis.core.findings.util.fhir.IFhirTransformer;
 import ch.elexis.core.findings.util.fhir.accessor.ConditionAccessor;
+import ch.elexis.core.findings.util.fhir.transformer.helper.AbstractHelper;
 import ch.elexis.core.findings.util.fhir.transformer.helper.FhirUtil;
 import ch.elexis.core.findings.util.fhir.transformer.helper.FindingsContentHelper;
+import ch.elexis.core.lock.types.LockResponse;
+import ch.elexis.core.model.IDiagnosisReference;
 import ch.elexis.core.model.IPatient;
 import ch.elexis.core.services.IModelService;
 import jakarta.enterprise.context.Dependent;
@@ -88,7 +95,118 @@ public class ConditionIConditionTransformer implements IFhirTransformer<Conditio
 			patient.ifPresent(k -> iCondition.setPatientId(id));
 		}
 		findingsService.saveFinding(iCondition);
+
+		// Additionally bridge into the Elexis client world if an Encounter context
+		// is referenced: the FHIR `Condition.encounter` is interpreted as a write
+		// anchor that should produce a row in the `behdl_dg_joint` junction table
+		// so that the desktop client, TARDOC billing, history view etc. actually
+		// see this diagnosis. The mapping mirrors the established pattern used by
+		// ClaimVerrechnetTransformer for `Claim.diagnosis[]`.
+		persistAsClientDiagnosis(fhirObject);
+
 		return Optional.of(iCondition);
+	}
+
+	/**
+	 * Bridge a FHIR Condition into the Elexis client diagnosis world
+	 * (`diagnosen` master + `behdl_dg_joint` junction).
+	 *
+	 * <p>
+	 * The Findings world (`ch_elexis_core_findings_condition`) is kept as the
+	 * canonical store for the FHIR roundtrip; this method only adds the
+	 * additional junction link expected by the desktop client. If any of the
+	 * required inputs (encounter reference, coding) is missing, the method is a
+	 * no-op so that other Condition use-cases (problem list, family history,
+	 * etc.) remain unaffected.
+	 * </p>
+	 */
+	private void persistAsClientDiagnosis(Condition fhirObject) {
+		if (fhirObject == null || !fhirObject.hasEncounter() || !fhirObject.hasCode()) {
+			return;
+		}
+		String fhirEncounterId = fhirObject.getEncounter().getReferenceElement().getIdPart();
+		if (StringUtils.isBlank(fhirEncounterId)) {
+			return;
+		}
+		// Two-step lookup identical to ChargeItemIBilledTransformer.assertEncounter:
+		//   FHIR-Encounter id -> ch_elexis_core_findings_encounter.CONSULTATIONID -> behandlungen.ID
+		Optional<ch.elexis.core.findings.IEncounter> findingsEncounter = findingsService.findById(fhirEncounterId,
+				ch.elexis.core.findings.IEncounter.class);
+		Optional<ch.elexis.core.model.IEncounter> consultation = findingsEncounter
+				.flatMap(f -> modelService.load(f.getConsultationId(), ch.elexis.core.model.IEncounter.class));
+		if (!consultation.isPresent()) {
+			LoggerFactory.getLogger(ConditionIConditionTransformer.class).warn(
+					"Condition.encounter='{}' could not be resolved to an Elexis Behandlung; skipping junction write.",
+					fhirEncounterId);
+			return;
+		}
+
+		if (!fhirObject.getCode().hasCoding() || fhirObject.getCode().getCoding().isEmpty()) {
+			return;
+		}
+
+		Logger log = LoggerFactory.getLogger(ConditionIConditionTransformer.class);
+		ch.elexis.core.model.IEncounter cons = consultation.get();
+		LockResponse lockResponse = AbstractHelper.acquireLock(cons);
+		try {
+			for (Coding coding : fhirObject.getCode().getCoding()) {
+				if (coding == null || StringUtils.isBlank(coding.getCode())) {
+					continue;
+				}
+				IDiagnosisReference diag = modelService.create(IDiagnosisReference.class);
+				diag.setCode(coding.getCode());
+				diag.setText(StringUtils.isNotBlank(coding.getDisplay()) ? coding.getDisplay() : coding.getCode());
+				diag.setReferredClass(mapCodingSystemToReferredClass(coding.getSystem()));
+				// Saving the diagnosis reference + the encounter triggers
+				// AbstractModelService.save -> ContextService.postEvent, which is not
+				// implemented on the headless server (UnsupportedOperationException).
+				// The JPA write itself succeeds (junction row is committed); swallow
+				// the post-save event failure so the HTTP request still returns 201.
+				safeSave(diag, log);
+				cons.addDiagnosis(diag);
+				log.debug("Linked Condition coding system='{}' code='{}' to Behandlung '{}'.",
+						coding.getSystem(), coding.getCode(), cons.getId());
+			}
+			safeSave(cons, log);
+		} finally {
+			if (lockResponse != null && lockResponse.isOk()) {
+				AbstractHelper.releaseLock(lockResponse.getLockInfo());
+			}
+		}
+	}
+
+	/**
+	 * Wrap modelService.save() so that the headless server's missing event-bus
+	 * (ContextService.postEvent throws UnsupportedOperationException) does not
+	 * surface as an HTTP 500 to the FHIR client. The actual JPA write has
+	 * already happened at that point and the row is persisted.
+	 */
+	private void safeSave(Object entity, Logger log) {
+		try {
+			modelService.save((ch.elexis.core.model.Identifiable) entity);
+		} catch (UnsupportedOperationException uoe) {
+			log.debug("modelService.save post-event raised UnsupportedOperationException; "
+					+ "persistence row is already committed, ignoring. entity={}", entity, uoe);
+		}
+	}
+
+	/**
+	 * Map a FHIR Coding.system URI to the Elexis `ReferredClass` value used in
+	 * the `diagnosen.KLASSE` column. Identical to the resolution used by
+	 * ClaimVerrechnetTransformer; additionally accepts the HAPI-default
+	 * "http://hl7.org/fhir/sid/icd-10" URI (without the German `-de` suffix) so
+	 * that off-the-shelf FHIR clients also produce ICD-10 mappings instead of
+	 * silently falling through to FreeTextDiagnose.
+	 */
+	static String mapCodingSystemToReferredClass(String system) {
+		if (system != null && CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE.getSystem().equals(system)) {
+			return "ch.elexis.data.TICode"; //$NON-NLS-1$
+		}
+		if (system != null && (CodingSystem.ICD_DE_CODESYSTEM.getSystem().equals(system)
+				|| "http://hl7.org/fhir/sid/icd-10".equals(system))) { //$NON-NLS-1$
+			return "ch.elexis.data.ICD10"; //$NON-NLS-1$
+		}
+		return "ch.elexis.data.FreeTextDiagnose"; //$NON-NLS-1$
 	}
 
 	@Override

--- a/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformerTest.java
+++ b/tests/ch.elexis.core.findings.util.test/src/ch/elexis/core/findings/util/fhir/transformer/ConditionIConditionTransformerTest.java
@@ -1,0 +1,73 @@
+package ch.elexis.core.findings.util.fhir.transformer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the static
+ * {@link ConditionIConditionTransformer#mapCodingSystemToReferredClass(String)}
+ * helper that converts FHIR Coding.system URIs to the
+ * {@code diagnosen.KLASSE} string used by the Elexis client.
+ *
+ * <p>
+ * This is a pure-POJO test that does not require an OSGi runtime or
+ * database, so it runs cleanly from {@code mvn test} or the Eclipse JUnit
+ * runner without further setup. The mapping has to stay in lock-step with
+ * the one in {@link ClaimVerrechnetTransformer}; if either drifts, billing
+ * (Claim) and diagnosis (Condition) round-trips will use different
+ * KLASSE values for the same code system, which would silently break
+ * client-side filtering.
+ * </p>
+ */
+public class ConditionIConditionTransformerTest {
+
+	@Test
+	public void icdDeMapsToICD10() {
+		// CodingSystem.ICD_DE_CODESYSTEM is the German ICD-10 URI used by
+		// the Elexis-DE FHIR profile.
+		assertEquals("ch.elexis.data.ICD10", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://hl7.org/fhir/sid/icd-10-de"));
+	}
+
+	@Test
+	public void icdGenericMapsToICD10() {
+		// HAPI-default ICD-10 URI without the German "-de" suffix - used
+		// by most off-the-shelf FHIR clients. Without explicit handling
+		// this would silently fall through to FreeTextDiagnose.
+		assertEquals("ch.elexis.data.ICD10", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://hl7.org/fhir/sid/icd-10"));
+	}
+
+	@Test
+	public void tessinerCodeMapsToTICode() {
+		// CodingSystem.ELEXIS_DIAGNOSE_TESSINERCODE - swiss "Tessiner Code"
+		// for TARDOC-internal diagnosis groupings.
+		assertEquals("ch.elexis.data.TICode", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("www.elexis.info/diagnose/tessinercode"));
+	}
+
+	@Test
+	public void unknownSystemFallsBackToFreeText() {
+		// Any other / unknown URI is treated as a free-text diagnosis so
+		// no data is lost; matches the ClaimVerrechnetTransformer
+		// behaviour.
+		assertEquals("ch.elexis.data.FreeTextDiagnose", ConditionIConditionTransformer
+				.mapCodingSystemToReferredClass("http://snomed.info/sct"));
+	}
+
+	@Test
+	public void nullSystemFallsBackToFreeText() {
+		// A Coding without an explicit system must not throw a
+		// NullPointerException - defensive callers may strip the system
+		// before invoking the transformer.
+		assertEquals("ch.elexis.data.FreeTextDiagnose",
+				ConditionIConditionTransformer.mapCodingSystemToReferredClass(null));
+	}
+
+	@Test
+	public void emptySystemFallsBackToFreeText() {
+		assertEquals("ch.elexis.data.FreeTextDiagnose",
+				ConditionIConditionTransformer.mapCodingSystemToReferredClass(""));
+	}
+}


### PR DESCRIPTION
## Symptom
`POST /Condition` with `encounter = "Encounter/<id>"` and `code.coding[]` (e.g. ICD-10 J10.1) returns HTTP 201 and is retrievable via `GET /Condition/{id}`. But in the desktop client the diagnosis is **not visible in the "Behandlungsdiagnosen" list** of the corresponding consultation, and it is **not picked up by TARDOC coding / statistics / printouts**.

Net effect: a FHIR-API-driven workflow can record diagnoses that are invisible to every UI that bills, reads, or reports on them.

## Reproduction
With `dev/elexis-server-test/e2e_pr_scope.sh` (committed in #931) — step 4:
1. `POST /Coverage`, `POST /Encounter` → `<encId>`
2. `POST /Condition` with `encounter=Encounter/<encId>` + `code.coding[0].system=http://hl7.org/fhir/sid/icd-10` + `code=J10.1`
3. `SELECT COUNT(*) FROM behdl_dg_joint WHERE BehandlungsID=<beh-id>` → **0** on unpatched server.

## Cause
The Elexis server keeps diagnoses in **two unrelated stores**:

| World | Table | Read by |
|---|---|---|
| Findings shadow store | `ch_elexis_core_findings_condition` (JSON blob) | `IFindingsService` consumers only |
| Client diagnosis world | `diagnosen` master + `behdl_dg_joint` junction | desktop UI, TARDOC coding, history, statistics |

`ConditionIConditionTransformer.createLocalObject(...)` writes only into the findings shadow store. The junction is never touched.

## Fix
Additive bridge using the established pattern from `ClaimVerrechnetTransformer`:

1. Resolve the FHIR encounter id through the same two-step lookup as in `ChargeItemIBilledTransformer` (`findings_encounter.CONSULTATIONID → behandlungen.ID`).
2. For each `Coding`, create an `IDiagnosisReference` with the right `ReferredClass` (`ICD10` / `TICode` / `FreeTextDiagnose`) — identical mapping table to the one used by `ClaimVerrechnetTransformer`, so Claim and Condition diagnoses stay consistent.
3. Call `IEncounter.addDiagnosis(diag)` and `modelService.save(cons)`; JPA writes the `behdl_dg_joint` row via the existing `@JoinTable(name="behdl_dg_joint")` mapping on `Behandlung.diagnoses`.

The findings shadow store (`ch_elexis_core_findings_condition`) is **kept unchanged** as the canonical FHIR-roundtrip store, so `GET /Condition/{id}` keeps returning the exact JSON the client posted. The junction is an additive sibling, not a replacement.

Two small wrinkles handled:
- `mapCodingSystemToReferredClass(...)` also accepts the HAPI-default `http://hl7.org/fhir/sid/icd-10` URI on top of the German `-de` variant — otherwise off-the-shelf FHIR clients silently fall through to `FreeTextDiagnose`.
- `safeSave(...)` swallows the `UnsupportedOperationException` thrown by the headless server's `ContextService.postEvent`. The JPA write has already committed at that point; only the (unimplemented) event-bus notification fails, and we don't want that to surface as HTTP 500.

## Tests
- `ConditionIConditionTransformerTest` — 6 pure-POJO JUnit tests pinning the `mapCodingSystemToReferredClass` table (ICD-10 / -de / Tessiner / unknown / null / empty), so it stays in lock-step with `ClaimVerrechnetTransformer`.
- End-to-end coverage in `dev/elexis-server-test/e2e_pr_scope.sh` (#931), step 4 asserts a real `behdl_dg_joint` row with `KLASSE=ch.elexis.data.ICD10`, `DG_CODE=J06.9`.

## Open design question for reviewers
The findings store now plays the role of "canonical FHIR roundtrip storage", the junction is an additive client-visibility bridge. If the original architectural intent was for FHIR diagnoses to flow through a different surface (e.g. `ClaimResponse.diagnosis[]` only, with `Condition` strictly reserved for problem lists), happy to rework — please let me know.
