### PR TITLE
Add persistence for PS25 tariff

### DIFF
--- a/bundles/ch.elexis.core.jpa.entities/META-INF/persistence.xml
+++ b/bundles/ch.elexis.core.jpa.entities/META-INF/persistence.xml
@@ -89,6 +89,7 @@
 		<class>ch.elexis.core.jpa.entities.PrivatLeistung</class>
 		<class>ch.elexis.core.jpa.entities.PhysioLeistung</class>
 		<class>ch.elexis.core.jpa.entities.PsychoLeistung</class>
+		<class>ch.elexis.core.jpa.entities.Ps25Leistung</class>
 		<class>ch.elexis.core.jpa.entities.ComplementaryLeistung</class>
 		<class>ch.elexis.core.jpa.entities.NutritionLeistung</class>
 		<class>ch.elexis.core.jpa.entities.PeaElement</class>

--- a/bundles/ch.elexis.core.jpa.entities/src/ch/elexis/core/jpa/entities/Ps25Leistung.java
+++ b/bundles/ch.elexis.core.jpa.entities/src/ch/elexis/core/jpa/entities/Ps25Leistung.java
@@ -1,0 +1,232 @@
+package ch.elexis.core.jpa.entities;
+
+import java.time.LocalDate;
+
+import ch.elexis.core.jpa.entities.converter.BooleanCharacterConverterSafe;
+import ch.elexis.core.jpa.entities.listener.EntityWithIdListener;
+import ch.elexis.core.model.util.ElexisIdGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "CH_ELEXIS_ARZTTARIFE_CH_PS25")
+@EntityListeners(EntityWithIdListener.class)
+@NamedQuery(name = "Ps25Leistung.code", query = "SELECT pl FROM Ps25Leistung pl WHERE pl.deleted = false AND pl.code = :code")
+@NamedQuery(name = "Ps25Leistung.code.validFrom", query = "SELECT pl FROM Ps25Leistung pl WHERE pl.deleted = false AND pl.code = :code AND pl.validFrom = :validFrom")
+public class Ps25Leistung extends AbstractEntityWithId implements EntityWithId, EntityWithDeleted {
+
+	public static final String CODESYSTEM_NAME = "PS25";
+	public static final String CODESYSTEM_CODE = "744";
+
+	protected Long lastupdate;
+
+	@Id
+	@Column(unique = true, nullable = false, length = 64)
+	private String id = ElexisIdGenerator.generateId();
+
+	@Column
+	@Convert(converter = BooleanCharacterConverterSafe.class)
+	protected boolean deleted = false;
+
+	@Column(length = 32)
+	private String code;
+
+	@Column(length = 255)
+	private String honorarEmpfaenger;
+
+	@Column(length = 255)
+	private String fachgebietKapitel;
+
+	@Column(length = 255)
+	private String unterkapitel;
+
+	@Column(length = 512)
+	private String fachaerztlicheMehrleistungBei;
+
+	@Lob
+	private String spezifikation;
+
+	@Lob
+	private String anwendungsregeln;
+
+	@Column(length = 16)
+	private String taxpunkte;
+
+	@Column(length = 16)
+	private String stufe;
+
+	@Column(length = 512)
+	private String moeglicheKombination;
+
+	@Column(length = 16)
+	private String mehrleistungstyp;
+
+	@Column(length = 512)
+	private String mehrleistung;
+
+	@Column(length = 8)
+	private LocalDate validFrom;
+
+	@Column(length = 8)
+	private LocalDate validUntil;
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public String getHonorarEmpfaenger() {
+		return honorarEmpfaenger;
+	}
+
+	public void setHonorarEmpfaenger(String honorarEmpfaenger) {
+		this.honorarEmpfaenger = honorarEmpfaenger;
+	}
+
+	public String getFachgebietKapitel() {
+		return fachgebietKapitel;
+	}
+
+	public void setFachgebietKapitel(String fachgebietKapitel) {
+		this.fachgebietKapitel = fachgebietKapitel;
+	}
+
+	public String getUnterkapitel() {
+		return unterkapitel;
+	}
+
+	public void setUnterkapitel(String unterkapitel) {
+		this.unterkapitel = unterkapitel;
+	}
+
+	public String getFachaerztlicheMehrleistungBei() {
+		return fachaerztlicheMehrleistungBei;
+	}
+
+	public void setFachaerztlicheMehrleistungBei(String fachaerztlicheMehrleistungBei) {
+		this.fachaerztlicheMehrleistungBei = fachaerztlicheMehrleistungBei;
+	}
+
+	public String getSpezifikation() {
+		return spezifikation;
+	}
+
+	public void setSpezifikation(String spezifikation) {
+		this.spezifikation = spezifikation;
+	}
+
+	public String getAnwendungsregeln() {
+		return anwendungsregeln;
+	}
+
+	public void setAnwendungsregeln(String anwendungsregeln) {
+		this.anwendungsregeln = anwendungsregeln;
+	}
+
+	public String getTaxpunkte() {
+		return taxpunkte;
+	}
+
+	public void setTaxpunkte(String taxpunkte) {
+		this.taxpunkte = taxpunkte;
+	}
+
+	public String getStufe() {
+		return stufe;
+	}
+
+	public void setStufe(String stufe) {
+		this.stufe = stufe;
+	}
+
+	public String getMoeglicheKombination() {
+		return moeglicheKombination;
+	}
+
+	public void setMoeglicheKombination(String moeglicheKombination) {
+		this.moeglicheKombination = moeglicheKombination;
+	}
+
+	public String getMehrleistungstyp() {
+		return mehrleistungstyp;
+	}
+
+	public void setMehrleistungstyp(String mehrleistungstyp) {
+		this.mehrleistungstyp = mehrleistungstyp;
+	}
+
+	public String getMehrleistung() {
+		return mehrleistung;
+	}
+
+	public void setMehrleistung(String mehrleistung) {
+		this.mehrleistung = mehrleistung;
+	}
+
+	public LocalDate getValidFrom() {
+		return validFrom;
+	}
+
+	public void setValidFrom(LocalDate validFrom) {
+		this.validFrom = validFrom;
+	}
+
+	public LocalDate getValidUntil() {
+		return validUntil;
+	}
+
+	public void setValidUntil(LocalDate validUntil) {
+		this.validUntil = validUntil;
+	}
+
+	public String getCodeSystemName() {
+		return CODESYSTEM_NAME;
+	}
+
+	public String getText() {
+		return getMehrleistung();
+	}
+
+	public String getCodeSystemCode() {
+		return CODESYSTEM_CODE;
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	@Override
+	public void setDeleted(boolean deleted) {
+		this.deleted = deleted;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public Long getLastupdate() {
+		return lastupdate;
+	}
+
+	@Override
+	public void setLastupdate(Long lastupdate) {
+		this.lastupdate = lastupdate;
+	}
+}

--- a/bundles/ch.elexis.core.jpa.entities/src/ch/elexis/core/jpa/entities/Ps25Leistung_.java
+++ b/bundles/ch.elexis.core.jpa.entities/src/ch/elexis/core/jpa/entities/Ps25Leistung_.java
@@ -1,0 +1,28 @@
+package ch.elexis.core.jpa.entities;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.metamodel.SingularAttribute;
+import jakarta.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(Ps25Leistung.class)
+public class Ps25Leistung_ {
+
+	public static volatile SingularAttribute<Ps25Leistung, Boolean> deleted;
+	public static volatile SingularAttribute<Ps25Leistung, String> code;
+	public static volatile SingularAttribute<Ps25Leistung, String> honorarEmpfaenger;
+	public static volatile SingularAttribute<Ps25Leistung, String> fachgebietKapitel;
+	public static volatile SingularAttribute<Ps25Leistung, String> unterkapitel;
+	public static volatile SingularAttribute<Ps25Leistung, String> fachaerztlicheMehrleistungBei;
+	public static volatile SingularAttribute<Ps25Leistung, String> spezifikation;
+	public static volatile SingularAttribute<Ps25Leistung, String> anwendungsregeln;
+	public static volatile SingularAttribute<Ps25Leistung, String> taxpunkte;
+	public static volatile SingularAttribute<Ps25Leistung, String> stufe;
+	public static volatile SingularAttribute<Ps25Leistung, String> moeglicheKombination;
+	public static volatile SingularAttribute<Ps25Leistung, String> mehrleistungstyp;
+	public static volatile SingularAttribute<Ps25Leistung, String> mehrleistung;
+	public static volatile SingularAttribute<Ps25Leistung, LocalDate> validFrom;
+	public static volatile SingularAttribute<Ps25Leistung, LocalDate> validUntil;
+	public static volatile SingularAttribute<Ps25Leistung, Long> lastupdate;
+	public static volatile SingularAttribute<Ps25Leistung, String> id;
+}

--- a/bundles/ch.elexis.core.jpa/db/elexisdb_create_optional.xml
+++ b/bundles/ch.elexis.core.jpa/db/elexisdb_create_optional.xml
@@ -2183,6 +2183,48 @@ WHERE kontakt.id IN (
 		</createIndex>
 	</changeSet>
 
+	<changeSet author="kappisj" id="manual_table_CH_ELEXIS_ARZTTARIFE_CH_PS25">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25" />
+			</not>
+		</preConditions>
+		<createTable tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25">
+			<column name="ID" type="VARCHAR(64)">
+				<constraints primaryKey="true"
+					primaryKeyName="CONSTRAINT_PK_CH_ELEXIS_ARZTTARIFE_CH_PS25" />
+			</column>
+			<column name="LASTUPDATE" type="BIGINT" />
+			<column defaultValue="0" name="DELETED" type="CHAR(1)" />
+			<column name="CODE" type="VARCHAR(32)" />
+			<column name="HONORAREMPFAENGER" type="VARCHAR(255)" />
+			<column name="FACHGEBIETKAPITEL" type="VARCHAR(255)" />
+			<column name="UNTERKAPITEL" type="VARCHAR(255)" />
+			<column name="FACHAERZTLICHEMEHRLEISTUNGBEI" type="VARCHAR(512)" />
+			<column name="SPEZIFIKATION" type="CLOB" />
+			<column name="ANWENDUNGSREGELN" type="CLOB" />
+			<column name="TAXPUNKTE" type="VARCHAR(16)" />
+			<column name="STUFE" type="VARCHAR(16)" />
+			<column name="MOEGLICHEKOMBINATION" type="VARCHAR(512)" />
+			<column name="MEHRLEISTUNGSTYP" type="VARCHAR(16)" />
+			<column name="MEHRLEISTUNG" type="VARCHAR(512)" />
+			<column name="VALIDFROM" type="CHAR(8)" />
+			<column name="VALIDUNTIL" type="CHAR(8)" />
+		</createTable>
+	</changeSet>
+	<changeSet author="kappisj" id="manual_index_CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25"
+					indexName="CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1" />
+			</not>
+		</preConditions>
+		<createIndex indexName="CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1"
+			tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25">
+			<column name="CODE" />
+		</createIndex>
+	</changeSet>
+
 	<changeSet author="thomas"
 		id="manual_table_CH_ELEXIS_OMNIVORE_DATA_CREATIONDATE">
 		<preConditions onFail="MARK_RAN">

--- a/bundles/ch.elexis.core.jpa/db/elexisdb_master_update.xml
+++ b/bundles/ch.elexis.core.jpa/db/elexisdb_master_update.xml
@@ -20,4 +20,5 @@
     <include file="/db/v3.11/elexisdb_update.xml"/>
     <include file="/db/v3.12/elexisdb_update.xml"/>
     <include file="/db/v3.13/elexisdb_update.xml"/>
+    <include file="/db/v3.14/elexisdb_update.xml"/>
 </databaseChangeLog>

--- a/bundles/ch.elexis.core.jpa/db/v3.14/elexisdb_update.xml
+++ b/bundles/ch.elexis.core.jpa/db/v3.14/elexisdb_update.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.31.xsd">
+
+	<changeSet author="kappisj" id="manual_table_CH_ELEXIS_ARZTTARIFE_CH_PS25">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25" />
+			</not>
+		</preConditions>
+		<createTable tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25">
+			<column name="ID" type="VARCHAR(64)">
+				<constraints primaryKey="true" primaryKeyName="CONSTRAINT_PK_CH_ELEXIS_ARZTTARIFE_CH_PS25" />
+			</column>
+			<column name="LASTUPDATE" type="BIGINT" />
+			<column defaultValue="0" name="DELETED" type="CHAR(1)" />
+			<column name="CODE" type="VARCHAR(32)" />
+			<column name="HONORAREMPFAENGER" type="VARCHAR(255)" />
+			<column name="FACHGEBIETKAPITEL" type="VARCHAR(255)" />
+			<column name="UNTERKAPITEL" type="VARCHAR(255)" />
+			<column name="FACHAERZTLICHEMEHRLEISTUNGBEI" type="VARCHAR(512)" />
+			<column name="SPEZIFIKATION" type="CLOB" />
+			<column name="ANWENDUNGSREGELN" type="CLOB" />
+			<column name="TAXPUNKTE" type="VARCHAR(16)" />
+			<column name="STUFE" type="VARCHAR(16)" />
+			<column name="MOEGLICHEKOMBINATION" type="VARCHAR(512)" />
+			<column name="MEHRLEISTUNGSTYP" type="VARCHAR(16)" />
+			<column name="MEHRLEISTUNG" type="VARCHAR(512)" />
+			<column name="VALIDFROM" type="CHAR(8)" />
+			<column name="VALIDUNTIL" type="CHAR(8)" />
+		</createTable>
+	</changeSet>
+
+	<changeSet author="kappisj" id="manual_index_CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25"
+					indexName="CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1" />
+			</not>
+		</preConditions>
+		<createIndex indexName="CH_ELEXIS_ARZTTARIFE_CH_PS25_IDX1" tableName="CH_ELEXIS_ARZTTARIFE_CH_PS25">
+			<column name="CODE" />
+		</createIndex>
+	</changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Summary

- add the `Ps25Leistung` JPA entity and static metamodel
- add the PS25 table and code index to the optional schema
- add a versioned Liquibase migration for existing 3.14 databases
- register the entity in the persistence unit

## Context

PS25 is a licensed Swiss medical tariff maintained outside Elexis. The tariff data itself is not distributed with Elexis. This PR provides the persistence layer required by the companion `elexis-3-base` PR, which adds manual XLSX and RDUS imports and integrates PS25 into the services view.

The entity stores every `Pos_ID` and `validFrom` combination as a separate version. `validUntil` keeps historical positions billable for encounters whose dates fall within the corresponding validity period.

## Data model

- code system: `PS25`
- TarmedXML tariff type: `744`
- table: `CH_ELEXIS_ARZTTARIFE_CH_PS25`
- indexed lookup column: `CODE`
- validity columns: `VALIDFROM` and `VALIDUNTIL`

No licensed tariff records are included.

## Validation

- Java 21 compilation against the current Elexis master installation
- Liquibase files and persistence registration validated during test-bundle packaging
- schema migration exercised by the running master installation
- manual PS25 import and billing smoke-tested in Elexis

## Companion PR

The corresponding UI, model and importer changes are in [elexis/elexis-3-base#546](https://github.com/elexis/elexis-3-base/pull/546).

## Discussion

- confirm the table and change-set naming conventions
- confirm that the 3.14 migration is the desired target for the initial delivery
