### PR TITLE
Reduce reminder query load with prefetch caching

### DIFF
--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Query.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Query.java
@@ -73,7 +73,8 @@ public class Query<T> {
 	private final ArrayList<String> exttables = new ArrayList<>(2);
 
 	private final String[] ID_FETCH_VAL = new String[] { "ID" };
-	private final String[] fetchVals;
+	private final String[] selectVals;
+	private final String[] cacheVals;
 
 	/**
 	 * @param cl the class to apply the query on
@@ -145,21 +146,26 @@ public class Query<T> {
 				// resolve the delivered field names to the real database columns
 				// consider the resp. datatypes stored
 				List<String> mappedPrefetchValues = new ArrayList<>(Arrays.asList(ID_FETCH_VAL));
+				List<String> cachePrefetchValues = new ArrayList<>(Arrays.asList(ID_FETCH_VAL));
 				for (int i = 0; i < prefetch.length; i++) {
 					String map = PersistentObject.map(tableName, prefetch[i]);
 					if (!map.contains(":")) {
 						mappedPrefetchValues.add(map);
+						cachePrefetchValues.add(prefetch[i]);
 					} else if (map.startsWith("S:")) {
 						mappedPrefetchValues.add(map.substring(4));
+						cachePrefetchValues.add(prefetch[i]);
 					} else {
 						throw new UnsupportedOperationException(
 								"prefetch value not supported: " + prefetch[i] + " maps to " + map);
 					}
 				}
 
-				fetchVals = mappedPrefetchValues.toArray(new String[] {});
+				selectVals = mappedPrefetchValues.toArray(new String[] {});
+				cacheVals = cachePrefetchValues.toArray(new String[] {});
 			} else {
-				fetchVals = ID_FETCH_VAL;
+				selectVals = ID_FETCH_VAL;
+				cacheVals = ID_FETCH_VAL;
 			}
 			clear(false);
 
@@ -203,7 +209,8 @@ public class Query<T> {
 			sql = new StringBuilder(500);
 			sql.append(string);
 			ordering = null;
-			fetchVals = ArrayUtils.EMPTY_STRING_ARRAY;
+			selectVals = ArrayUtils.EMPTY_STRING_ARRAY;
+			cacheVals = ArrayUtils.EMPTY_STRING_ARRAY;
 			clearEntityCache = false;
 		} catch (Exception ex) {
 			ElexisStatus status = new ElexisStatus(ElexisStatus.ERROR, CoreHub.PLUGIN_ID, ElexisStatus.CODE_NONE,
@@ -236,9 +243,9 @@ public class Query<T> {
 		String table = template.getTableName();
 
 		sql.append("SELECT ");
-		for (int i = 0; i < fetchVals.length; i++) {
-			sql.append(fetchVals[i]);
-			if (i + 1 < fetchVals.length) {
+		for (int i = 0; i < selectVals.length; i++) {
+			sql.append(selectVals[i]);
+			if (i + 1 < selectVals.length) {
 				sql.append(", ");
 			}
 		}
@@ -658,10 +665,10 @@ public class Query<T> {
 					po.clearCachedAttributes();
 				}
 
-				if (fetchVals.length > 1) {
-					for (int i = 1; i < fetchVals.length; i++) {
+				if (selectVals.length > 1) {
+					for (int i = 1; i < selectVals.length; i++) {
 						Object prefetchVal = res.getObject(i + 1);
-						po.putInCache(fetchVals[i], prefetchVal);
+						po.putInCache(cacheVals[i], prefetchVal);
 					}
 				}
 

--- a/bundles/ch.elexis.core.data/src/ch/elexis/data/Reminder.java
+++ b/bundles/ch.elexis.core.data/src/ch/elexis/data/Reminder.java
@@ -79,6 +79,10 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 	public static final Cache<String, Boolean> cachedAttributeKeys = CacheBuilder.newBuilder()
 			.expireAfterWrite(30, TimeUnit.SECONDS).build();
 
+	private static final Object patientLabelConfigCacheLock = new Object();
+	private static String cachedPatientLabelConfigUserId;
+	private static String[] cachedPatientLabelConfigFields;
+
 	/**
 	 * To be stored in {@link #FLD_RESPONSIBLE}, making this reminder a
 	 * responsibility for every user.
@@ -214,8 +218,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 	private String getConfiguredKontaktLabel(Kontakt k, boolean isPatientRelatedReminder) {
 		if (isPatientRelatedReminder) {
 			StringBuilder sb = new StringBuilder();
-			String[] configLabel = ConfigServiceHolder
-					.getUser(Preferences.USR_REMINDER_PAT_LABEL_CHOOSEN, LabelFields.LASTNAME.toString()).split(",");
+			String[] configLabel = getConfiguredPatientLabelFields();
 
 			String[] values = k.get(true, configLabel);
 			for (int i = 0; i < values.length; i++) {
@@ -228,6 +231,33 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 			return sb.toString();
 		}
 		return k.get(Kontakt.FLD_NAME3);
+	}
+
+	public static void invalidatePatientLabelConfigCache() {
+		synchronized (patientLabelConfigCacheLock) {
+			cachedPatientLabelConfigUserId = null;
+			cachedPatientLabelConfigFields = null;
+		}
+	}
+
+	private static String[] getConfiguredPatientLabelFields() {
+		Anwender loggedInContact = CoreHub.getLoggedInContact();
+		String userId = loggedInContact != null ? loggedInContact.getId() : StringUtils.EMPTY;
+
+		synchronized (patientLabelConfigCacheLock) {
+			if (Objects.equals(cachedPatientLabelConfigUserId, userId) && cachedPatientLabelConfigFields != null) {
+				return cachedPatientLabelConfigFields;
+			}
+		}
+
+		String[] configLabel = ConfigServiceHolder
+				.getUser(Preferences.USR_REMINDER_PAT_LABEL_CHOOSEN, LabelFields.LASTNAME.toString()).split(",");
+
+		synchronized (patientLabelConfigCacheLock) {
+			cachedPatientLabelConfigUserId = userId;
+			cachedPatientLabelConfigFields = configLabel;
+			return cachedPatientLabelConfigFields;
+		}
 	}
 
 	public static ProcessStatus determineCurrentStatus(ProcessStatus givenStatus, TimeTool dueDate) {
@@ -394,7 +424,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 		return !Objects.equals(creatorId, contactId);
 	}
 
-	private static String PS_REMINDERS_RESPONSIBLE = "SELECT r.ID, r.SUBJECT, r.DateDue, r.IdentID, r.OriginID FROM "
+	private static String PS_REMINDERS_RESPONSIBLE = "SELECT r.ID, r.SUBJECT, r.DateDue, r.IdentID, r.OriginID, r.Message, r.Typ, r.Status FROM "
 			+ TABLENAME
 			+ " r LEFT JOIN REMINDERS_RESPONSIBLE_LINK rrl ON (r.id = rrl.ReminderId) WHERE (rrl.ResponsibleID = ? OR r.Responsible = '"
 			+ ALL_RESPONSIBLE + "') AND r.deleted = '0'";
@@ -423,11 +453,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 				Reminder reminder = Reminder.load(res.getString(1));
 
 				// cache pre-fetch
-				reminder.putInCache("subject", res.getString(2));
-				String decode = reminder.decode(Reminder.FLD_DUE, res);
-				reminder.putInCache("Due", decode);
-				reminder.putInCache("IdentId", res.getString(4));
-				reminder.putInCache("OriginId", res.getString(5));
+				reminder.cachePrefetchedValues(res);
 
 				reminder.setDBConnection(dbConnection);
 				ret.add(reminder);
@@ -495,7 +521,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 		return qbe.execute();
 	}
 
-	private static String PS_REMINDERS_BASE = "SELECT r.ID, r.SUBJECT, r.DateDue, r.IdentID, r.OriginID FROM "
+	private static String PS_REMINDERS_BASE = "SELECT r.ID, r.SUBJECT, r.DateDue, r.IdentID, r.OriginID, r.Message, r.Typ, r.Status FROM "
 			+ TABLENAME
 			+ " r LEFT JOIN REMINDERS_RESPONSIBLE_LINK rrl ON (r.id = rrl.ReminderId) WHERE (rrl.ResponsibleID = ? OR r.Responsible = '"
 			+ ALL_RESPONSIBLE + "') AND r.deleted = '0' AND r.Status != '3'";
@@ -553,11 +579,7 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 					Reminder reminder = Reminder.load(res.getString(1));
 
 					// cache pre-fetch
-					reminder.putInCache("subject", res.getString(2));
-					String decode = reminder.decode(Reminder.FLD_DUE, res);
-					reminder.putInCache("Due", decode);
-					reminder.putInCache("IdentId", res.getString(4));
-					reminder.putInCache("OriginID", res.getString(5));
+					reminder.cachePrefetchedValues(res);
 
 					reminder.setDBConnection(dbConnection);
 					if (onlyPopup && (reminder.getVisibility() != Visibility.POPUP_ON_PATIENT_SELECTION)) {
@@ -592,6 +614,16 @@ public class Reminder extends PersistentObject implements Comparable<Reminder> {
 	 */
 	public static List<Reminder> findRemindersDueFor(final Patient p, final Anwender a, final boolean bOnlyPopup) {
 		return findOpenRemindersResponsibleFor(a, true, p, bOnlyPopup);
+	}
+
+	private void cachePrefetchedValues(ResultSet res) throws SQLException {
+		putInCache(FLD_SUBJECT, res.getString(2));
+		putInCache(FLD_DUE, decode(FLD_DUE, res));
+		putInCache(FLD_KONTAKT_ID, res.getString(4));
+		putInCache(FLD_CREATOR, res.getString(5));
+		putInCache(FLD_MESSAGE, res.getString(6));
+		putInCache(FLD_VISIBILITY, res.getString(7));
+		putInCache(FLD_STATUS, res.getString(8));
 	}
 
 	public Patient getKontakt() {

--- a/bundles/ch.elexis.core.ui.reminder/src/ch/elexis/core/ui/reminder/part/nattable/RemiderRichTextUtil.java
+++ b/bundles/ch.elexis.core.ui.reminder/src/ch/elexis/core/ui/reminder/part/nattable/RemiderRichTextUtil.java
@@ -1,5 +1,6 @@
 package ch.elexis.core.ui.reminder.part.nattable;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -20,7 +21,9 @@ public class RemiderRichTextUtil {
 
 	public static String richText(IReminder reminder, boolean addDate) {
 		StringBuilder sb = new StringBuilder();
-		if (reminder.getPriority() == Priority.HIGH) {
+		Priority priority = reminder.getPriority();
+		LocalDate due = reminder.getDue();
+		if (priority == Priority.HIGH) {
 			sb.append("<strong><span style=\"font-size: 14; color:rgb(255,0,0);\">");
 			sb.append(" !! ");
 			sb.append("</span></strong>");
@@ -39,8 +42,8 @@ public class RemiderRichTextUtil {
 			});
 		}
 		sb.append("<addition>");
-		if (addDate && reminder.getDue() != null) {
-			sb.append(DateTimeFormatter.ofPattern("dd.MM").format(reminder.getDue()));
+		if (addDate && due != null) {
+			sb.append(DateTimeFormatter.ofPattern("dd.MM").format(due));
 		}
 		sb.append("</addition>");
 		return sb.toString();
@@ -70,10 +73,13 @@ public class RemiderRichTextUtil {
 	}
 
 	private static String getSubject(IReminder reminder) {
-		if (StringUtils.isNotBlank(reminder.getSubject())) {
-			return reminder.getSubject();
-		} else if (StringUtils.isNotBlank(reminder.getMessage())) {
-			return StringUtils.abbreviate(reminder.getMessage(), 80);
+		String subject = reminder.getSubject();
+		if (StringUtils.isNotBlank(subject)) {
+			return subject;
+		}
+		String message = reminder.getMessage();
+		if (StringUtils.isNotBlank(message)) {
+			return StringUtils.abbreviate(message, 80);
 		}
 		return StringUtils.EMPTY;
 	}

--- a/bundles/ch.elexis.core.ui.reminder/src/ch/elexis/core/ui/reminder/part/nattable/ReminderBodyDataProvider.java
+++ b/bundles/ch.elexis.core.ui.reminder/src/ch/elexis/core/ui/reminder/part/nattable/ReminderBodyDataProvider.java
@@ -77,26 +77,24 @@ public class ReminderBodyDataProvider implements ISpanningDataProvider {
 		LoggerFactory.getLogger(getClass()).info("RELOAD START");
 		List<Map<String, List<IReminder>>> dataListMap = new ArrayList<>();
 		Map<String, Integer> maxMap = new HashMap<>();
+		LocalDate today = LocalDate.now();
+		LocalDate tomorrow = today.plusDays(1);
 		for (ReminderColumn reminderColumn : columns) {
 			List<IReminder> allReminders = reminderColumn.loadReminders();
-			List<IReminder> overDueReminders = getOverDue(allReminders);
-			List<IReminder> todayReminders = getToday(allReminders);
-			List<IReminder> tomorrowReminders = getTomorrow(allReminders);
-			List<IReminder> futureReminders = getFuture(allReminders);
-			List<IReminder> noDueReminders = getNoDue(allReminders);
-			dataListMap.add(Map.of("overdue", overDueReminders, "today", todayReminders, "tomorrow", tomorrowReminders,
-					"future", futureReminders, "nodue", noDueReminders));
+			ReminderBuckets buckets = bucketReminders(allReminders, today, tomorrow);
+			dataListMap.add(Map.of("overdue", buckets.overdue, "today", buckets.today, "tomorrow", buckets.tomorrow,
+					"future", buckets.future, "nodue", buckets.nodue));
 
 			maxMap.put("overdue", Math.max(maxMap.getOrDefault("overdue", 0),
-					overDueReminders.size()));
+					buckets.overdue.size()));
 			maxMap.put("today", Math.max(maxMap.getOrDefault("today", 0),
-					todayReminders.size()));
+					buckets.today.size()));
 			maxMap.put("tomorrow", Math.max(maxMap.getOrDefault("tomorrow", 0),
-					tomorrowReminders.size()));
+					buckets.tomorrow.size()));
 			maxMap.put("future", Math.max(maxMap.getOrDefault("future", 0),
-					futureReminders.size()));
+					buckets.future.size()));
 			maxMap.put("nodue", Math.max(maxMap.getOrDefault("nodue", 0),
-					noDueReminders.size()));
+					buckets.nodue.size()));
 		}
 		
 		dataMatrix = new Object[2 + maxMap.get("overdue") + 1 + maxMap.get("today") + 1 + maxMap.get("tomorrow") + 1
@@ -157,24 +155,31 @@ public class ReminderBodyDataProvider implements ISpanningDataProvider {
 		}
 	}
 
