### PR TITLE
[28466] Fix focus-induced scrolling of consultation links on macOS

### DIFF
--- a/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
+++ b/bundles/ch.elexis.core.ui/src/ch/elexis/core/ui/views/HistoryDisplay.java
@@ -97,7 +97,18 @@ public class HistoryDisplay extends Composite implements BackgroundJobListener {
 		this.multiline = multiline;
 		lKons = new ArrayList<>(20);
 
-		text = UiDesk.getToolkit().createFormText(scrolledComposite, false);
+		if ("cocoa".equals(SWT.getPlatform())) { //$NON-NLS-1$
+			// Prevent focus-induced scrolling from moving the link during a mouse click.
+			// NO_FOCUS also disables keyboard traversal of the links on macOS.
+			text = new FormText(scrolledComposite, SWT.NO_FOCUS | UiDesk.getToolkit().getOrientation());
+			text.marginWidth = 1;
+			text.marginHeight = 0;
+			text.setHyperlinkSettings(UiDesk.getToolkit().getHyperlinkGroup());
+			UiDesk.getToolkit().adapt(text, false, true);
+			text.setMenu(scrolledComposite.getMenu());
+		} else {
+			text = UiDesk.getToolkit().createFormText(scrolledComposite, false);
+		}
 		text.setWhitespaceNormalized(true);
 		text.setColor(UiDesk.COL_BLUE, UiDesk.getColorRegistry().get(UiDesk.COL_BLUE));
 		text.setColor(UiDesk.COL_GREEN, UiDesk.getColorRegistry().get(UiDesk.COL_LIGHTGREY));


### PR DESCRIPTION
Clicking a consultation link in the Verlauf view on macOS can scroll the text before the link activates, requiring several clicks to select a consultation. Create the FormText with SWT.NO_FOCUS on Cocoa so the clicked link stays in place and a single click selects the consultation. Preserve the toolkit's appearance and hyperlink configuration; other platforms continue using createFormText.

The workaround is always active on macOS. No diagnostic listeners, logging or JVM test switches are included.

Known tradeoff: SWT.NO_FOCUS disables Tab/Enter navigation of these links on macOS. This PR carries the mouse workaround validated in the macOS test; it does not claim to preserve keyboard link navigation.

Validation:
- The user confirmed the macOS test succeeded. Its diagnostic log recorded two single-click link activations with successful encounter loading and context handoff; scroll positions remained at 195 and 684 pixels throughout the respective clicks.
- The cleaned production change was built with Java 21.0.11 and the Maven/Tycho reactor: `mvn -V -B -pl bundles/ch.elexis.core.ui -am clean verify -DskipTests` (26 modules, BUILD SUCCESS). Automated tests were skipped; the final build without diagnostics has not been separately retested on macOS.
- UTF-8 BOM check and `git diff --check` passed. Only HistoryDisplay.java is changed.
