### PR TITLE
Load laboratory orders asynchronously

### DIFF
--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrderViewerItem.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrderViewerItem.java
@@ -22,6 +22,8 @@ public class LaborOrderViewerItem {
 
 	private StructuredViewer viewer;
 	private LabOrder order;
+	private LabItem labItem;
+	private LabResult labResult;
 
 	private String labItemLabel;
 	private String labResultString;
@@ -35,10 +37,14 @@ public class LaborOrderViewerItem {
 	public LaborOrderViewerItem(StructuredViewer viewer, LabOrder order) {
 		this.viewer = viewer;
 		this.order = order;
+		order.get(false, LabOrder.FLD_ITEM, LabOrder.FLD_RESULT, LabOrder.FLD_TIME,
+				LabOrder.FLD_OBSERVATIONTIME, LabOrder.FLD_STATE, LabOrder.FLD_ORDERID, LabOrder.FLD_GROUPNAME);
+		labItem = order.getLabItem();
+		labResult = (LabResult) order.getLabResult();
 	}
 
 	public LabResult getLabResult() {
-		return (LabResult) order.getLabResult();
+		return labResult;
 	}
 
 	public LabOrder getLabOrder() {
@@ -78,7 +84,7 @@ public class LaborOrderViewerItem {
 	public Optional<String> getLabItemPrio() {
 		if (hasLabItem()) {
 			if (itemPrio == null) {
-				itemPrio = order.getLabItem().getPrio();
+				itemPrio = labItem.getPrio();
 			}
 			return Optional.of(itemPrio);
 		}
@@ -96,12 +102,14 @@ public class LaborOrderViewerItem {
 
 	public LabResult createResult() {
 		LabResult ret = order.createResult();
+		labResult = ret;
 		viewer.refresh(this);
 		return ret;
 	}
 
 	public LabResult createResult(Kontakt origin) {
 		LabResult ret = order.createResult(origin);
+		labResult = ret;
 		viewer.refresh(this);
 		return ret;
 	}
@@ -112,11 +120,11 @@ public class LaborOrderViewerItem {
 	}
 
 	public boolean hasLabItem() {
-		return order.getLabItem() != null;
+		return labItem != null;
 	}
 
 	public LabItemTyp getLabItemTyp() {
-		return order.getLabItem().getTyp();
+		return labItem.getTyp();
 	}
 
 	public State getState() {
@@ -167,14 +175,14 @@ public class LaborOrderViewerItem {
 		}
 
 		private void resolveLabItemLabel() {
-			LabItem labItem = item.order.getLabItem();
+			LabItem labItem = item.labItem;
 			if (labItem != null) {
 				item.labItemLabel = labItem.getLabel();
 			}
 		}
 
 		private void resolveLabResultString() {
-			LabResult labResult = (LabResult) item.order.getLabResult();
+			LabResult labResult = item.labResult;
 			if (labResult != null) {
 				item.labResultString = getNonEmptyResultString(labResult);
 			}

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrdersComposite.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/LaborOrdersComposite.java
@@ -3,10 +3,17 @@ package ch.elexis.core.ui.laboratory.controls;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
@@ -35,6 +42,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.ColorDialog;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
@@ -48,6 +56,7 @@ import ch.elexis.core.services.IQuery.COMPARATOR;
 import ch.elexis.core.services.holder.ConfigServiceHolder;
 import ch.elexis.core.services.holder.ContextServiceHolder;
 import ch.elexis.core.services.holder.CoreModelServiceHolder;
+import ch.elexis.core.ui.laboratory.Activator;
 import ch.elexis.core.ui.UiDesk;
 import ch.elexis.core.ui.e4.util.CoreUiUtil;
 import ch.elexis.core.ui.icons.Images;
@@ -73,6 +82,21 @@ public class LaborOrdersComposite extends Composite {
 	private boolean reloadPending;
 
 	private boolean includeDone;
+	private Map<String, IOutputLog> orderLogEntries = Collections.emptyMap();
+	private Button btnHistory;
+	private Job reloadJob;
+	private long reloadGeneration;
+	private final ISchedulingRule reloadRule = new ISchedulingRule() {
+		@Override
+		public boolean contains(ISchedulingRule rule) {
+			return rule == this;
+		}
+
+		@Override
+		public boolean isConflicting(ISchedulingRule rule) {
+			return rule == this;
+		}
+	};
 
 	private Patient actPatient;
 	private Composite toolComposite;
@@ -156,7 +180,7 @@ public class LaborOrdersComposite extends Composite {
 			}
 		});
 
-		Button btnHistory = tk.createButton(toolComposite, Messages.LaborOrdersComposite_actionTooltipShowHistory,
+		btnHistory = tk.createButton(toolComposite, Messages.LaborOrdersComposite_actionTooltipShowHistory,
 				SWT.CHECK);
 		btnHistory.setSelection(includeDone);
 		btnHistory.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
@@ -236,14 +260,9 @@ public class LaborOrdersComposite extends Composite {
 			@Override
 			public Image getImage(Object element) {
 				if (element instanceof LaborOrderViewerItem item) {
-
-					ILabOrder order = CoreModelServiceHolder.get().load(item.getLabOrder().getId(), ILabOrder.class)
-							.orElse(null);
-					if (order != null) {
-						IOutputLog log = getOrderLogEntry(order);
-						if (log != null && OUTPUTLOG_EXTERNES_LABOR.equals(log.getOutputterStatus())) {
-							return Images.IMG_BLOOD_TEST.getImage();
-						}
+					IOutputLog log = orderLogEntries.get(item.getLabOrder().getId());
+					if (log != null && OUTPUTLOG_EXTERNES_LABOR.equals(log.getOutputterStatus())) {
+						return Images.IMG_BLOOD_TEST.getImage();
 					}
 				}
 				return null;
@@ -443,17 +462,24 @@ public class LaborOrdersComposite extends Composite {
 
 	public void selectPatient(Patient patient) {
 		setRedraw(false);
-		if (patient != null) {
-			if (!patient.equals(actPatient)) {
-				actPatient = patient;
-				form.setText(actPatient.getLabel());
-				reload();
+		try {
+			if (patient != null) {
+				if (!patient.equals(actPatient)) {
+					actPatient = patient;
+					form.setText(actPatient.getLabel());
+					reload();
+				}
+			} else {
+				actPatient = null;
+				form.setText(Messages.Core_No_patient_selected);
+				invalidateReload();
+				orderLogEntries = Collections.emptyMap();
+				viewer.setInput(Collections.emptyList());
+				setLoading(false);
 			}
-		} else {
-			actPatient = patient;
-			form.setText(Messages.Core_No_patient_selected);
+		} finally {
+			setRedraw(true);
 		}
-		setRedraw(true);
 	}
 
 	public void setIncludeDone(boolean value) {
@@ -467,16 +493,26 @@ public class LaborOrdersComposite extends Composite {
 	 * If visible full reload from database
 	 */
 	public void reload() {
+		long generation = ++reloadGeneration;
+		cancelReloadJob();
 		if (!isVisible()) {
 			reloadPending = true;
 			return;
 		}
-		setRedraw(false);
 		reloadPending = false;
-		if (actPatient != null) {
-			viewer.setInput(getOrders());
+		if (actPatient == null) {
+			orderLogEntries = Collections.emptyMap();
+			viewer.setInput(Collections.emptyList());
+			setLoading(false);
+			return;
 		}
-		setRedraw(true);
+
+		boolean mandatorOnly = ConfigServiceHolder
+				.getUser(Preferences.LABSETTINGS_CFG_SHOW_MANDANT_ORDERS_ONLY, false);
+		String mandatorId = mandatorOnly ? ContextServiceHolder.getActiveMandatorOrNull().getId() : null;
+		LoadRequest request = new LoadRequest(generation, actPatient.getId(), mandatorId, includeDone);
+		beginLoading();
+		scheduleReload(request);
 	}
 
 	@Override
@@ -487,35 +523,161 @@ public class LaborOrdersComposite extends Composite {
 		return super.setFocus();
 	}
 
-	private List<LaborOrderViewerItem> getOrders() {
-		if (actPatient != null) {
-			List<LabOrder> orders = null;
-			if (ConfigServiceHolder.getUser(Preferences.LABSETTINGS_CFG_SHOW_MANDANT_ORDERS_ONLY, false)) {
-				orders = LabOrder.getLabOrders(actPatient.getId(),
-						ContextServiceHolder.getActiveMandatorOrNull().getId(), null, null, null, null,
-						includeDone ? null : State.ORDERED);
-			} else {
-				orders = LabOrder.getLabOrders(actPatient, null, null, null, null, null,
-						includeDone ? null : State.ORDERED);
-			}
-			// Sorting by priority of labItem
-			if (orders != null) {
-				List<LaborOrderViewerItem> viewerItems = new ArrayList<>();
-				orders.forEach(order -> viewerItems.add(new LaborOrderViewerItem(viewer, order)));
-
-				Collections.sort(viewerItems, new Comparator<LaborOrderViewerItem>() {
-
-					@Override
-					public int compare(LaborOrderViewerItem lo1, LaborOrderViewerItem lo2) {
-						String prio1 = lo1.getLabItemPrio().orElse(StringUtils.EMPTY);
-						String prio2 = lo2.getLabItemPrio().orElse(StringUtils.EMPTY);
-						return prio1.compareTo(prio2);
+	private void scheduleReload(LoadRequest request) {
+		Display display = getDisplay();
+		reloadJob = new Job(Messages.Core_loading) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				try {
+					LoadResult result = loadOrders(request, monitor);
+					if (result == null || monitor.isCanceled()) {
+						return Status.CANCEL_STATUS;
 					}
-				});
-				return viewerItems;
+					if (!display.isDisposed()) {
+						display.asyncExec(() -> applyLoadResult(request, result));
+					}
+					return Status.OK_STATUS;
+				} catch (Exception exception) {
+					if (monitor.isCanceled()) {
+						return Status.CANCEL_STATUS;
+					}
+					if (!display.isDisposed()) {
+						display.asyncExec(() -> applyLoadFailure(request));
+					}
+					return new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Could not load laboratory orders", //$NON-NLS-1$
+							exception);
+				}
 			}
+		};
+		reloadJob.setPriority(Job.SHORT);
+		reloadJob.setUser(false);
+		reloadJob.setRule(reloadRule);
+		reloadJob.schedule();
+	}
+
+	private LoadResult loadOrders(LoadRequest request, IProgressMonitor monitor) {
+		List<LabOrder> orders = LabOrder.getLabOrders(request.patientId(), request.mandatorId(), null, null, null, null,
+				request.includeDone() ? null : State.ORDERED);
+		if (monitor.isCanceled()) {
+			return null;
 		}
-		return Collections.emptyList();
+		List<LaborOrderViewerItem> viewerItems = new ArrayList<>();
+		for (LabOrder order : orders) {
+			if (monitor.isCanceled()) {
+				return null;
+			}
+			viewerItems.add(new LaborOrderViewerItem(viewer, order));
+		}
+		Map<String, IOutputLog> loadedLogEntries = loadOrderLogEntries(viewerItems);
+		if (monitor.isCanceled()) {
+			return null;
+		}
+		viewerItems.sort(new Comparator<LaborOrderViewerItem>() {
+			@Override
+			public int compare(LaborOrderViewerItem lo1, LaborOrderViewerItem lo2) {
+				String prio1 = lo1.getLabItemPrio().orElse(StringUtils.EMPTY);
+				String prio2 = lo2.getLabItemPrio().orElse(StringUtils.EMPTY);
+				return prio1.compareTo(prio2);
+			}
+		});
+		return new LoadResult(viewerItems, loadedLogEntries);
+	}
+
+	private Map<String, IOutputLog> loadOrderLogEntries(List<LaborOrderViewerItem> viewerItems) {
+		if (viewerItems.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		List<String> orderIds = viewerItems.stream().map(item -> item.getLabOrder().getId()).toList();
+		IQuery<IOutputLog> query = CoreModelServiceHolder.get().getQuery(IOutputLog.class);
+		query.and(ModelPackage.Literals.IOUTPUT_LOG__OBJECT_ID, COMPARATOR.IN, orderIds);
+		Map<String, IOutputLog> loadedEntries = new HashMap<>();
+		for (IOutputLog entry : query.execute()) {
+			loadedEntries.putIfAbsent(entry.getObjectId(), entry);
+		}
+		return loadedEntries;
+	}
+
+	private void beginLoading() {
+		setRedraw(false);
+		try {
+			orderLogEntries = Collections.emptyMap();
+			viewer.setInput(Collections.emptyList());
+			setLoading(true);
+		} finally {
+			setRedraw(true);
+		}
+	}
+
+	private void applyLoadResult(LoadRequest request, LoadResult result) {
+		if (!isCurrent(request)) {
+			return;
+		}
+		reloadJob = null;
+		if (!isVisible()) {
+			reloadPending = true;
+			++reloadGeneration;
+			setLoading(false);
+			return;
+		}
+		setRedraw(false);
+		try {
+			orderLogEntries = result.logEntries();
+			viewer.setInput(result.viewerItems());
+			setLoading(false);
+		} finally {
+			setRedraw(true);
+		}
+	}
+
+	private void applyLoadFailure(LoadRequest request) {
+		if (!isCurrent(request)) {
+			return;
+		}
+		reloadJob = null;
+		orderLogEntries = Collections.emptyMap();
+		viewer.setInput(Collections.emptyList());
+		setLoading(false);
+	}
+
+	private boolean isCurrent(LoadRequest request) {
+		return !isDisposed() && viewer != null && !viewer.getControl().isDisposed()
+				&& request.generation() == reloadGeneration && actPatient != null
+				&& request.patientId().equals(actPatient.getId()) && request.includeDone() == includeDone;
+	}
+
+	private void setLoading(boolean loading) {
+		if (viewer == null || viewer.getControl().isDisposed()) {
+			return;
+		}
+		viewer.getControl().setEnabled(!loading);
+		viewer.getControl().setCursor(loading ? getDisplay().getSystemCursor(SWT.CURSOR_WAIT) : null);
+		if (btnHistory != null && !btnHistory.isDisposed()) {
+			btnHistory.setEnabled(!loading);
+		}
+	}
+
+	private void invalidateReload() {
+		++reloadGeneration;
+		cancelReloadJob();
+	}
+
+	private void cancelReloadJob() {
+		if (reloadJob != null) {
+			reloadJob.cancel();
+			reloadJob = null;
+		}
+	}
+
+	@Override
+	public void dispose() {
+		invalidateReload();
+		super.dispose();
+	}
+
+	private record LoadRequest(long generation, String patientId, String mandatorId, boolean includeDone) {
+	}
+
+	private record LoadResult(List<LaborOrderViewerItem> viewerItems, Map<String, IOutputLog> logEntries) {
 	}
 
 	public StructuredViewer getViewer() {

--- a/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/Messages.java
+++ b/bundles/ch.elexis.core.ui.laboratory/src/ch/elexis/core/ui/laboratory/controls/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
 	public static String Core_Parameter = ch.elexis.core.l10n.Messages.Core_Parameter;
 	public static String Core_Status = ch.elexis.core.l10n.Messages.Core_Status;
 	public static String Core_Value = ch.elexis.core.l10n.Messages.Core_Value;
+	public static String Core_loading = ch.elexis.core.l10n.Messages.Core_loading;
 	public static String LaborOrdersComposite_validatorNotNumber = ch.elexis.core.l10n.Messages.LaborOrdersComposite_validatorNotNumber;
 	public static String Core_No_patient_selected = ch.elexis.core.l10n.Messages.Core_No_patient_selected;
 	public static String LaborOrdersComposite_actionTooltipShowHistory = ch.elexis.core.l10n.Messages.LaborOrdersComposite_actionTooltipShowHistory;


### PR DESCRIPTION
## Summary

Improve the responsiveness of the `Labor` view's `Verordnungen` tab when Elexis is connected to a database over LAN.

The change keeps the existing `LabOrder` objects and user-facing behavior, but reduces repeated object resolution and moves the remaining loading work away from the SWT UI thread.

## Changes

- Prefetch the displayed `LabOrder` fields and reuse the resolved `LabItem` and `LabResult` per viewer item.
- Replace one `OUTPUT_LOG` lookup per order with one bulk query per reload.
- Load orders, related objects, output logs and priority sorting in a serialized Eclipse background job.
- Clear and disable the table and history filter while loading.
- Reject stale results using a generation, patient ID and filter snapshot.
- Cancel or invalidate pending work on patient changes, hidden views and disposal.
- Apply viewer items and their OutputLog mapping atomically on the SWT thread.

There are no public API or database schema changes.

## Root cause

The patient-specific `LABORDER` query returns a manageable result set, but rendering previously triggered many individual field and relation lookups over LAN. The complete loading and sorting path also ran synchronously on the SWT UI thread.

## Measurements

Automated LAN captures used patients `29585`, `3651` and `4739`, loading open orders and toggling imported/completed orders.

| Metric | Baseline | With this change |
|---|---:|---:|
| Slow-log statements | 219,551 | 25,201 |
| UI freezes | 14 | 2 |
| Cumulative freeze time | 67.58 s | 1.73 s |
| Longest freeze | 12.0 s | 1.1 s |
| Order-loading freezes >= 1 s | present | 0 |

The remaining 1.1 second event occurred while Elexis was closing and had no matching SQL query. Total loading time over LAN remains dependent on the database and data volume; the UI stays responsive while that work completes.

## Validation

- Java 21 Maven/Tycho reactor: `clean verify -DskipTests`
- UTF-8 source encoding without BOM
- Open and imported/completed order flows for all three patients
- Rapid patient switch `29585 -> 3651 -> 4739`; only the final patient's result was displayed
- Switched away from the tab while loading and returned after completion
- No stale result, SWT disposed-widget error, EventLoop exception or asynchronous load error
- General/Slow Log and temporary preference settings restored after each capture

Manual mutation tests for creating/editing a result, changing status or observation time, and deleting an order are intentionally left for review with disposable clinical test data.