-	private List<IReminder> getNoDue(List<IReminder> all) {
-		return all.stream().filter(r -> r.getDue() == null).toList();
+	private ReminderBuckets bucketReminders(List<IReminder> all, LocalDate today, LocalDate tomorrow) {
+		ReminderBuckets ret = new ReminderBuckets();
+		for (IReminder reminder : all) {
+			LocalDate due = reminder.getDue();
+			if (due == null) {
+				ret.nodue.add(reminder);
+			} else if (due.isBefore(today)) {
+				ret.overdue.add(reminder);
+			} else if (due.isEqual(today)) {
+				ret.today.add(reminder);
+			} else if (due.isEqual(tomorrow)) {
+				ret.tomorrow.add(reminder);
+			} else {
+				ret.future.add(reminder);
+			}
+		}
+		return ret;
 	}
 
-	private List<IReminder> getFuture(List<IReminder> all) {
-		return all.stream().filter(r -> r.getDue() != null && r.getDue().isAfter(LocalDate.now().plusDays(1))).toList();
-	}
-
-	private List<IReminder> getTomorrow(List<IReminder> all) {
-		return all.stream().filter(r -> r.getDue() != null && r.getDue().isEqual(LocalDate.now().plusDays(1))).toList();
-	}
-
-	private List<IReminder> getToday(List<IReminder> all) {
-		return all.stream().filter(r -> r.getDue() != null && r.getDue().isEqual(LocalDate.now())).toList();
-	}
-
-	private List<IReminder> getOverDue(List<IReminder> all) {
-		return all.stream().filter(r -> r.getDue() != null && r.getDue().isBefore(LocalDate.now())).toList();
+	private static class ReminderBuckets {
+		private final List<IReminder> overdue = new ArrayList<>();
+		private final List<IReminder> today = new ArrayList<>();
+		private final List<IReminder> tomorrow = new ArrayList<>();
+		private final List<IReminder> future = new ArrayList<>();
+		private final List<IReminder> nodue = new ArrayList<>();
 	}
 
 	public void setColumns(List<ReminderColumn> columns) {

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ReminderPrefences.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/preferences/ReminderPrefences.java
@@ -446,6 +446,7 @@ public class ReminderPrefences extends PreferencePage implements IWorkbenchPrefe
 				defaultResponsibleSelf.getSelection());
 		ConfigServiceHolder.setUser(Preferences.USR_REMINDER_PAT_LABEL_CHOOSEN,
 				getListAsString(lViewerChoosen.getList().getItems()));
+		Reminder.invalidatePatientLabelConfigCache();
 		ConfigServiceHolder.setUser(Preferences.USR_REMINDER_PAT_LABEL_AVAILABLE,
 				getListAsString(lViewerAvailable.getList().getItems()));
 		ConfigServiceHolder.setUser(Preferences.USR_REMINDER_COLUMNS_VISIBLE,

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/ReminderView.java
@@ -210,7 +210,8 @@ public class ReminderView extends ViewPart implements IRefreshable, HeartListene
 
 	public ReminderView() {
 		qbe = new Query<>(Reminder.class, null, null, Reminder.TABLENAME, new String[] { Reminder.FLD_DUE,
-				Reminder.FLD_PRIORITY, Reminder.FLD_ACTION_TYPE, Reminder.FLD_CREATOR, Reminder.FLD_KONTAKT_ID });
+				Reminder.FLD_PRIORITY, Reminder.FLD_ACTION_TYPE, Reminder.FLD_CREATOR, Reminder.FLD_KONTAKT_ID,
+				Reminder.FLD_SUBJECT, Reminder.FLD_MESSAGE, Reminder.FLD_VISIBILITY, Reminder.FLD_STATUS });
 	}
 
 	@Override


### PR DESCRIPTION
# Reduce reminder query load by prefetching used fields

## Summary

This change reduces excessive reminder-related database roundtrips by ensuring reminder fields used by the UI are prefetched and cached under the logical field names expected by `PersistentObject`.

The main issue was an N+1-style load pattern in the reminder UI: reminders were selected in batches, but fields such as due date, creator, subject, message, type and status were later loaded again per reminder.

## Changes

- Keep separate selected database column names and logical cache field names in `Query`.
- Cache prefetched `Reminder` values using the constants expected by the getter methods.
- Include `Message`, `Typ` and `Status` in reminder prefetch queries.
- Extend `ReminderView` prefetch fields to include subject, message, visibility and status.
- Reduce repeated getter calls while grouping/rendering reminder UI entries.
- Cache configured patient label fields per user and invalidate that cache when reminder preferences are saved.

## Measured impact

Measured with MySQL general log, changing the patient 15 times while performing comparable reminder operations:

| Run | Reminder queries | Duration | Query rate |
|---|---:|---:|---:|
| Original | 56,121 | 23.891s | 2349.0/s |
| UI reminder patch | 86,284 | 38.827s | 2222.3/s |
| Reminder data patch | 57,803 | 27.369s | 2112.0/s |
| Query prefetch fix | 23,056 | 24.190s | 953.1/s |
| Final combined patch | 133 | 47.869s | 2.8/s |

The final patch reduces the reminder query rate by about 99.9%.

Previously dominant query patterns are eliminated:

| Query pattern | Before | After |
|---|---:|---:|
| `SELECT ORIGINID FROM REMINDERS WHERE ID='?'` | 17,817 | 0 |
| `SELECT DATEDUE FROM REMINDERS WHERE ID='?'` | 17,816 | 0 |
| `SELECT SUBJECT,MESSAGE,TYP FROM REMINDERS WHERE ID='?'` | 17,815 | 0 |
| `SELECT SUBJECT FROM REMINDERS WHERE ID='?'` | 2,480 | 0 |

## Validation

- Built patched bundles locally and tested them in an existing Elexis installation.
- Re-ran MySQL general log analysis after each patch iteration.
- Verified that the final run no longer contains the previous high-volume per-reminder field lookup patterns.

## Notes

The remaining reminder queries are low-volume batch/refresh queries rather than per-reminder field lookups.
