### PR TITLE
Add patient date index for appointments

### DIFF
--- a/bundles/ch.elexis.core.jpa/db/elexisdb_create_optional.xml
+++ b/bundles/ch.elexis.core.jpa/db/elexisdb_create_optional.xml
@@ -1606,6 +1606,23 @@ DROP TABLE TEMP_ETIKETTEN_OBJCLASS_LINK;
             <column name="PATID"/>
         </createIndex>
     </changeSet>
+	<changeSet author="julian" id="manual_idx_agntermine_patid_tag_deleted">
+		<preConditions onFail="MARK_RAN">
+			<and>
+				<tableExists tableName="AGNTERMINE" />
+				<not>
+					<indexExists tableName="AGNTERMINE"
+						indexName="AGN_PATID_TAG_DELETED" />
+				</not>
+			</and>
+		</preConditions>
+		<createIndex indexName="AGN_PATID_TAG_DELETED"
+			tableName="AGNTERMINE">
+			<column name="PATID" />
+			<column name="TAG" />
+			<column name="DELETED" />
+		</createIndex>
+	</changeSet>
     
     <changeSet author="thomas" id="agntermine_priority">
 		<preConditions onFail="MARK_RAN">


### PR DESCRIPTION
## Summary

Add a composite index for loading the latest appointments of a patient in the
Terminliste view.

## Root cause

The Terminliste query filtered `AGNTERMINE` by `PATID`, discarded deleted rows,
sorted all matching appointments by `TAG DESC`, and returned only the latest 15.
With only the existing `PATID` index, MySQL read roughly 484 rows for the measured
patient and performed a filesort.

## Change

Add the idempotent Liquibase index `AGN_PATID_TAG_DELETED` on:

```text
(PATID, TAG, DELETED)
```

The existing single-column indexes are intentionally left unchanged.

## Validation

- Liquibase XML parsed successfully with the Java XML parser.
- Tested against MySQL 5.7.30 with approximately 1.03 million `AGNTERMINE` rows.
- MySQL selected the new index and no longer used filesort.
- Two baseline captures averaged 82.5 ms and 107.2 ms per Terminliste query.
- Two indexed captures averaged 7.2 ms and 6.2 ms, an improvement of about
  92-94%.
- The index was rolled back after each isolated database test.