### PR TITLE
[28430] Load patient letters progressively

### DIFF
--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/Messages.java
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/Messages.java
@@ -565,6 +565,7 @@ public class Messages extends NLS {
 	public static String BriefAuswahlCreateNewDocument;
 	public static String BriefAuswahlDeleteConfirmText;
 	public static String BriefAuswahlLoadButtonText;
+	public static String BriefAuswahlLoadMoreButtonText;
 	public static String BriefAuswahlNewSubjectHeading;
 	public static String BriefAuswahlNewSubjectText;
 	public static String BriefAuswahlNotAllowedToRunStresstess;

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages.properties
@@ -1198,6 +1198,7 @@ BriefAuswahlCreateNewDocument = create a new document
 BriefAuswahlDeleteConfirmText = really delete this document?
 
 BriefAuswahlLoadButtonText = load
+BriefAuswahlLoadMoreButtonText = Load more
 
 BriefAuswahlNewSubjectHeading = new subject
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_de.properties
@@ -1192,6 +1192,7 @@ BriefAuswahlCreateNewDocument = Einen neues Dokument erstellen
 BriefAuswahlDeleteConfirmText = Wollen Sie dieses Dokument wirklich unwiderruflich l\u00F6schen?
 
 BriefAuswahlLoadButtonText = Laden
+BriefAuswahlLoadMoreButtonText = Mehr laden
 
 BriefAuswahlNewSubjectHeading = Neuer Betreff
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_en.properties
@@ -1172,6 +1172,7 @@ BriefAuswahlCreateNewDocument = Create a new document
 BriefAuswahlDeleteConfirmText = Do you really want to permanently delete this document?
 
 BriefAuswahlLoadButtonText = load
+BriefAuswahlLoadMoreButtonText = Load more
 
 BriefAuswahlNewSubjectHeading = New subject
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_fr.properties
@@ -1166,6 +1166,7 @@ BriefAuswahlCreateNewDocument = Cr\u00E9ez un nouveau document
 BriefAuswahlDeleteConfirmText = Voulez-vous vraiment supprimer ce document de mani\u00E8re irr\u00E9vocable?
 
 BriefAuswahlLoadButtonText = Charger
+BriefAuswahlLoadMoreButtonText = Charger plus
 
 BriefAuswahlNewSubjectHeading = Nouveau sujet
 

--- a/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
+++ b/bundles/ch.elexis.core.l10n/src/ch/elexis/core/l10n/messages_it.properties
@@ -1170,6 +1170,7 @@ BriefAuswahlCreateNewDocument = Creare un nuovo documento
 BriefAuswahlDeleteConfirmText = Vuoi davvero eliminare questo documento irrevocabilmente?
 
 BriefAuswahlLoadButtonText = Carico
+BriefAuswahlLoadMoreButtonText = Carica altro
 
 BriefAuswahlNewSubjectHeading = Nuovo soggetto
 

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BriefAuswahl.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/BriefAuswahl.java
@@ -81,6 +81,7 @@ import ch.elexis.core.model.ModelPackage;
 import ch.elexis.core.services.IDocumentService;
 import ch.elexis.core.services.IQuery;
 import ch.elexis.core.services.IQuery.COMPARATOR;
+import ch.elexis.core.services.IQuery.ORDER;
 import ch.elexis.core.services.LocalConfigService;
 import ch.elexis.core.services.holder.BriefDocumentStoreHolder;
 import ch.elexis.core.services.holder.ContextServiceHolder;
@@ -130,6 +131,7 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 	void activePatient(@Optional IPatient patient) {
 		ContextServiceHolder.get().getRootContext().removeTyped(IDocumentLetter.class);
 		Display.getDefault().asyncExec(() -> {
+			pages.forEach(sPage::resetQueryLimit);
 			if (form != null && !form.isDisposed()) {
 				if (patient == null) {
 					form.setText(Messages.Core_No_patient_selected); // $NON-NLS-1$
@@ -286,10 +288,15 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 	}
 
 	class sPage extends Composite {
+		private static final int QUERY_LIMIT_INCREMENT = 50;
+
 		private TableViewer tableViewer;
+		private Button loadMoreButton;
 		private LetterViewerComparator comparator;
 		private final CommonViewer cv;
 		private final ViewerConfigurer vc;
+		private int queryLimit = QUERY_LIMIT_INCREMENT;
+		private boolean hasMore;
 
 		public CommonViewer getCommonViewer() {
 			return cv;
@@ -304,8 +311,6 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 					});
 			CommonViewerContentProvider contentProvider = new ch.elexis.core.ui.util.viewers.CommonViewerContentProvider(
 					cv) {
-
-				private static final int QUERY_LIMIT = 500;
 
 				@Override
 				public Object[] getElements(final Object inputElement) {
@@ -322,8 +327,12 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 						// apply filters from control field provider
 						controlFieldProvider.setQuery(query);
 						List<?> elements = query.execute();
-						return elements.toArray(new Object[elements.size()]);
+						boolean hasMore = !ignoreLimit && elements.size() > queryLimit;
+						updateLoadMoreButton(hasMore);
+						List<?> visibleElements = hasMore ? elements.subList(0, queryLimit) : elements;
+						return visibleElements.toArray(new Object[visibleElements.size()]);
 					} else {
+						updateLoadMoreButton(false);
 						return new Object[0];
 					}
 				}
@@ -331,8 +340,10 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 				@Override
 				protected IQuery<?> getBaseQuery() {
 					IQuery<IDocumentLetter> ret = CoreModelServiceHolder.get().getQuery(IDocumentLetter.class);
+					ret.orderBy("creationDate", ORDER.DESC); //$NON-NLS-1$
+					ret.orderBy("id", ORDER.DESC); //$NON-NLS-1$
 					if (!ignoreLimit) {
-						ret.limit(QUERY_LIMIT);
+						ret.limit(queryLimit + 1);
 					}
 					return ret;
 				}
@@ -365,6 +376,17 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 			}
 
 			vc.getContentProvider().startListening();
+			loadMoreButton = tk.createButton(this, Messages.BriefAuswahlLoadMoreButtonText, SWT.PUSH);
+			loadMoreButton.setEnabled(hasMore);
+			loadMoreButton.addSelectionListener(new SelectionAdapter() {
+				@Override
+				public void widgetSelected(final SelectionEvent e) {
+					queryLimit += QUERY_LIMIT_INCREMENT;
+					cv.notify(CommonViewer.Message.update);
+				}
+			});
+			loadMoreButton.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+
 			Button bLoad = tk.createButton(this, Messages.BriefAuswahlLoadButtonText, SWT.PUSH); // $NON-NLS-1$
 			bLoad.addSelectionListener(new SelectionAdapter() {
 				@Override
@@ -374,6 +396,17 @@ public class BriefAuswahl extends ViewPart implements IRefreshable {
 
 			});
 			bLoad.setLayoutData(SWTHelper.getFillGridData(1, true, 1, false));
+		}
+
+		private void resetQueryLimit() {
+			queryLimit = QUERY_LIMIT_INCREMENT;
+		}
+
+		private void updateLoadMoreButton(boolean enabled) {
+			hasMore = enabled;
+			if (loadMoreButton != null && !loadMoreButton.isDisposed()) {
+				loadMoreButton.setEnabled(enabled);
+			}
 		}
 
 		// create the columns for the table

--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/Messages.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/Messages.java
@@ -129,6 +129,7 @@ public class Messages {
 
 	public static String Core_Error = ch.elexis.core.l10n.Messages.Core_Error;
 	public static String BriefAuswahlLoadButtonText = ch.elexis.core.l10n.Messages.BriefAuswahlLoadButtonText;
+	public static String BriefAuswahlLoadMoreButtonText = ch.elexis.core.l10n.Messages.BriefAuswahlLoadMoreButtonText;
 
 	public static String BriefAuswahlNewSubjectHeading = ch.elexis.core.l10n.Messages.BriefAuswahlNewSubjectHeading;
 	public static String BriefAuswahlNewSubjectText = ch.elexis.core.l10n.Messages.BriefAuswahlNewSubjectText;


### PR DESCRIPTION
## What changed

- Load the 50 most recent patient letters initially instead of up to 500.
- Order results deterministically by creation date and ID, descending.
- Add a `Load more` button that increases the visible result limit by 50.
- Reset the limit when the active patient changes.
- Disable the button when no further results are available.

The change is limited to `BriefAuswahl` and its translations. It does not alter
the global `Brief` JPA entity or loading behavior used by other views.

## Why

Loading the letter selection currently materializes the complete eager object
graph for every returned letter. This includes document content from `HEAP` and
related contacts, consultations, and invoices, although the list initially only
shows date and title.

Limiting the initial result set reduces that work while keeping older documents
available on demand.

## Measured impact

Two MySQL General Log runs were normalized and compared using the same high-volume
patients:

- Initial `HEAP` loads for nine patients: 1,711 -> 459 (-73.2%).
- Largest patient: 500 -> 51 loaded rows (-89.8%).
- The progressive queries were observed as `LIMIT 51`, `101`, `151`, and so on.
- The query uses `ORDER BY Datum DESC, ID DESC`.

The extra row in each query is used to determine whether `Load more` should stay
enabled; only 50 additional rows are displayed per step.

## Validation

- Compiled successfully with Java 21 against an Elexis 3.14 installation.
- Installed and functionally tested in Elexis.
- Verified initial loading, repeated `Load more`, patient changes, and SQL output.
- Rebased cleanly onto the current upstream `master`.

An additional local recompilation after rebasing was blocked because the running
Elexis installation held plugin JARs open. The rebased source diff itself is
conflict-free and unchanged in scope from the tested build.
